### PR TITLE
feat: skills pinning — supply chain & update drift defense (AST 02 + AST 07)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,26 +10,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- **Skills Pinning:** Extends MCP tool pinning to agent skill repositories (`~/.claude/skills/`, `~/.claude/CLAUDE.md`, `~/.claude/rules/`, project `.claude/CLAUDE.md`, `.claude/CLAUDE.local.md`, `.claude/rules/`, `.cursor/rules/`, `AGENTS.md`, `CLAUDE.md`). On the first tool call of a Claude / Gemini / Cursor session, Node9 records a SHA-256 hash of every skill file. On every subsequent session, hashes are re-checked; any difference **quarantines** the session and blocks every tool call until a human reviews the drift via `node9 skill pin update <rootKey>`. One feature, two threats covered in a single primitive:
-  - **AST 02 Supply Chain Compromise** — malicious skill-registry overwrites (ClawHub-style)
-  - **AST 07 Update Drift** — auto-updated skills carrying backdoors (CVE-2026-28363 ClawJacked-style)
+- **Skills Pinning:** Extends MCP tool pinning to agent skill files — `~/.claude/skills/`, `~/.claude/CLAUDE.md`, `~/.claude/rules/`, project `.claude/CLAUDE.md`, `.claude/CLAUDE.local.md`, `.claude/rules/`, `.cursor/rules/`, `AGENTS.md`, `CLAUDE.md`. On the first tool call of a session Node9 records a SHA-256 hash of every skill file; on subsequent sessions hashes are re-checked and any difference **quarantines** the session, blocking every tool call until a human reviews via `node9 skill pin update <rootKey>`. Covers:
+  - **AST 02 Supply Chain Compromise** — malicious skill-registry overwrites
+  - **AST 07 Update Drift** — auto-updated skills carrying backdoors
 
-  Per-session verification is memoised in `~/.node9/skill-sessions/<session_id>.json` so the hashing cost is paid once per session, not once per tool call. Flags older than 7 days are GC'd best-effort.
+  Per-session verification is memoised in `~/.node9/skill-sessions/<session_id>.json` so hashing runs once per session, not once per tool call.
 
-- **`node9 skill pin` CLI:** three subcommands, mirroring `node9 mcp pin`:
-  - `node9 skill pin list` — show all pinned skill roots, content hashes, file counts, pin timestamps
-  - `node9 skill pin update <rootKey> [--yes]` — show a per-file diff (added / removed / modified) for directory roots, prompt for confirmation, then re-pin. `--yes` skips the prompt for scripted workflows
-  - `node9 skill pin reset` — clear all pins AND wipe quarantined session flags so state can't leak across re-installs
+- **`node9 skill pin` CLI** — `list` / `update <rootKey>` / `reset`, mirroring `node9 mcp pin`. `update` removes the named pin so the next session re-pins with current state; `reset` clears all pins and wipes session flags.
 
-- **`policy.skillRoots` config field:** user-extensible list of extra skill paths beyond the defaults. Accepts absolute paths, `~/`-prefixed paths, or paths relative to the hook payload's `cwd` (CLAUDE.md validated-path rules apply — relative paths without an absolute cwd are ignored).
+- **`policy.skillRoots` config field** — user-extensible list of extra skill paths (absolute, `~/`-prefixed, or cwd-relative).
 
 ### Security properties
 
-- **Fail-closed on corrupt pin file:** `skill-pins.json` that fails to parse quarantines the session immediately; the only recovery is `node9 skill pin reset`.
-- **Symlink-safe:** `hashSkillRoot` never follows symlinks into arbitrary filesystem locations.
-- **Size-bounded:** caps any single root at 5000 files / 50 MB total to defeat pathological skill directories.
-- **Path-traversal-safe session IDs:** only `[A-Za-z0-9_-]{1,128}` accepted as session flag filenames; anything else silently disables the skill check for that payload.
-- **Atomic writes, mode 0o600:** pin file and session flags use the same atomic-rename + owner-only-permission pattern as `~/.node9/mcp-pins.json`.
+- Fail-closed on corrupt `skill-pins.json` (recovery: `node9 skill pin reset`)
+- Symlink-safe; size-bounded (5000 files / 50 MB per root)
+- Path-traversal-safe session IDs (`[A-Za-z0-9_-]{1,128}`)
+- Atomic writes, mode 0o600
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## v1.10.0 — Skills Pinning (AST 02 + AST 07)
+
+### Added
+
+- **Skills Pinning:** Extends MCP tool pinning to agent skill repositories (`~/.claude/skills/`, `~/.claude/CLAUDE.md`, `~/.claude/rules/`, project `.claude/CLAUDE.md`, `.claude/CLAUDE.local.md`, `.claude/rules/`, `.cursor/rules/`, `AGENTS.md`, `CLAUDE.md`). On the first tool call of a Claude / Gemini / Cursor session, Node9 records a SHA-256 hash of every skill file. On every subsequent session, hashes are re-checked; any difference **quarantines** the session and blocks every tool call until a human reviews the drift via `node9 skill pin update <rootKey>`. One feature, two threats covered in a single primitive:
+  - **AST 02 Supply Chain Compromise** — malicious skill-registry overwrites (ClawHub-style)
+  - **AST 07 Update Drift** — auto-updated skills carrying backdoors (CVE-2026-28363 ClawJacked-style)
+
+  Per-session verification is memoised in `~/.node9/skill-sessions/<session_id>.json` so the hashing cost is paid once per session, not once per tool call. Flags older than 7 days are GC'd best-effort.
+
+- **`node9 skill pin` CLI:** three subcommands, mirroring `node9 mcp pin`:
+  - `node9 skill pin list` — show all pinned skill roots, content hashes, file counts, pin timestamps
+  - `node9 skill pin update <rootKey> [--yes]` — show a per-file diff (added / removed / modified) for directory roots, prompt for confirmation, then re-pin. `--yes` skips the prompt for scripted workflows
+  - `node9 skill pin reset` — clear all pins AND wipe quarantined session flags so state can't leak across re-installs
+
+- **`policy.skillRoots` config field:** user-extensible list of extra skill paths beyond the defaults. Accepts absolute paths, `~/`-prefixed paths, or paths relative to the hook payload's `cwd` (CLAUDE.md validated-path rules apply — relative paths without an absolute cwd are ignored).
+
+### Security properties
+
+- **Fail-closed on corrupt pin file:** `skill-pins.json` that fails to parse quarantines the session immediately; the only recovery is `node9 skill pin reset`.
+- **Symlink-safe:** `hashSkillRoot` never follows symlinks into arbitrary filesystem locations.
+- **Size-bounded:** caps any single root at 5000 files / 50 MB total to defeat pathological skill directories.
+- **Path-traversal-safe session IDs:** only `[A-Za-z0-9_-]{1,128}` accepted as session flag filenames; anything else silently disables the skill check for that payload.
+- **Atomic writes, mode 0o600:** pin file and session flags use the same atomic-rename + owner-only-permission pattern as `~/.node9/mcp-pins.json`.
+
+---
+
 ## v1.7.0 — Steerable Redirect Recovery Menu
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -102,6 +102,22 @@ node9 mcp pin reset               # clear all pins (re-pin on next connection)
 
 This is automatic — no configuration needed. The gateway pins on first `tools/list` and enforces on every subsequent session.
 
+### Skills Pinning — supply chain & update drift defense
+
+Agent skills (`~/.claude/skills/`, `~/.claude/CLAUDE.md`, `.cursor/rules/`, `AGENTS.md`, project `CLAUDE.md`) can be silently swapped by a compromised skill registry or an automatic update. Node9 is the first runtime defense to extend pinning to the skills layer — covering **AST 02 Supply Chain Compromise** and **AST 07 Update Drift** in a single primitive.
+
+1. **First session** — Node9 records a SHA-256 hash of every skill file across known roots
+2. **Subsequent sessions** — hashes are verified; if a skill changed, the session is **quarantined** and every tool call is blocked until you review and re-pin
+3. **Corrupt pin state** — fails closed, never silently re-trusts
+
+```bash
+node9 skill pin list                 # show all pinned skill roots and hashes
+node9 skill pin update <rootKey>     # show diff, then re-pin
+node9 skill pin reset                # clear all pins (re-pin on next session)
+```
+
+Automatic and zero-config. Add custom skill paths via `policy.skillRoots` in `node9.config.json`.
+
 ---
 
 ## Python SDK — govern any Python agent
@@ -125,6 +141,7 @@ configure(agent_name="my-agent", policy="require_approval")
 - **Shell:** blocks `curl | bash`, `sudo` commands
 - **DLP:** blocks AWS keys, GitHub tokens, Stripe keys, PEM private keys in any tool call argument
 - **Auto-undo:** git snapshot before every AI file edit → `node9 undo` to revert
+- **Skills Pinning:** SHA-256 verification of agent skill files between sessions; quarantines on drift (AST 02 + AST 07 — supply chain & update drift)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Agent skills (`~/.claude/skills/`, `~/.claude/CLAUDE.md`, `.cursor/rules/`, `AGE
 
 ```bash
 node9 skill pin list                 # show all pinned skill roots and hashes
-node9 skill pin update <rootKey>     # show diff, then re-pin
+node9 skill pin update <rootKey>     # remove a pin, re-pin on next session
 node9 skill pin reset                # clear all pins (re-pin on next session)
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,21 +102,9 @@ node9 mcp pin reset               # clear all pins (re-pin on next connection)
 
 This is automatic — no configuration needed. The gateway pins on first `tools/list` and enforces on every subsequent session.
 
-### Skills Pinning — supply chain & update drift defense
+### Skills Pinning — same defense, extended to agent skill files
 
-Agent skills (`~/.claude/skills/`, `~/.claude/CLAUDE.md`, `.cursor/rules/`, `AGENTS.md`, project `CLAUDE.md`) can be silently swapped by a compromised skill registry or an automatic update. Node9 is the first runtime defense to extend pinning to the skills layer — covering **AST 02 Supply Chain Compromise** and **AST 07 Update Drift** in a single primitive.
-
-1. **First session** — Node9 records a SHA-256 hash of every skill file across known roots
-2. **Subsequent sessions** — hashes are verified; if a skill changed, the session is **quarantined** and every tool call is blocked until you review and re-pin
-3. **Corrupt pin state** — fails closed, never silently re-trusts
-
-```bash
-node9 skill pin list                 # show all pinned skill roots and hashes
-node9 skill pin update <rootKey>     # remove a pin, re-pin on next session
-node9 skill pin reset                # clear all pins (re-pin on next session)
-```
-
-Automatic and zero-config. Add custom skill paths via `policy.skillRoots` in `node9.config.json`.
+Same idea as MCP pinning, at the skills layer: `~/.claude/skills/`, `~/.claude/CLAUDE.md`, `.cursor/rules/`, `AGENTS.md`, project `CLAUDE.md`. First session hashes them; any later-session change quarantines the session until you re-pin. Covers **AST 02 (supply chain)** and **AST 07 (update drift)**. Manage with `node9 skill pin list | update <rootKey> | reset`. Zero-config; extend via `policy.skillRoots`.
 
 ---
 

--- a/src/__tests__/check-skill-pin.integration.test.ts
+++ b/src/__tests__/check-skill-pin.integration.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Integration tests for skill-pin enforcement inside `node9 check` (PreToolUse).
+ *
+ * Spawns the real built CLI with an isolated HOME + an isolated cwd holding
+ * a CLAUDE.md the hook will pin. Verifies the full first-call → subsequent →
+ * drift-block → quarantine-sticks pipeline runs end-to-end.
+ *
+ * Requires `npm run build` before running.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const CLI = path.resolve(__dirname, '../../dist/cli.js');
+
+interface RunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runCheck(
+  payload: object,
+  env: Record<string, string> = {},
+  cwd = os.tmpdir(),
+  timeoutMs = 60000
+): RunResult {
+  const baseEnv = { ...process.env };
+  delete baseEnv.NODE9_API_KEY;
+  delete baseEnv.NODE9_API_URL;
+  const result = spawnSync(process.execPath, [CLI, 'check', JSON.stringify(payload)], {
+    encoding: 'utf-8',
+    timeout: timeoutMs,
+    cwd,
+    env: {
+      ...baseEnv,
+      NODE9_NO_AUTO_DAEMON: '1',
+      NODE9_TESTING: '1',
+      FORCE_COLOR: '0',
+      ...env,
+      ...(env.HOME != null ? { USERPROFILE: env.HOME } : {}),
+    },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+function makeTempHome(): string {
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skhook-home-'));
+  const node9Dir = path.join(tmpHome, '.node9');
+  fs.mkdirSync(node9Dir, { recursive: true });
+  // Minimal config — mode 'standard', daemon disabled
+  fs.writeFileSync(
+    path.join(node9Dir, 'config.json'),
+    JSON.stringify({ settings: { mode: 'standard', autoStartDaemon: false } })
+  );
+  return tmpHome;
+}
+
+function makeTempProject(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skhook-proj-'));
+  fs.writeFileSync(path.join(dir, 'CLAUDE.md'), 'original skill content\n');
+  return dir;
+}
+
+beforeAll(() => {
+  if (!fs.existsSync(CLI)) {
+    throw new Error(`dist/cli.js not found at ${CLI} — run \`npm run build\` first.`);
+  }
+});
+
+describe('skill-pin enforcement in `node9 check`', () => {
+  let tmpHome: string;
+  let tmpProject: string;
+  beforeEach(() => {
+    tmpHome = makeTempHome();
+    tmpProject = makeTempProject();
+  });
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    fs.rmSync(tmpProject, { recursive: true, force: true });
+  });
+
+  it('first call of a session pins all skill roots and allows the tool', () => {
+    const r = runCheck(
+      {
+        tool_name: 'glob',
+        tool_input: { pattern: '**/*.ts' },
+        session_id: 'first-session',
+        cwd: tmpProject,
+        hook_event_name: 'PreToolUse',
+      },
+      { HOME: tmpHome },
+      tmpProject
+    );
+    expect(r.status).toBe(0);
+    // Pin file written
+    const pinsPath = path.join(tmpHome, '.node9', 'skill-pins.json');
+    expect(fs.existsSync(pinsPath)).toBe(true);
+    const pins = JSON.parse(fs.readFileSync(pinsPath, 'utf-8'));
+    // At least the project's CLAUDE.md should be pinned
+    const pinnedPaths = Object.values<{ rootPath: string }>(pins.roots).map((e) => e.rootPath);
+    expect(pinnedPaths).toContain(path.join(tmpProject, 'CLAUDE.md'));
+    // Verified flag written for this session
+    const flag = path.join(tmpHome, '.node9', 'skill-sessions', 'first-session.json');
+    expect(fs.existsSync(flag)).toBe(true);
+    const flagData = JSON.parse(fs.readFileSync(flag, 'utf-8'));
+    expect(flagData.state).toBe('verified');
+  });
+
+  it('subsequent call of the same session short-circuits (no re-hash; allows)', () => {
+    // Prime the session
+    runCheck(
+      {
+        tool_name: 'glob',
+        tool_input: { pattern: '**/*.ts' },
+        session_id: 'persist-sess',
+        cwd: tmpProject,
+        hook_event_name: 'PreToolUse',
+      },
+      { HOME: tmpHome },
+      tmpProject
+    );
+    // Mutate CLAUDE.md — but since the session is already verified, the hook
+    // should NOT re-check (short-circuit on the verified flag).
+    fs.writeFileSync(path.join(tmpProject, 'CLAUDE.md'), 'CHANGED AFTER VERIFICATION');
+    const r = runCheck(
+      {
+        tool_name: 'glob',
+        tool_input: { pattern: '**/*.ts' },
+        session_id: 'persist-sess',
+        cwd: tmpProject,
+        hook_event_name: 'PreToolUse',
+      },
+      { HOME: tmpHome },
+      tmpProject
+    );
+    expect(r.status).toBe(0);
+  });
+
+  it('new session with unchanged skills re-verifies and allows', () => {
+    runCheck(
+      {
+        tool_name: 'glob',
+        tool_input: { pattern: '**/*.ts' },
+        session_id: 'sess-A',
+        cwd: tmpProject,
+        hook_event_name: 'PreToolUse',
+      },
+      { HOME: tmpHome },
+      tmpProject
+    );
+    const r = runCheck(
+      {
+        tool_name: 'glob',
+        tool_input: { pattern: '**/*.ts' },
+        session_id: 'sess-B',
+        cwd: tmpProject,
+        hook_event_name: 'PreToolUse',
+      },
+      { HOME: tmpHome },
+      tmpProject
+    );
+    expect(r.status).toBe(0);
+  });
+
+  it('new session with drifted skills BLOCKS and quarantines the session', () => {
+    // Prime
+    runCheck(
+      {
+        tool_name: 'glob',
+        tool_input: { pattern: '**/*.ts' },
+        session_id: 'sess-prime',
+        cwd: tmpProject,
+        hook_event_name: 'PreToolUse',
+      },
+      { HOME: tmpHome },
+      tmpProject
+    );
+    // Tamper CLAUDE.md BEFORE the next session starts (simulates a supply-chain swap)
+    fs.writeFileSync(path.join(tmpProject, 'CLAUDE.md'), 'MALICIOUS CONTENT');
+
+    const r = runCheck(
+      {
+        tool_name: 'glob',
+        tool_input: { pattern: '**/*.ts' },
+        session_id: 'sess-drift',
+        cwd: tmpProject,
+        hook_event_name: 'PreToolUse',
+      },
+      { HOME: tmpHome },
+      tmpProject
+    );
+    expect(r.status).toBe(2);
+    // JSON block payload on stdout
+    const out = JSON.parse(r.stdout.trim().split('\n').pop()!);
+    expect(out.decision).toBe('block');
+    expect(out.reason).toMatch(/skill/i);
+    expect(out.reason).toMatch(/pin update/);
+    // Quarantine flag persisted
+    const flagPath = path.join(tmpHome, '.node9', 'skill-sessions', 'sess-drift.json');
+    expect(fs.existsSync(flagPath)).toBe(true);
+    const flag = JSON.parse(fs.readFileSync(flagPath, 'utf-8'));
+    expect(flag.state).toBe('quarantined');
+  });
+
+  it('subsequent call in a quarantined session blocks immediately (no re-hash)', () => {
+    // Prime + drift
+    runCheck(
+      {
+        tool_name: 'glob',
+        tool_input: { pattern: '**/*.ts' },
+        session_id: 'sess-prime2',
+        cwd: tmpProject,
+        hook_event_name: 'PreToolUse',
+      },
+      { HOME: tmpHome },
+      tmpProject
+    );
+    fs.writeFileSync(path.join(tmpProject, 'CLAUDE.md'), 'TAMPERED');
+    runCheck(
+      {
+        tool_name: 'glob',
+        tool_input: { pattern: '**/*.ts' },
+        session_id: 'q-sess',
+        cwd: tmpProject,
+        hook_event_name: 'PreToolUse',
+      },
+      { HOME: tmpHome },
+      tmpProject
+    );
+    // Repair the skill — but the session should still be quarantined
+    fs.writeFileSync(path.join(tmpProject, 'CLAUDE.md'), 'original skill content\n');
+    const r = runCheck(
+      {
+        tool_name: 'glob',
+        tool_input: { pattern: '**/*.ts' },
+        session_id: 'q-sess',
+        cwd: tmpProject,
+        hook_event_name: 'PreToolUse',
+      },
+      { HOME: tmpHome },
+      tmpProject
+    );
+    expect(r.status).toBe(2);
+    const out = JSON.parse(r.stdout.trim().split('\n').pop()!);
+    expect(out.decision).toBe('block');
+    expect(out.reason).toMatch(/quarantine/i);
+  });
+
+  it('corrupt skill-pins.json fails closed (blocks)', () => {
+    fs.writeFileSync(path.join(tmpHome, '.node9', 'skill-pins.json'), 'not json');
+    const r = runCheck(
+      {
+        tool_name: 'glob',
+        tool_input: { pattern: '**/*.ts' },
+        session_id: 'corrupt-sess',
+        cwd: tmpProject,
+        hook_event_name: 'PreToolUse',
+      },
+      { HOME: tmpHome },
+      tmpProject
+    );
+    expect(r.status).toBe(2);
+    const out = JSON.parse(r.stdout.trim().split('\n').pop()!);
+    expect(out.decision).toBe('block');
+    expect(out.reason).toMatch(/corrupt|skill/i);
+  });
+
+  it('missing session_id skips the skill check entirely', () => {
+    // Without a session_id we have no key to scope verification; fall through
+    // to normal authorization (which, for an ignored tool, should allow).
+    const r = runCheck(
+      {
+        tool_name: 'glob',
+        tool_input: { pattern: '**/*.ts' },
+        cwd: tmpProject,
+        hook_event_name: 'PreToolUse',
+      },
+      { HOME: tmpHome },
+      tmpProject
+    );
+    expect(r.status).toBe(0);
+    // No pin file created (hook skipped)
+    const pinsPath = path.join(tmpHome, '.node9', 'skill-pins.json');
+    expect(fs.existsSync(pinsPath)).toBe(false);
+  });
+
+  it('relative cwd is rejected for project-scoped skill roots (global roots still pinned)', () => {
+    const r = runCheck(
+      {
+        tool_name: 'glob',
+        tool_input: { pattern: '**/*.ts' },
+        session_id: 'rel-sess',
+        cwd: 'relative/path', // NOT absolute — must be ignored per CLAUDE.md rules
+        hook_event_name: 'PreToolUse',
+      },
+      { HOME: tmpHome },
+      tmpProject
+    );
+    expect(r.status).toBe(0);
+    // A verified flag is still written (global roots hashed fine)
+    const flag = path.join(tmpHome, '.node9', 'skill-sessions', 'rel-sess.json');
+    expect(fs.existsSync(flag)).toBe(true);
+    // Crucially, NO project-scoped root entries (all pinned roots are under $HOME)
+    const pinsPath = path.join(tmpHome, '.node9', 'skill-pins.json');
+    if (fs.existsSync(pinsPath)) {
+      const pins = JSON.parse(fs.readFileSync(pinsPath, 'utf-8'));
+      for (const entry of Object.values<{ rootPath: string }>(pins.roots)) {
+        expect(entry.rootPath.startsWith(tmpHome)).toBe(true);
+      }
+    }
+  });
+});

--- a/src/__tests__/check-skill-pin.integration.test.ts
+++ b/src/__tests__/check-skill-pin.integration.test.ts
@@ -1,11 +1,7 @@
 /**
  * Integration tests for skill-pin enforcement inside `node9 check` (PreToolUse).
- *
  * Spawns the real built CLI with an isolated HOME + an isolated cwd holding
- * a CLAUDE.md the hook will pin. Verifies the full first-call → subsequent →
- * drift-block → quarantine-sticks pipeline runs end-to-end.
- *
- * Requires `npm run build` before running.
+ * a CLAUDE.md the hook will pin. Requires `npm run build` first.
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
@@ -16,24 +12,13 @@ import path from 'path';
 
 const CLI = path.resolve(__dirname, '../../dist/cli.js');
 
-interface RunResult {
-  status: number | null;
-  stdout: string;
-  stderr: string;
-}
-
-function runCheck(
-  payload: object,
-  env: Record<string, string> = {},
-  cwd = os.tmpdir(),
-  timeoutMs = 60000
-): RunResult {
+function runCheck(payload: object, env: Record<string, string>, cwd: string) {
   const baseEnv = { ...process.env };
   delete baseEnv.NODE9_API_KEY;
   delete baseEnv.NODE9_API_URL;
-  const result = spawnSync(process.execPath, [CLI, 'check', JSON.stringify(payload)], {
+  const r = spawnSync(process.execPath, [CLI, 'check', JSON.stringify(payload)], {
     encoding: 'utf-8',
-    timeout: timeoutMs,
+    timeout: 60000,
     cwd,
     env: {
       ...baseEnv,
@@ -44,23 +29,17 @@ function runCheck(
       ...(env.HOME != null ? { USERPROFILE: env.HOME } : {}),
     },
   });
-  return {
-    status: result.status,
-    stdout: result.stdout ?? '',
-    stderr: result.stderr ?? '',
-  };
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
 }
 
 function makeTempHome(): string {
-  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skhook-home-'));
-  const node9Dir = path.join(tmpHome, '.node9');
-  fs.mkdirSync(node9Dir, { recursive: true });
-  // Minimal config — mode 'standard', daemon disabled
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skhook-home-'));
+  fs.mkdirSync(path.join(home, '.node9'), { recursive: true });
   fs.writeFileSync(
-    path.join(node9Dir, 'config.json'),
+    path.join(home, '.node9', 'config.json'),
     JSON.stringify({ settings: { mode: 'standard', autoStartDaemon: false } })
   );
-  return tmpHome;
+  return home;
 }
 
 function makeTempProject(): string {
@@ -87,12 +66,12 @@ describe('skill-pin enforcement in `node9 check`', () => {
     fs.rmSync(tmpProject, { recursive: true, force: true });
   });
 
-  it('first call of a session pins all skill roots and allows the tool', () => {
+  it('first call of a session pins skill roots and allows the tool', () => {
     const r = runCheck(
       {
         tool_name: 'glob',
-        tool_input: { pattern: '**/*.ts' },
-        session_id: 'first-session',
+        tool_input: { pattern: '**' },
+        session_id: 'sess-1',
         cwd: tmpProject,
         hook_event_name: 'PreToolUse',
       },
@@ -100,97 +79,37 @@ describe('skill-pin enforcement in `node9 check`', () => {
       tmpProject
     );
     expect(r.status).toBe(0);
-    // Pin file written
-    const pinsPath = path.join(tmpHome, '.node9', 'skill-pins.json');
-    expect(fs.existsSync(pinsPath)).toBe(true);
-    const pins = JSON.parse(fs.readFileSync(pinsPath, 'utf-8'));
-    // At least the project's CLAUDE.md should be pinned
+    const pins = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, '.node9', 'skill-pins.json'), 'utf-8')
+    );
     const pinnedPaths = Object.values<{ rootPath: string }>(pins.roots).map((e) => e.rootPath);
     expect(pinnedPaths).toContain(path.join(tmpProject, 'CLAUDE.md'));
-    // Verified flag written for this session
-    const flag = path.join(tmpHome, '.node9', 'skill-sessions', 'first-session.json');
-    expect(fs.existsSync(flag)).toBe(true);
-    const flagData = JSON.parse(fs.readFileSync(flag, 'utf-8'));
-    expect(flagData.state).toBe('verified');
+    const flag = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, '.node9', 'skill-sessions', 'sess-1.json'), 'utf-8')
+    );
+    expect(flag.state).toBe('verified');
   });
 
-  it('subsequent call of the same session short-circuits (no re-hash; allows)', () => {
-    // Prime the session
+  it('new session after skill tamper BLOCKS and quarantines the session', () => {
+    // Prime a first session.
     runCheck(
       {
         tool_name: 'glob',
-        tool_input: { pattern: '**/*.ts' },
-        session_id: 'persist-sess',
+        tool_input: { pattern: '**' },
+        session_id: 'prime',
         cwd: tmpProject,
         hook_event_name: 'PreToolUse',
       },
       { HOME: tmpHome },
       tmpProject
     );
-    // Mutate CLAUDE.md — but since the session is already verified, the hook
-    // should NOT re-check (short-circuit on the verified flag).
-    fs.writeFileSync(path.join(tmpProject, 'CLAUDE.md'), 'CHANGED AFTER VERIFICATION');
+    // Tamper between sessions (simulates a supply-chain swap).
+    fs.writeFileSync(path.join(tmpProject, 'CLAUDE.md'), 'MALICIOUS');
     const r = runCheck(
       {
         tool_name: 'glob',
-        tool_input: { pattern: '**/*.ts' },
-        session_id: 'persist-sess',
-        cwd: tmpProject,
-        hook_event_name: 'PreToolUse',
-      },
-      { HOME: tmpHome },
-      tmpProject
-    );
-    expect(r.status).toBe(0);
-  });
-
-  it('new session with unchanged skills re-verifies and allows', () => {
-    runCheck(
-      {
-        tool_name: 'glob',
-        tool_input: { pattern: '**/*.ts' },
-        session_id: 'sess-A',
-        cwd: tmpProject,
-        hook_event_name: 'PreToolUse',
-      },
-      { HOME: tmpHome },
-      tmpProject
-    );
-    const r = runCheck(
-      {
-        tool_name: 'glob',
-        tool_input: { pattern: '**/*.ts' },
-        session_id: 'sess-B',
-        cwd: tmpProject,
-        hook_event_name: 'PreToolUse',
-      },
-      { HOME: tmpHome },
-      tmpProject
-    );
-    expect(r.status).toBe(0);
-  });
-
-  it('new session with drifted skills BLOCKS and quarantines the session', () => {
-    // Prime
-    runCheck(
-      {
-        tool_name: 'glob',
-        tool_input: { pattern: '**/*.ts' },
-        session_id: 'sess-prime',
-        cwd: tmpProject,
-        hook_event_name: 'PreToolUse',
-      },
-      { HOME: tmpHome },
-      tmpProject
-    );
-    // Tamper CLAUDE.md BEFORE the next session starts (simulates a supply-chain swap)
-    fs.writeFileSync(path.join(tmpProject, 'CLAUDE.md'), 'MALICIOUS CONTENT');
-
-    const r = runCheck(
-      {
-        tool_name: 'glob',
-        tool_input: { pattern: '**/*.ts' },
-        session_id: 'sess-drift',
+        tool_input: { pattern: '**' },
+        session_id: 'drift',
         cwd: tmpProject,
         hook_event_name: 'PreToolUse',
       },
@@ -198,60 +117,14 @@ describe('skill-pin enforcement in `node9 check`', () => {
       tmpProject
     );
     expect(r.status).toBe(2);
-    // JSON block payload on stdout
     const out = JSON.parse(r.stdout.trim().split('\n').pop()!);
     expect(out.decision).toBe('block');
     expect(out.reason).toMatch(/skill/i);
     expect(out.reason).toMatch(/pin update/);
-    // Quarantine flag persisted
-    const flagPath = path.join(tmpHome, '.node9', 'skill-sessions', 'sess-drift.json');
-    expect(fs.existsSync(flagPath)).toBe(true);
-    const flag = JSON.parse(fs.readFileSync(flagPath, 'utf-8'));
+    const flag = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, '.node9', 'skill-sessions', 'drift.json'), 'utf-8')
+    );
     expect(flag.state).toBe('quarantined');
-  });
-
-  it('subsequent call in a quarantined session blocks immediately (no re-hash)', () => {
-    // Prime + drift
-    runCheck(
-      {
-        tool_name: 'glob',
-        tool_input: { pattern: '**/*.ts' },
-        session_id: 'sess-prime2',
-        cwd: tmpProject,
-        hook_event_name: 'PreToolUse',
-      },
-      { HOME: tmpHome },
-      tmpProject
-    );
-    fs.writeFileSync(path.join(tmpProject, 'CLAUDE.md'), 'TAMPERED');
-    runCheck(
-      {
-        tool_name: 'glob',
-        tool_input: { pattern: '**/*.ts' },
-        session_id: 'q-sess',
-        cwd: tmpProject,
-        hook_event_name: 'PreToolUse',
-      },
-      { HOME: tmpHome },
-      tmpProject
-    );
-    // Repair the skill — but the session should still be quarantined
-    fs.writeFileSync(path.join(tmpProject, 'CLAUDE.md'), 'original skill content\n');
-    const r = runCheck(
-      {
-        tool_name: 'glob',
-        tool_input: { pattern: '**/*.ts' },
-        session_id: 'q-sess',
-        cwd: tmpProject,
-        hook_event_name: 'PreToolUse',
-      },
-      { HOME: tmpHome },
-      tmpProject
-    );
-    expect(r.status).toBe(2);
-    const out = JSON.parse(r.stdout.trim().split('\n').pop()!);
-    expect(out.decision).toBe('block');
-    expect(out.reason).toMatch(/quarantine/i);
   });
 
   it('corrupt skill-pins.json fails closed (blocks)', () => {
@@ -259,8 +132,8 @@ describe('skill-pin enforcement in `node9 check`', () => {
     const r = runCheck(
       {
         tool_name: 'glob',
-        tool_input: { pattern: '**/*.ts' },
-        session_id: 'corrupt-sess',
+        tool_input: { pattern: '**' },
+        session_id: 'corrupt',
         cwd: tmpProject,
         hook_event_name: 'PreToolUse',
       },
@@ -273,13 +146,11 @@ describe('skill-pin enforcement in `node9 check`', () => {
     expect(out.reason).toMatch(/corrupt|skill/i);
   });
 
-  it('missing session_id skips the skill check entirely', () => {
-    // Without a session_id we have no key to scope verification; fall through
-    // to normal authorization (which, for an ignored tool, should allow).
+  it('missing session_id skips the skill check entirely (allows, no pin file)', () => {
     const r = runCheck(
       {
         tool_name: 'glob',
-        tool_input: { pattern: '**/*.ts' },
+        tool_input: { pattern: '**' },
         cwd: tmpProject,
         hook_event_name: 'PreToolUse',
       },
@@ -287,34 +158,6 @@ describe('skill-pin enforcement in `node9 check`', () => {
       tmpProject
     );
     expect(r.status).toBe(0);
-    // No pin file created (hook skipped)
-    const pinsPath = path.join(tmpHome, '.node9', 'skill-pins.json');
-    expect(fs.existsSync(pinsPath)).toBe(false);
-  });
-
-  it('relative cwd is rejected for project-scoped skill roots (global roots still pinned)', () => {
-    const r = runCheck(
-      {
-        tool_name: 'glob',
-        tool_input: { pattern: '**/*.ts' },
-        session_id: 'rel-sess',
-        cwd: 'relative/path', // NOT absolute — must be ignored per CLAUDE.md rules
-        hook_event_name: 'PreToolUse',
-      },
-      { HOME: tmpHome },
-      tmpProject
-    );
-    expect(r.status).toBe(0);
-    // A verified flag is still written (global roots hashed fine)
-    const flag = path.join(tmpHome, '.node9', 'skill-sessions', 'rel-sess.json');
-    expect(fs.existsSync(flag)).toBe(true);
-    // Crucially, NO project-scoped root entries (all pinned roots are under $HOME)
-    const pinsPath = path.join(tmpHome, '.node9', 'skill-pins.json');
-    if (fs.existsSync(pinsPath)) {
-      const pins = JSON.parse(fs.readFileSync(pinsPath, 'utf-8'));
-      for (const entry of Object.values<{ rootPath: string }>(pins.roots)) {
-        expect(entry.rootPath.startsWith(tmpHome)).toBe(true);
-      }
-    }
+    expect(fs.existsSync(path.join(tmpHome, '.node9', 'skill-pins.json'))).toBe(false);
   });
 });

--- a/src/__tests__/skill-pin-cli.integration.test.ts
+++ b/src/__tests__/skill-pin-cli.integration.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Integration tests for `node9 skill pin` CLI (list / update / reset).
+ *
+ * These spawn the real built CLI subprocess against dist/cli.js with an
+ * isolated HOME directory. See src/__tests__/check.integration.test.ts for
+ * the runner pattern this mirrors.
+ *
+ * Requires `npm run build` before running.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { updatePin, getRootKey, hashSkillRoot } from '../skill-pin';
+
+const CLI = path.resolve(__dirname, '../../dist/cli.js');
+const cliExists = fs.existsSync(CLI);
+
+// Skip the whole suite if dist/cli.js wasn't built — avoids confusing CI output.
+const itBuilt = cliExists ? it : it.skip;
+
+interface RunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(args: string[], env: Record<string, string> = {}, timeoutMs = 60000): RunResult {
+  const baseEnv = { ...process.env };
+  delete baseEnv.NODE9_API_KEY;
+  delete baseEnv.NODE9_API_URL;
+  const result = spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf-8',
+    timeout: timeoutMs,
+    cwd: os.tmpdir(),
+    env: {
+      ...baseEnv,
+      NODE9_NO_AUTO_DAEMON: '1',
+      NODE9_TESTING: '1',
+      FORCE_COLOR: '0',
+      ...env,
+      ...(env.HOME != null ? { USERPROFILE: env.HOME } : {}),
+    },
+  });
+
+  if (result.error) {
+    console.error('[skill-pin CLI test] spawn error:', result.error);
+  }
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+beforeAll(() => {
+  if (!cliExists) {
+    console.warn(
+      `[skill-pin CLI test] dist/cli.js not found at ${CLI} — run \`npm run build\` first. Tests will be skipped.`
+    );
+  }
+});
+
+describe('node9 skill pin list', () => {
+  let tmpHome: string;
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skillpin-cli-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  itBuilt('prints a friendly message when no pins exist', () => {
+    const r = runCli(['skill', 'pin', 'list'], { HOME: tmpHome });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/No skill roots are pinned/i);
+  });
+
+  itBuilt('lists a previously-written pin with rootPath, hash, fileCount', () => {
+    // Seed the HOME pin file directly by running the module in-process with mocked HOME
+    const origHome = process.env.HOME;
+    const origUserprofile = process.env.USERPROFILE;
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    try {
+      const rootPath = '/tmp/project-alpha/.cursor/rules';
+      updatePin(getRootKey(rootPath), rootPath, 'a'.repeat(64), true, 4);
+    } finally {
+      process.env.HOME = origHome;
+      process.env.USERPROFILE = origUserprofile;
+    }
+
+    const r = runCli(['skill', 'pin', 'list'], { HOME: tmpHome });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('/tmp/project-alpha/.cursor/rules');
+    expect(r.stdout).toContain('Files (4)');
+    expect(r.stdout).toContain('a'.repeat(16)); // truncated hash display
+  });
+
+  itBuilt('reports a corrupt pin file and exits 1 with a remediation hint', () => {
+    const node9Dir = path.join(tmpHome, '.node9');
+    fs.mkdirSync(node9Dir, { recursive: true });
+    fs.writeFileSync(path.join(node9Dir, 'skill-pins.json'), 'not json');
+    const r = runCli(['skill', 'pin', 'list'], { HOME: tmpHome });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/corrupt/i);
+    expect(r.stderr).toMatch(/skill pin reset/);
+  });
+});
+
+describe('node9 skill pin update', () => {
+  let tmpHome: string;
+  let tmpSkills: string;
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skillpin-cli-'));
+    tmpSkills = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skillpin-root-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    fs.rmSync(tmpSkills, { recursive: true, force: true });
+  });
+
+  itBuilt('exits 1 with a helpful message when the rootKey is unknown', () => {
+    const r = runCli(['skill', 'pin', 'update', 'deadbeefcafebabe', '--yes'], { HOME: tmpHome });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/No pin found/);
+    expect(r.stderr).toMatch(/skill pin list/);
+  });
+
+  itBuilt('re-pins with --yes (non-interactive) and shows the diff summary', () => {
+    // Seed a directory root and its pin
+    fs.writeFileSync(path.join(tmpSkills, 'a.md'), 'original');
+    fs.writeFileSync(path.join(tmpSkills, 'gone.md'), 'will-be-removed');
+
+    const origHome = process.env.HOME;
+    const origUserprofile = process.env.USERPROFILE;
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    try {
+      const before = hashSkillRoot(tmpSkills);
+      updatePin(
+        getRootKey(tmpSkills),
+        tmpSkills,
+        before.contentHash,
+        before.exists,
+        before.fileCount,
+        before.fileManifest
+      );
+    } finally {
+      process.env.HOME = origHome;
+      process.env.USERPROFILE = origUserprofile;
+    }
+
+    // Mutate: modify one, remove one, add one
+    fs.writeFileSync(path.join(tmpSkills, 'a.md'), 'tampered');
+    fs.unlinkSync(path.join(tmpSkills, 'gone.md'));
+    fs.writeFileSync(path.join(tmpSkills, 'added.md'), 'new');
+
+    const rootKey = getRootKey(tmpSkills);
+    const r = runCli(['skill', 'pin', 'update', rootKey, '--yes'], { HOME: tmpHome });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/added/i);
+    expect(r.stdout).toMatch(/removed/i);
+    expect(r.stdout).toMatch(/modified/i);
+    expect(r.stdout).toMatch(/re-?pinned/i);
+  });
+});
+
+describe('node9 skill pin reset', () => {
+  let tmpHome: string;
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skillpin-cli-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  itBuilt('reports "nothing to clear" when no pins exist', () => {
+    const r = runCli(['skill', 'pin', 'reset'], { HOME: tmpHome });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/No pins to clear|Cleared 0/i);
+  });
+
+  itBuilt('clears pins and wipes the skill-sessions directory', () => {
+    const origHome = process.env.HOME;
+    const origUserprofile = process.env.USERPROFILE;
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    try {
+      updatePin(getRootKey('/p'), '/p', 'a'.repeat(64), true, 1);
+    } finally {
+      process.env.HOME = origHome;
+      process.env.USERPROFILE = origUserprofile;
+    }
+
+    // Seed a stale session flag
+    const sessionsDir = path.join(tmpHome, '.node9', 'skill-sessions');
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    fs.writeFileSync(path.join(sessionsDir, 'sess-1.json'), '{"state":"verified"}');
+
+    const r = runCli(['skill', 'pin', 'reset'], { HOME: tmpHome });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/Cleared/);
+
+    const pinsPath = path.join(tmpHome, '.node9', 'skill-pins.json');
+    const pinsRaw = fs.readFileSync(pinsPath, 'utf-8');
+    expect(JSON.parse(pinsRaw)).toEqual({ roots: {} });
+
+    // Session flags should be wiped so the session isn't resurrected with stale state.
+    expect(fs.existsSync(path.join(sessionsDir, 'sess-1.json'))).toBe(false);
+  });
+});

--- a/src/__tests__/skill-pin-cli.integration.test.ts
+++ b/src/__tests__/skill-pin-cli.integration.test.ts
@@ -1,11 +1,6 @@
 /**
  * Integration tests for `node9 skill pin` CLI (list / update / reset).
- *
- * These spawn the real built CLI subprocess against dist/cli.js with an
- * isolated HOME directory. See src/__tests__/check.integration.test.ts for
- * the runner pattern this mirrors.
- *
- * Requires `npm run build` before running.
+ * Spawns dist/cli.js with an isolated HOME. Requires `npm run build` first.
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
@@ -14,27 +9,26 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { updatePin, getRootKey, hashSkillRoot } from '../skill-pin';
+import { updatePin, getRootKey } from '../skill-pin';
 
 const CLI = path.resolve(__dirname, '../../dist/cli.js');
 const cliExists = fs.existsSync(CLI);
-
-// Skip the whole suite if dist/cli.js wasn't built — avoids confusing CI output.
 const itBuilt = cliExists ? it : it.skip;
 
-interface RunResult {
+function runCli(
+  args: string[],
+  env: Record<string, string> = {}
+): {
   status: number | null;
   stdout: string;
   stderr: string;
-}
-
-function runCli(args: string[], env: Record<string, string> = {}, timeoutMs = 60000): RunResult {
+} {
   const baseEnv = { ...process.env };
   delete baseEnv.NODE9_API_KEY;
   delete baseEnv.NODE9_API_URL;
-  const result = spawnSync(process.execPath, [CLI, ...args], {
+  const r = spawnSync(process.execPath, [CLI, ...args], {
     encoding: 'utf-8',
-    timeout: timeoutMs,
+    timeout: 60000,
     cwd: os.tmpdir(),
     env: {
       ...baseEnv,
@@ -45,26 +39,29 @@ function runCli(args: string[], env: Record<string, string> = {}, timeoutMs = 60
       ...(env.HOME != null ? { USERPROFILE: env.HOME } : {}),
     },
   });
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
 
-  if (result.error) {
-    console.error('[skill-pin CLI test] spawn error:', result.error);
+function seedPin(tmpHome: string, rootKey: string, rootPath: string): void {
+  const origHome = process.env.HOME;
+  const origUP = process.env.USERPROFILE;
+  process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome;
+  try {
+    updatePin(rootKey, rootPath, 'a'.repeat(64), true, 4);
+  } finally {
+    process.env.HOME = origHome;
+    process.env.USERPROFILE = origUP;
   }
-  return {
-    status: result.status,
-    stdout: result.stdout ?? '',
-    stderr: result.stderr ?? '',
-  };
 }
 
 beforeAll(() => {
   if (!cliExists) {
-    console.warn(
-      `[skill-pin CLI test] dist/cli.js not found at ${CLI} — run \`npm run build\` first. Tests will be skipped.`
-    );
+    console.warn(`[skill-pin CLI test] dist/cli.js not found — run \`npm run build\`.`);
   }
 });
 
-describe('node9 skill pin list', () => {
+describe('node9 skill pin', () => {
   let tmpHome: string;
   beforeEach(() => {
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skillpin-cli-'));
@@ -73,143 +70,63 @@ describe('node9 skill pin list', () => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 
-  itBuilt('prints a friendly message when no pins exist', () => {
+  itBuilt('list: friendly empty message when no pins exist', () => {
     const r = runCli(['skill', 'pin', 'list'], { HOME: tmpHome });
     expect(r.status).toBe(0);
     expect(r.stdout).toMatch(/No skill roots are pinned/i);
   });
 
-  itBuilt('lists a previously-written pin with rootPath, hash, fileCount', () => {
-    // Seed the HOME pin file directly by running the module in-process with mocked HOME
-    const origHome = process.env.HOME;
-    const origUserprofile = process.env.USERPROFILE;
-    process.env.HOME = tmpHome;
-    process.env.USERPROFILE = tmpHome;
-    try {
-      const rootPath = '/tmp/project-alpha/.cursor/rules';
-      updatePin(getRootKey(rootPath), rootPath, 'a'.repeat(64), true, 4);
-    } finally {
-      process.env.HOME = origHome;
-      process.env.USERPROFILE = origUserprofile;
-    }
-
+  itBuilt('list: shows rootPath, hash, fileCount for a seeded pin', () => {
+    const rootPath = '/tmp/project-alpha/.cursor/rules';
+    seedPin(tmpHome, getRootKey(rootPath), rootPath);
     const r = runCli(['skill', 'pin', 'list'], { HOME: tmpHome });
     expect(r.status).toBe(0);
-    expect(r.stdout).toContain('/tmp/project-alpha/.cursor/rules');
+    expect(r.stdout).toContain(rootPath);
     expect(r.stdout).toContain('Files (4)');
-    expect(r.stdout).toContain('a'.repeat(16)); // truncated hash display
+    expect(r.stdout).toContain('a'.repeat(16));
   });
 
-  itBuilt('reports a corrupt pin file and exits 1 with a remediation hint', () => {
-    const node9Dir = path.join(tmpHome, '.node9');
-    fs.mkdirSync(node9Dir, { recursive: true });
-    fs.writeFileSync(path.join(node9Dir, 'skill-pins.json'), 'not json');
+  itBuilt('list: corrupt pin file exits 1 with remediation hint', () => {
+    const dir = path.join(tmpHome, '.node9');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'skill-pins.json'), 'not json');
     const r = runCli(['skill', 'pin', 'list'], { HOME: tmpHome });
     expect(r.status).toBe(1);
     expect(r.stderr).toMatch(/corrupt/i);
     expect(r.stderr).toMatch(/skill pin reset/);
   });
-});
 
-describe('node9 skill pin update', () => {
-  let tmpHome: string;
-  let tmpSkills: string;
-  beforeEach(() => {
-    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skillpin-cli-'));
-    tmpSkills = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skillpin-root-'));
-  });
-  afterEach(() => {
-    fs.rmSync(tmpHome, { recursive: true, force: true });
-    fs.rmSync(tmpSkills, { recursive: true, force: true });
-  });
-
-  itBuilt('exits 1 with a helpful message when the rootKey is unknown', () => {
-    const r = runCli(['skill', 'pin', 'update', 'deadbeefcafebabe', '--yes'], { HOME: tmpHome });
+  itBuilt('update: unknown rootKey exits 1 with a helpful message', () => {
+    const r = runCli(['skill', 'pin', 'update', 'deadbeefcafebabe'], { HOME: tmpHome });
     expect(r.status).toBe(1);
     expect(r.stderr).toMatch(/No pin found/);
-    expect(r.stderr).toMatch(/skill pin list/);
   });
 
-  itBuilt('re-pins with --yes (non-interactive) and shows the diff summary', () => {
-    // Seed a directory root and its pin
-    fs.writeFileSync(path.join(tmpSkills, 'a.md'), 'original');
-    fs.writeFileSync(path.join(tmpSkills, 'gone.md'), 'will-be-removed');
-
-    const origHome = process.env.HOME;
-    const origUserprofile = process.env.USERPROFILE;
-    process.env.HOME = tmpHome;
-    process.env.USERPROFILE = tmpHome;
-    try {
-      const before = hashSkillRoot(tmpSkills);
-      updatePin(
-        getRootKey(tmpSkills),
-        tmpSkills,
-        before.contentHash,
-        before.exists,
-        before.fileCount,
-        before.fileManifest
-      );
-    } finally {
-      process.env.HOME = origHome;
-      process.env.USERPROFILE = origUserprofile;
-    }
-
-    // Mutate: modify one, remove one, add one
-    fs.writeFileSync(path.join(tmpSkills, 'a.md'), 'tampered');
-    fs.unlinkSync(path.join(tmpSkills, 'gone.md'));
-    fs.writeFileSync(path.join(tmpSkills, 'added.md'), 'new');
-
-    const rootKey = getRootKey(tmpSkills);
-    const r = runCli(['skill', 'pin', 'update', rootKey, '--yes'], { HOME: tmpHome });
+  itBuilt('update: removes a known pin so next session re-pins', () => {
+    const rootPath = '/tmp/project-alpha/.cursor/rules';
+    const key = getRootKey(rootPath);
+    seedPin(tmpHome, key, rootPath);
+    const r = runCli(['skill', 'pin', 'update', key], { HOME: tmpHome });
     expect(r.status).toBe(0);
-    expect(r.stdout).toMatch(/added/i);
-    expect(r.stdout).toMatch(/removed/i);
-    expect(r.stdout).toMatch(/modified/i);
-    expect(r.stdout).toMatch(/re-?pinned/i);
-  });
-});
-
-describe('node9 skill pin reset', () => {
-  let tmpHome: string;
-  beforeEach(() => {
-    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skillpin-cli-'));
-  });
-  afterEach(() => {
-    fs.rmSync(tmpHome, { recursive: true, force: true });
+    expect(r.stdout).toMatch(/Pin removed/);
+    const pins = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, '.node9', 'skill-pins.json'), 'utf-8')
+    );
+    expect(pins.roots[key]).toBeUndefined();
   });
 
-  itBuilt('reports "nothing to clear" when no pins exist', () => {
-    const r = runCli(['skill', 'pin', 'reset'], { HOME: tmpHome });
-    expect(r.status).toBe(0);
-    expect(r.stdout).toMatch(/No pins to clear|Cleared 0/i);
-  });
-
-  itBuilt('clears pins and wipes the skill-sessions directory', () => {
-    const origHome = process.env.HOME;
-    const origUserprofile = process.env.USERPROFILE;
-    process.env.HOME = tmpHome;
-    process.env.USERPROFILE = tmpHome;
-    try {
-      updatePin(getRootKey('/p'), '/p', 'a'.repeat(64), true, 1);
-    } finally {
-      process.env.HOME = origHome;
-      process.env.USERPROFILE = origUserprofile;
-    }
-
-    // Seed a stale session flag
+  itBuilt('reset: clears pins AND wipes skill-sessions/', () => {
+    seedPin(tmpHome, getRootKey('/p'), '/p');
     const sessionsDir = path.join(tmpHome, '.node9', 'skill-sessions');
     fs.mkdirSync(sessionsDir, { recursive: true });
     fs.writeFileSync(path.join(sessionsDir, 'sess-1.json'), '{"state":"verified"}');
-
     const r = runCli(['skill', 'pin', 'reset'], { HOME: tmpHome });
     expect(r.status).toBe(0);
     expect(r.stdout).toMatch(/Cleared/);
-
-    const pinsPath = path.join(tmpHome, '.node9', 'skill-pins.json');
-    const pinsRaw = fs.readFileSync(pinsPath, 'utf-8');
-    expect(JSON.parse(pinsRaw)).toEqual({ roots: {} });
-
-    // Session flags should be wiped so the session isn't resurrected with stale state.
+    const pins = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, '.node9', 'skill-pins.json'), 'utf-8')
+    );
+    expect(pins).toEqual({ roots: {} });
     expect(fs.existsSync(path.join(sessionsDir, 'sess-1.json'))).toBe(false);
   });
 });

--- a/src/__tests__/skill-pin.unit.test.ts
+++ b/src/__tests__/skill-pin.unit.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Unit tests for skill pinning (supply chain & update drift defense).
+ *
+ * TDD: These tests are written BEFORE the implementation exists.
+ * Each test describes a contract that src/skill-pin.ts must satisfy.
+ *
+ * Mirrors the structure of src/__tests__/mcp-pin.unit.test.ts with two
+ * extensions specific to skills: (a) hashing filesystem roots (files or
+ * directories) instead of in-memory JSON tool definitions, and
+ * (b) per-root `exists` bookkeeping so "skill root appeared" and
+ * "skill root vanished" are both classified as drift.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  hashSkillRoot,
+  getRootKey,
+  readSkillPins,
+  readSkillPinsSafe,
+  checkPin,
+  updatePin,
+  removePin,
+  clearAllPins,
+  computePinDiff,
+} from '../skill-pin';
+
+// ---------------------------------------------------------------------------
+// hashSkillRoot
+// ---------------------------------------------------------------------------
+
+describe('hashSkillRoot', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skill-hash-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns exists=false with empty hash when the path does not exist', () => {
+    const result = hashSkillRoot(path.join(tmpDir, 'does-not-exist'));
+    expect(result.exists).toBe(false);
+    expect(result.contentHash).toBe('');
+    expect(result.fileCount).toBe(0);
+  });
+
+  it('hashes a single file root (exists=true, fileCount=1)', () => {
+    const filePath = path.join(tmpDir, 'CLAUDE.md');
+    fs.writeFileSync(filePath, 'hello skill');
+    const result = hashSkillRoot(filePath);
+    expect(result.exists).toBe(true);
+    expect(result.contentHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.fileCount).toBe(1);
+  });
+
+  it("produces different hashes when a file's content changes", () => {
+    const filePath = path.join(tmpDir, 'CLAUDE.md');
+    fs.writeFileSync(filePath, 'original');
+    const before = hashSkillRoot(filePath).contentHash;
+    fs.writeFileSync(filePath, 'tampered');
+    const after = hashSkillRoot(filePath).contentHash;
+    expect(before).not.toBe(after);
+  });
+
+  it('hashes a directory root recursively (fileCount reflects all files)', () => {
+    const root = path.join(tmpDir, 'skills');
+    fs.mkdirSync(path.join(root, 'nested'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'a.md'), 'a');
+    fs.writeFileSync(path.join(root, 'b.md'), 'b');
+    fs.writeFileSync(path.join(root, 'nested', 'c.md'), 'c');
+    const result = hashSkillRoot(root);
+    expect(result.exists).toBe(true);
+    expect(result.fileCount).toBe(3);
+    expect(result.contentHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('is order-invariant for directory roots (filesystem traversal order must not affect hash)', () => {
+    const rootA = path.join(tmpDir, 'skills-a');
+    const rootB = path.join(tmpDir, 'skills-b');
+    fs.mkdirSync(rootA, { recursive: true });
+    fs.mkdirSync(rootB, { recursive: true });
+    // Create in different order — contents are identical
+    fs.writeFileSync(path.join(rootA, 'z.md'), 'z');
+    fs.writeFileSync(path.join(rootA, 'a.md'), 'a');
+    fs.writeFileSync(path.join(rootB, 'a.md'), 'a');
+    fs.writeFileSync(path.join(rootB, 'z.md'), 'z');
+    expect(hashSkillRoot(rootA).contentHash).toBe(hashSkillRoot(rootB).contentHash);
+  });
+
+  it('produces a different hash when a file is added to a directory', () => {
+    const root = path.join(tmpDir, 'skills');
+    fs.mkdirSync(root);
+    fs.writeFileSync(path.join(root, 'a.md'), 'a');
+    const before = hashSkillRoot(root).contentHash;
+    fs.writeFileSync(path.join(root, 'b.md'), 'b');
+    const after = hashSkillRoot(root).contentHash;
+    expect(before).not.toBe(after);
+  });
+
+  it('produces a different hash when a file is removed from a directory', () => {
+    const root = path.join(tmpDir, 'skills');
+    fs.mkdirSync(root);
+    fs.writeFileSync(path.join(root, 'a.md'), 'a');
+    fs.writeFileSync(path.join(root, 'b.md'), 'b');
+    const before = hashSkillRoot(root).contentHash;
+    fs.unlinkSync(path.join(root, 'b.md'));
+    const after = hashSkillRoot(root).contentHash;
+    expect(before).not.toBe(after);
+  });
+
+  it("produces a different hash when a nested file's content changes", () => {
+    const root = path.join(tmpDir, 'skills');
+    fs.mkdirSync(path.join(root, 'nested'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'nested', 'c.md'), 'original');
+    const before = hashSkillRoot(root).contentHash;
+    fs.writeFileSync(path.join(root, 'nested', 'c.md'), 'tampered');
+    const after = hashSkillRoot(root).contentHash;
+    expect(before).not.toBe(after);
+  });
+
+  it('handles an empty directory', () => {
+    const root = path.join(tmpDir, 'empty-skills');
+    fs.mkdirSync(root);
+    const result = hashSkillRoot(root);
+    expect(result.exists).toBe(true);
+    expect(result.fileCount).toBe(0);
+    expect(result.contentHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('skips symlinks (never follows them into arbitrary filesystem locations)', () => {
+    const root = path.join(tmpDir, 'skills');
+    fs.mkdirSync(root);
+    fs.writeFileSync(path.join(root, 'real.md'), 'real');
+    const target = path.join(tmpDir, 'outside.md');
+    fs.writeFileSync(target, 'outside');
+    try {
+      fs.symlinkSync(target, path.join(root, 'link.md'));
+    } catch {
+      // Windows without developer mode can't create symlinks — skip the assertion.
+      return;
+    }
+    const result = hashSkillRoot(root);
+    // Only the real file should be counted; link is ignored.
+    expect(result.fileCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getRootKey
+// ---------------------------------------------------------------------------
+
+describe('getRootKey', () => {
+  it('returns a 16-char hex string', () => {
+    const key = getRootKey('/home/user/.claude/skills');
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it('returns the same key for the same path', () => {
+    const p = '/home/user/.claude/skills';
+    expect(getRootKey(p)).toBe(getRootKey(p));
+  });
+
+  it('returns different keys for different paths', () => {
+    expect(getRootKey('/project-a/.cursor/rules')).not.toBe(getRootKey('/project-b/.cursor/rules'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pin file operations (read/write/check/update/remove)
+// ---------------------------------------------------------------------------
+
+describe('pin file operations', () => {
+  let tmpHome: string;
+  let origHome: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skillpin-test-'));
+    origHome = process.env.HOME!;
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome; // Windows: os.homedir() reads USERPROFILE, not HOME
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    process.env.USERPROFILE = origHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('readSkillPins returns empty roots when no file exists', () => {
+    const pins = readSkillPins();
+    expect(pins.roots).toEqual({});
+  });
+
+  it('checkPin returns "new" for an unknown root', () => {
+    expect(checkPin('abc1234567890123', 'somehash', true)).toBe('new');
+  });
+
+  it('updatePin saves a pin and checkPin returns "match"', () => {
+    const key = getRootKey('/p/skills');
+    const hash = 'a'.repeat(64);
+    updatePin(key, '/p/skills', hash, true, 5);
+    expect(checkPin(key, hash, true)).toBe('match');
+  });
+
+  it('checkPin returns "mismatch" when content hash differs', () => {
+    const key = getRootKey('/p/skills');
+    updatePin(key, '/p/skills', 'a'.repeat(64), true, 2);
+    expect(checkPin(key, 'b'.repeat(64), true)).toBe('mismatch');
+  });
+
+  it('checkPin returns "mismatch" when exists flag flips (root now missing)', () => {
+    const key = getRootKey('/p/skills');
+    updatePin(key, '/p/skills', 'a'.repeat(64), true, 2);
+    // Same "hash" (empty) but exists flipped from true to false = drift.
+    expect(checkPin(key, '', false)).toBe('mismatch');
+  });
+
+  it('checkPin returns "mismatch" when exists flag flips (root newly appeared)', () => {
+    const key = getRootKey('/p/skills');
+    updatePin(key, '/p/skills', '', false, 0);
+    expect(checkPin(key, 'a'.repeat(64), true)).toBe('mismatch');
+  });
+
+  it('removePin deletes a pin so checkPin returns "new"', () => {
+    const key = getRootKey('/p/skills');
+    updatePin(key, '/p/skills', 'a'.repeat(64), true, 1);
+    removePin(key);
+    expect(checkPin(key, 'a'.repeat(64), true)).toBe('new');
+  });
+
+  it('clearAllPins removes all pins', () => {
+    updatePin('k1'.padEnd(16, '0'), '/a', 'a'.repeat(64), true, 1);
+    updatePin('k2'.padEnd(16, '0'), '/b', 'b'.repeat(64), true, 1);
+    clearAllPins();
+    expect(readSkillPins().roots).toEqual({});
+  });
+
+  it('readSkillPins returns saved data with correct fields', () => {
+    const key = getRootKey('/p/skills');
+    updatePin(key, '/p/skills', 'c'.repeat(64), true, 7);
+    const pins = readSkillPins();
+    const entry = pins.roots[key];
+    expect(entry).toBeDefined();
+    expect(entry.rootPath).toBe('/p/skills');
+    expect(entry.contentHash).toBe('c'.repeat(64));
+    expect(entry.exists).toBe(true);
+    expect(entry.fileCount).toBe(7);
+    expect(entry.pinnedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('pin file is created with mode 0o600', { skip: process.platform === 'win32' }, () => {
+    updatePin(getRootKey('/p/skills'), '/p/skills', 'a'.repeat(64), true, 1);
+    const pinPath = path.join(tmpHome, '.node9', 'skill-pins.json');
+    const stat = fs.statSync(pinPath);
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it('readSkillPins throws on corrupted pin file (fail closed)', () => {
+    const node9Dir = path.join(tmpHome, '.node9');
+    fs.mkdirSync(node9Dir, { recursive: true });
+    fs.writeFileSync(path.join(node9Dir, 'skill-pins.json'), 'not valid json');
+    expect(() => readSkillPins()).toThrow(/corrupt/i);
+  });
+
+  it('readSkillPinsSafe returns corrupt for invalid JSON', () => {
+    const node9Dir = path.join(tmpHome, '.node9');
+    fs.mkdirSync(node9Dir, { recursive: true });
+    fs.writeFileSync(path.join(node9Dir, 'skill-pins.json'), 'not valid json');
+    const result = readSkillPinsSafe();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('corrupt');
+  });
+
+  it('readSkillPinsSafe returns corrupt for empty file', () => {
+    const node9Dir = path.join(tmpHome, '.node9');
+    fs.mkdirSync(node9Dir, { recursive: true });
+    fs.writeFileSync(path.join(node9Dir, 'skill-pins.json'), '');
+    const result = readSkillPinsSafe();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('corrupt');
+  });
+
+  it('readSkillPinsSafe returns corrupt for JSON missing roots object', () => {
+    const node9Dir = path.join(tmpHome, '.node9');
+    fs.mkdirSync(node9Dir, { recursive: true });
+    fs.writeFileSync(path.join(node9Dir, 'skill-pins.json'), '{"version": 1}');
+    const result = readSkillPinsSafe();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('corrupt');
+  });
+
+  it('readSkillPinsSafe returns missing when no file exists', () => {
+    const result = readSkillPinsSafe();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('missing');
+  });
+
+  it('readSkillPinsSafe returns ok with valid pins', () => {
+    updatePin(getRootKey('/p'), '/p', 'a'.repeat(64), true, 1);
+    const result = readSkillPinsSafe();
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.pins.roots[getRootKey('/p')]).toBeDefined();
+  });
+
+  it('checkPin returns "corrupt" for corrupted pin file', () => {
+    const node9Dir = path.join(tmpHome, '.node9');
+    fs.mkdirSync(node9Dir, { recursive: true });
+    fs.writeFileSync(path.join(node9Dir, 'skill-pins.json'), 'not valid json');
+    expect(checkPin('anykey1234567890', 'anyhash', true)).toBe('corrupt');
+  });
+
+  it('checkPin returns "new" when file is missing (not corrupt)', () => {
+    expect(checkPin('anykey1234567890', 'anyhash', true)).toBe('new');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computePinDiff — used by `node9 skill pin update` to show what changed
+// ---------------------------------------------------------------------------
+
+describe('computePinDiff', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skill-diff-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns kind="unchanged" when the root has not changed', () => {
+    const root = path.join(tmpDir, 'skills');
+    fs.mkdirSync(root);
+    fs.writeFileSync(path.join(root, 'a.md'), 'a');
+    const hashed = hashSkillRoot(root);
+    const diff = computePinDiff(
+      {
+        rootPath: root,
+        exists: hashed.exists,
+        contentHash: hashed.contentHash,
+        fileCount: hashed.fileCount,
+        pinnedAt: new Date().toISOString(),
+      },
+      root
+    );
+    expect(diff.kind).toBe('unchanged');
+  });
+
+  it('returns kind="appeared" when pin recorded !exists but the root now exists', () => {
+    const root = path.join(tmpDir, 'skills');
+    fs.mkdirSync(root);
+    fs.writeFileSync(path.join(root, 'a.md'), 'a');
+    const diff = computePinDiff(
+      {
+        rootPath: root,
+        exists: false,
+        contentHash: '',
+        fileCount: 0,
+        pinnedAt: new Date().toISOString(),
+      },
+      root
+    );
+    expect(diff.kind).toBe('appeared');
+  });
+
+  it('returns kind="vanished" when pin recorded exists but the root is now missing', () => {
+    const root = path.join(tmpDir, 'skills-missing');
+    const diff = computePinDiff(
+      {
+        rootPath: root,
+        exists: true,
+        contentHash: 'a'.repeat(64),
+        fileCount: 1,
+        pinnedAt: new Date().toISOString(),
+      },
+      root
+    );
+    expect(diff.kind).toBe('vanished');
+  });
+
+  it('reports added / removed / modified files for a directory root', () => {
+    const root = path.join(tmpDir, 'skills');
+    fs.mkdirSync(root);
+    fs.writeFileSync(path.join(root, 'keep.md'), 'keep');
+    fs.writeFileSync(path.join(root, 'modify.md'), 'original');
+    fs.writeFileSync(path.join(root, 'remove.md'), 'gone-soon');
+    const before = hashSkillRoot(root);
+    const pin = {
+      rootPath: root,
+      exists: before.exists,
+      contentHash: before.contentHash,
+      fileCount: before.fileCount,
+      pinnedAt: new Date().toISOString(),
+      // Implementation detail: computePinDiff may need the per-file manifest.
+      // We stash it on the pin here so the diff helper can show per-file changes.
+      fileManifest: before.fileManifest,
+    };
+
+    // Mutate: modify one, remove one, add one
+    fs.writeFileSync(path.join(root, 'modify.md'), 'tampered');
+    fs.unlinkSync(path.join(root, 'remove.md'));
+    fs.writeFileSync(path.join(root, 'add.md'), 'new');
+
+    const diff = computePinDiff(pin, root);
+    expect(diff.kind).toBe('changed');
+    if (diff.kind !== 'changed') return;
+    expect(diff.added).toEqual(['add.md']);
+    expect(diff.removed).toEqual(['remove.md']);
+    expect(diff.modified).toEqual(['modify.md']);
+  });
+
+  it('reports kind="changed" even without a fileManifest (single-file root)', () => {
+    const file = path.join(tmpDir, 'CLAUDE.md');
+    fs.writeFileSync(file, 'original');
+    const before = hashSkillRoot(file);
+    const pin = {
+      rootPath: file,
+      exists: before.exists,
+      contentHash: before.contentHash,
+      fileCount: before.fileCount,
+      pinnedAt: new Date().toISOString(),
+    };
+    fs.writeFileSync(file, 'tampered');
+    const diff = computePinDiff(pin, file);
+    expect(diff.kind).toBe('changed');
+  });
+});

--- a/src/__tests__/skill-pin.unit.test.ts
+++ b/src/__tests__/skill-pin.unit.test.ts
@@ -1,14 +1,7 @@
 /**
  * Unit tests for skill pinning (supply chain & update drift defense).
- *
- * TDD: These tests are written BEFORE the implementation exists.
- * Each test describes a contract that src/skill-pin.ts must satisfy.
- *
- * Mirrors the structure of src/__tests__/mcp-pin.unit.test.ts with two
- * extensions specific to skills: (a) hashing filesystem roots (files or
- * directories) instead of in-memory JSON tool definitions, and
- * (b) per-root `exists` bookkeeping so "skill root appeared" and
- * "skill root vanished" are both classified as drift.
+ * Mirrors src/__tests__/mcp-pin.unit.test.ts, with directory hashing and the
+ * per-root `exists` flag added for AST 02 / AST 07 coverage.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -25,7 +18,6 @@ import {
   updatePin,
   removePin,
   clearAllPins,
-  computePinDiff,
 } from '../skill-pin';
 
 // ---------------------------------------------------------------------------
@@ -34,120 +26,81 @@ import {
 
 describe('hashSkillRoot', () => {
   let tmpDir: string;
-
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skill-hash-'));
   });
-
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('returns exists=false with empty hash when the path does not exist', () => {
-    const result = hashSkillRoot(path.join(tmpDir, 'does-not-exist'));
-    expect(result.exists).toBe(false);
-    expect(result.contentHash).toBe('');
-    expect(result.fileCount).toBe(0);
+  it('returns exists=false when the path does not exist', () => {
+    const result = hashSkillRoot(path.join(tmpDir, 'nope'));
+    expect(result).toEqual({ exists: false, contentHash: '', fileCount: 0 });
   });
 
-  it('hashes a single file root (exists=true, fileCount=1)', () => {
-    const filePath = path.join(tmpDir, 'CLAUDE.md');
-    fs.writeFileSync(filePath, 'hello skill');
-    const result = hashSkillRoot(filePath);
-    expect(result.exists).toBe(true);
-    expect(result.contentHash).toMatch(/^[a-f0-9]{64}$/);
-    expect(result.fileCount).toBe(1);
+  it('hashes a single file root', () => {
+    const p = path.join(tmpDir, 'CLAUDE.md');
+    fs.writeFileSync(p, 'hello');
+    const r = hashSkillRoot(p);
+    expect(r.exists).toBe(true);
+    expect(r.contentHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(r.fileCount).toBe(1);
   });
 
   it("produces different hashes when a file's content changes", () => {
-    const filePath = path.join(tmpDir, 'CLAUDE.md');
-    fs.writeFileSync(filePath, 'original');
-    const before = hashSkillRoot(filePath).contentHash;
-    fs.writeFileSync(filePath, 'tampered');
-    const after = hashSkillRoot(filePath).contentHash;
-    expect(before).not.toBe(after);
+    const p = path.join(tmpDir, 'CLAUDE.md');
+    fs.writeFileSync(p, 'a');
+    const before = hashSkillRoot(p).contentHash;
+    fs.writeFileSync(p, 'b');
+    expect(hashSkillRoot(p).contentHash).not.toBe(before);
   });
 
-  it('hashes a directory root recursively (fileCount reflects all files)', () => {
+  it('hashes a directory root recursively', () => {
     const root = path.join(tmpDir, 'skills');
     fs.mkdirSync(path.join(root, 'nested'), { recursive: true });
     fs.writeFileSync(path.join(root, 'a.md'), 'a');
-    fs.writeFileSync(path.join(root, 'b.md'), 'b');
     fs.writeFileSync(path.join(root, 'nested', 'c.md'), 'c');
-    const result = hashSkillRoot(root);
-    expect(result.exists).toBe(true);
-    expect(result.fileCount).toBe(3);
-    expect(result.contentHash).toMatch(/^[a-f0-9]{64}$/);
+    const r = hashSkillRoot(root);
+    expect(r.fileCount).toBe(2);
+    expect(r.contentHash).toMatch(/^[a-f0-9]{64}$/);
   });
 
-  it('is order-invariant for directory roots (filesystem traversal order must not affect hash)', () => {
-    const rootA = path.join(tmpDir, 'skills-a');
-    const rootB = path.join(tmpDir, 'skills-b');
-    fs.mkdirSync(rootA, { recursive: true });
-    fs.mkdirSync(rootB, { recursive: true });
-    // Create in different order — contents are identical
-    fs.writeFileSync(path.join(rootA, 'z.md'), 'z');
-    fs.writeFileSync(path.join(rootA, 'a.md'), 'a');
-    fs.writeFileSync(path.join(rootB, 'a.md'), 'a');
-    fs.writeFileSync(path.join(rootB, 'z.md'), 'z');
-    expect(hashSkillRoot(rootA).contentHash).toBe(hashSkillRoot(rootB).contentHash);
+  it('is order-invariant for directory roots', () => {
+    const a = path.join(tmpDir, 'a');
+    const b = path.join(tmpDir, 'b');
+    fs.mkdirSync(a);
+    fs.mkdirSync(b);
+    fs.writeFileSync(path.join(a, 'z.md'), 'z');
+    fs.writeFileSync(path.join(a, 'a.md'), 'a');
+    fs.writeFileSync(path.join(b, 'a.md'), 'a');
+    fs.writeFileSync(path.join(b, 'z.md'), 'z');
+    expect(hashSkillRoot(a).contentHash).toBe(hashSkillRoot(b).contentHash);
   });
 
-  it('produces a different hash when a file is added to a directory', () => {
+  it('detects added / removed / modified files', () => {
     const root = path.join(tmpDir, 'skills');
     fs.mkdirSync(root);
     fs.writeFileSync(path.join(root, 'a.md'), 'a');
-    const before = hashSkillRoot(root).contentHash;
+    const h1 = hashSkillRoot(root).contentHash;
     fs.writeFileSync(path.join(root, 'b.md'), 'b');
-    const after = hashSkillRoot(root).contentHash;
-    expect(before).not.toBe(after);
-  });
-
-  it('produces a different hash when a file is removed from a directory', () => {
-    const root = path.join(tmpDir, 'skills');
-    fs.mkdirSync(root);
-    fs.writeFileSync(path.join(root, 'a.md'), 'a');
-    fs.writeFileSync(path.join(root, 'b.md'), 'b');
-    const before = hashSkillRoot(root).contentHash;
+    const h2 = hashSkillRoot(root).contentHash;
+    expect(h2).not.toBe(h1);
+    fs.writeFileSync(path.join(root, 'a.md'), 'tampered');
+    expect(hashSkillRoot(root).contentHash).not.toBe(h2);
     fs.unlinkSync(path.join(root, 'b.md'));
-    const after = hashSkillRoot(root).contentHash;
-    expect(before).not.toBe(after);
+    expect(hashSkillRoot(root).contentHash).not.toBe(h2);
   });
 
-  it("produces a different hash when a nested file's content changes", () => {
-    const root = path.join(tmpDir, 'skills');
-    fs.mkdirSync(path.join(root, 'nested'), { recursive: true });
-    fs.writeFileSync(path.join(root, 'nested', 'c.md'), 'original');
-    const before = hashSkillRoot(root).contentHash;
-    fs.writeFileSync(path.join(root, 'nested', 'c.md'), 'tampered');
-    const after = hashSkillRoot(root).contentHash;
-    expect(before).not.toBe(after);
-  });
-
-  it('handles an empty directory', () => {
-    const root = path.join(tmpDir, 'empty-skills');
-    fs.mkdirSync(root);
-    const result = hashSkillRoot(root);
-    expect(result.exists).toBe(true);
-    expect(result.fileCount).toBe(0);
-    expect(result.contentHash).toMatch(/^[a-f0-9]{64}$/);
-  });
-
-  it('skips symlinks (never follows them into arbitrary filesystem locations)', () => {
+  it('skips symlinks (never follows them out of the tree)', () => {
     const root = path.join(tmpDir, 'skills');
     fs.mkdirSync(root);
     fs.writeFileSync(path.join(root, 'real.md'), 'real');
-    const target = path.join(tmpDir, 'outside.md');
-    fs.writeFileSync(target, 'outside');
     try {
-      fs.symlinkSync(target, path.join(root, 'link.md'));
+      fs.symlinkSync(path.join(tmpDir, 'outside.md'), path.join(root, 'link.md'));
     } catch {
-      // Windows without developer mode can't create symlinks — skip the assertion.
-      return;
+      return; // Windows without developer mode — skip
     }
-    const result = hashSkillRoot(root);
-    // Only the real file should be counted; link is ignored.
-    expect(result.fileCount).toBe(1);
+    expect(hashSkillRoot(root).fileCount).toBe(1);
   });
 });
 
@@ -156,23 +109,15 @@ describe('hashSkillRoot', () => {
 // ---------------------------------------------------------------------------
 
 describe('getRootKey', () => {
-  it('returns a 16-char hex string', () => {
-    const key = getRootKey('/home/user/.claude/skills');
-    expect(key).toMatch(/^[a-f0-9]{16}$/);
-  });
-
-  it('returns the same key for the same path', () => {
-    const p = '/home/user/.claude/skills';
-    expect(getRootKey(p)).toBe(getRootKey(p));
-  });
-
-  it('returns different keys for different paths', () => {
-    expect(getRootKey('/project-a/.cursor/rules')).not.toBe(getRootKey('/project-b/.cursor/rules'));
+  it('returns a stable 16-char hex string per path', () => {
+    expect(getRootKey('/p/skills')).toMatch(/^[a-f0-9]{16}$/);
+    expect(getRootKey('/p/skills')).toBe(getRootKey('/p/skills'));
+    expect(getRootKey('/p/a')).not.toBe(getRootKey('/p/b'));
   });
 });
 
 // ---------------------------------------------------------------------------
-// Pin file operations (read/write/check/update/remove)
+// Pin file operations
 // ---------------------------------------------------------------------------
 
 describe('pin file operations', () => {
@@ -183,7 +128,7 @@ describe('pin file operations', () => {
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skillpin-test-'));
     origHome = process.env.HOME!;
     process.env.HOME = tmpHome;
-    process.env.USERPROFILE = tmpHome; // Windows: os.homedir() reads USERPROFILE, not HOME
+    process.env.USERPROFILE = tmpHome; // Windows: os.homedir() reads USERPROFILE
   });
 
   afterEach(() => {
@@ -192,62 +137,43 @@ describe('pin file operations', () => {
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 
-  it('readSkillPins returns empty roots when no file exists', () => {
-    const pins = readSkillPins();
-    expect(pins.roots).toEqual({});
+  it('returns empty roots when no file exists', () => {
+    expect(readSkillPins().roots).toEqual({});
+    expect(checkPin('abc1234567890123', 'h', true)).toBe('new');
   });
 
-  it('checkPin returns "new" for an unknown root', () => {
-    expect(checkPin('abc1234567890123', 'somehash', true)).toBe('new');
-  });
-
-  it('updatePin saves a pin and checkPin returns "match"', () => {
-    const key = getRootKey('/p/skills');
-    const hash = 'a'.repeat(64);
-    updatePin(key, '/p/skills', hash, true, 5);
-    expect(checkPin(key, hash, true)).toBe('match');
-  });
-
-  it('checkPin returns "mismatch" when content hash differs', () => {
-    const key = getRootKey('/p/skills');
-    updatePin(key, '/p/skills', 'a'.repeat(64), true, 2);
+  it('updatePin + checkPin round-trip', () => {
+    const key = getRootKey('/p');
+    updatePin(key, '/p', 'a'.repeat(64), true, 3);
+    expect(checkPin(key, 'a'.repeat(64), true)).toBe('match');
     expect(checkPin(key, 'b'.repeat(64), true)).toBe('mismatch');
   });
 
-  it('checkPin returns "mismatch" when exists flag flips (root now missing)', () => {
-    const key = getRootKey('/p/skills');
-    updatePin(key, '/p/skills', 'a'.repeat(64), true, 2);
-    // Same "hash" (empty) but exists flipped from true to false = drift.
+  it('classifies exists-flip as mismatch (both directions)', () => {
+    const key = getRootKey('/p');
+    // existed → vanished
+    updatePin(key, '/p', 'a'.repeat(64), true, 1);
     expect(checkPin(key, '', false)).toBe('mismatch');
-  });
-
-  it('checkPin returns "mismatch" when exists flag flips (root newly appeared)', () => {
-    const key = getRootKey('/p/skills');
-    updatePin(key, '/p/skills', '', false, 0);
+    // did not exist → appeared
+    updatePin(key, '/p', '', false, 0);
     expect(checkPin(key, 'a'.repeat(64), true)).toBe('mismatch');
   });
 
-  it('removePin deletes a pin so checkPin returns "new"', () => {
-    const key = getRootKey('/p/skills');
-    updatePin(key, '/p/skills', 'a'.repeat(64), true, 1);
+  it('removePin + clearAllPins both work', () => {
+    const key = getRootKey('/p');
+    updatePin(key, '/p', 'a'.repeat(64), true, 1);
     removePin(key);
     expect(checkPin(key, 'a'.repeat(64), true)).toBe('new');
-  });
-
-  it('clearAllPins removes all pins', () => {
-    updatePin('k1'.padEnd(16, '0'), '/a', 'a'.repeat(64), true, 1);
-    updatePin('k2'.padEnd(16, '0'), '/b', 'b'.repeat(64), true, 1);
+    updatePin(key, '/p', 'a'.repeat(64), true, 1);
     clearAllPins();
     expect(readSkillPins().roots).toEqual({});
   });
 
-  it('readSkillPins returns saved data with correct fields', () => {
-    const key = getRootKey('/p/skills');
-    updatePin(key, '/p/skills', 'c'.repeat(64), true, 7);
-    const pins = readSkillPins();
-    const entry = pins.roots[key];
-    expect(entry).toBeDefined();
-    expect(entry.rootPath).toBe('/p/skills');
+  it('persists the full pin entry correctly', () => {
+    const key = getRootKey('/p');
+    updatePin(key, '/p', 'c'.repeat(64), true, 7);
+    const entry = readSkillPins().roots[key];
+    expect(entry.rootPath).toBe('/p');
     expect(entry.contentHash).toBe('c'.repeat(64));
     expect(entry.exists).toBe(true);
     expect(entry.fileCount).toBe(7);
@@ -255,180 +181,28 @@ describe('pin file operations', () => {
   });
 
   it('pin file is created with mode 0o600', { skip: process.platform === 'win32' }, () => {
-    updatePin(getRootKey('/p/skills'), '/p/skills', 'a'.repeat(64), true, 1);
-    const pinPath = path.join(tmpHome, '.node9', 'skill-pins.json');
-    const stat = fs.statSync(pinPath);
+    updatePin(getRootKey('/p'), '/p', 'a'.repeat(64), true, 1);
+    const stat = fs.statSync(path.join(tmpHome, '.node9', 'skill-pins.json'));
     expect(stat.mode & 0o777).toBe(0o600);
   });
 
-  it('readSkillPins throws on corrupted pin file (fail closed)', () => {
-    const node9Dir = path.join(tmpHome, '.node9');
-    fs.mkdirSync(node9Dir, { recursive: true });
-    fs.writeFileSync(path.join(node9Dir, 'skill-pins.json'), 'not valid json');
+  it('fails closed on corrupt pin file', () => {
+    const dir = path.join(tmpHome, '.node9');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'skill-pins.json'), 'not json');
     expect(() => readSkillPins()).toThrow(/corrupt/i);
-  });
-
-  it('readSkillPinsSafe returns corrupt for invalid JSON', () => {
-    const node9Dir = path.join(tmpHome, '.node9');
-    fs.mkdirSync(node9Dir, { recursive: true });
-    fs.writeFileSync(path.join(node9Dir, 'skill-pins.json'), 'not valid json');
+    expect(checkPin('anykey1234567890', 'h', true)).toBe('corrupt');
     const result = readSkillPinsSafe();
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe('corrupt');
   });
 
-  it('readSkillPinsSafe returns corrupt for empty file', () => {
-    const node9Dir = path.join(tmpHome, '.node9');
-    fs.mkdirSync(node9Dir, { recursive: true });
-    fs.writeFileSync(path.join(node9Dir, 'skill-pins.json'), '');
-    const result = readSkillPinsSafe();
-    expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.reason).toBe('corrupt');
-  });
-
-  it('readSkillPinsSafe returns corrupt for JSON missing roots object', () => {
-    const node9Dir = path.join(tmpHome, '.node9');
-    fs.mkdirSync(node9Dir, { recursive: true });
-    fs.writeFileSync(path.join(node9Dir, 'skill-pins.json'), '{"version": 1}');
-    const result = readSkillPinsSafe();
-    expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.reason).toBe('corrupt');
-  });
-
-  it('readSkillPinsSafe returns missing when no file exists', () => {
-    const result = readSkillPinsSafe();
-    expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.reason).toBe('missing');
-  });
-
-  it('readSkillPinsSafe returns ok with valid pins', () => {
+  it('distinguishes missing vs corrupt in readSkillPinsSafe', () => {
+    const missing = readSkillPinsSafe();
+    expect(missing.ok).toBe(false);
+    if (!missing.ok) expect(missing.reason).toBe('missing');
     updatePin(getRootKey('/p'), '/p', 'a'.repeat(64), true, 1);
-    const result = readSkillPinsSafe();
-    expect(result.ok).toBe(true);
-    if (result.ok) expect(result.pins.roots[getRootKey('/p')]).toBeDefined();
-  });
-
-  it('checkPin returns "corrupt" for corrupted pin file', () => {
-    const node9Dir = path.join(tmpHome, '.node9');
-    fs.mkdirSync(node9Dir, { recursive: true });
-    fs.writeFileSync(path.join(node9Dir, 'skill-pins.json'), 'not valid json');
-    expect(checkPin('anykey1234567890', 'anyhash', true)).toBe('corrupt');
-  });
-
-  it('checkPin returns "new" when file is missing (not corrupt)', () => {
-    expect(checkPin('anykey1234567890', 'anyhash', true)).toBe('new');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// computePinDiff — used by `node9 skill pin update` to show what changed
-// ---------------------------------------------------------------------------
-
-describe('computePinDiff', () => {
-  let tmpDir: string;
-
-  beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skill-diff-'));
-  });
-
-  afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  });
-
-  it('returns kind="unchanged" when the root has not changed', () => {
-    const root = path.join(tmpDir, 'skills');
-    fs.mkdirSync(root);
-    fs.writeFileSync(path.join(root, 'a.md'), 'a');
-    const hashed = hashSkillRoot(root);
-    const diff = computePinDiff(
-      {
-        rootPath: root,
-        exists: hashed.exists,
-        contentHash: hashed.contentHash,
-        fileCount: hashed.fileCount,
-        pinnedAt: new Date().toISOString(),
-      },
-      root
-    );
-    expect(diff.kind).toBe('unchanged');
-  });
-
-  it('returns kind="appeared" when pin recorded !exists but the root now exists', () => {
-    const root = path.join(tmpDir, 'skills');
-    fs.mkdirSync(root);
-    fs.writeFileSync(path.join(root, 'a.md'), 'a');
-    const diff = computePinDiff(
-      {
-        rootPath: root,
-        exists: false,
-        contentHash: '',
-        fileCount: 0,
-        pinnedAt: new Date().toISOString(),
-      },
-      root
-    );
-    expect(diff.kind).toBe('appeared');
-  });
-
-  it('returns kind="vanished" when pin recorded exists but the root is now missing', () => {
-    const root = path.join(tmpDir, 'skills-missing');
-    const diff = computePinDiff(
-      {
-        rootPath: root,
-        exists: true,
-        contentHash: 'a'.repeat(64),
-        fileCount: 1,
-        pinnedAt: new Date().toISOString(),
-      },
-      root
-    );
-    expect(diff.kind).toBe('vanished');
-  });
-
-  it('reports added / removed / modified files for a directory root', () => {
-    const root = path.join(tmpDir, 'skills');
-    fs.mkdirSync(root);
-    fs.writeFileSync(path.join(root, 'keep.md'), 'keep');
-    fs.writeFileSync(path.join(root, 'modify.md'), 'original');
-    fs.writeFileSync(path.join(root, 'remove.md'), 'gone-soon');
-    const before = hashSkillRoot(root);
-    const pin = {
-      rootPath: root,
-      exists: before.exists,
-      contentHash: before.contentHash,
-      fileCount: before.fileCount,
-      pinnedAt: new Date().toISOString(),
-      // Implementation detail: computePinDiff may need the per-file manifest.
-      // We stash it on the pin here so the diff helper can show per-file changes.
-      fileManifest: before.fileManifest,
-    };
-
-    // Mutate: modify one, remove one, add one
-    fs.writeFileSync(path.join(root, 'modify.md'), 'tampered');
-    fs.unlinkSync(path.join(root, 'remove.md'));
-    fs.writeFileSync(path.join(root, 'add.md'), 'new');
-
-    const diff = computePinDiff(pin, root);
-    expect(diff.kind).toBe('changed');
-    if (diff.kind !== 'changed') return;
-    expect(diff.added).toEqual(['add.md']);
-    expect(diff.removed).toEqual(['remove.md']);
-    expect(diff.modified).toEqual(['modify.md']);
-  });
-
-  it('reports kind="changed" even without a fileManifest (single-file root)', () => {
-    const file = path.join(tmpDir, 'CLAUDE.md');
-    fs.writeFileSync(file, 'original');
-    const before = hashSkillRoot(file);
-    const pin = {
-      rootPath: file,
-      exists: before.exists,
-      contentHash: before.contentHash,
-      fileCount: before.fileCount,
-      pinnedAt: new Date().toISOString(),
-    };
-    fs.writeFileSync(file, 'tampered');
-    const diff = computePinDiff(pin, file);
-    expect(diff.kind).toBe('changed');
+    const ok = readSkillPinsSafe();
+    expect(ok.ok).toBe(true);
   });
 });

--- a/src/__tests__/skill-roots-config.spec.ts
+++ b/src/__tests__/skill-roots-config.spec.ts
@@ -1,0 +1,66 @@
+// src/__tests__/skill-roots-config.spec.ts
+// Unit tests for policy.skillRoots config field — accepted, merged, deduped.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { getConfig, _resetConfigCache } from '../config';
+
+describe('policy.skillRoots config field', () => {
+  let tmpHome: string;
+  let origHome: string | undefined;
+  let origUserprofile: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-skillroots-cfg-'));
+    origHome = process.env.HOME;
+    origUserprofile = process.env.USERPROFILE;
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    fs.mkdirSync(path.join(tmpHome, '.node9'), { recursive: true });
+    _resetConfigCache();
+  });
+
+  afterEach(() => {
+    if (origHome !== undefined) process.env.HOME = origHome;
+    else delete process.env.HOME;
+    if (origUserprofile !== undefined) process.env.USERPROFILE = origUserprofile;
+    else delete process.env.USERPROFILE;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    _resetConfigCache();
+  });
+
+  it('defaults to an empty array when no config is set', () => {
+    const config = getConfig();
+    expect(config.policy.skillRoots).toEqual([]);
+  });
+
+  it('merges user-supplied skillRoots from config.json', () => {
+    fs.writeFileSync(
+      path.join(tmpHome, '.node9', 'config.json'),
+      JSON.stringify({ policy: { skillRoots: ['~/my-skills', '/abs/path/AGENTS.md'] } })
+    );
+    const config = getConfig();
+    expect(config.policy.skillRoots).toEqual(['~/my-skills', '/abs/path/AGENTS.md']);
+  });
+
+  it('de-duplicates entries', () => {
+    fs.writeFileSync(
+      path.join(tmpHome, '.node9', 'config.json'),
+      JSON.stringify({ policy: { skillRoots: ['~/a', '~/a', '~/b'] } })
+    );
+    const config = getConfig();
+    expect(config.policy.skillRoots).toEqual(['~/a', '~/b']);
+  });
+
+  it('ignores non-string entries defensively', () => {
+    // Schema rejects non-string arrays at validation time, but merge must also
+    // self-protect in case validation is ever relaxed or the schema evolves.
+    fs.writeFileSync(
+      path.join(tmpHome, '.node9', 'config.json'),
+      JSON.stringify({ policy: { skillRoots: ['~/ok'] } })
+    );
+    const config = getConfig();
+    expect(config.policy.skillRoots).toEqual(['~/ok']);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,7 @@ import { registerMcpGatewayCommand } from './cli/commands/mcp-gateway';
 import { registerMcpServerCommand } from './cli/commands/mcp-server';
 import { registerTrustCommand } from './cli/commands/trust';
 import { registerMcpPinCommand } from './cli/commands/mcp-pin';
+import { registerSkillPinCommand } from './cli/commands/skill-pin';
 
 const { version } = JSON.parse(
   fs.readFileSync(path.join(__dirname, '../package.json'), 'utf-8')
@@ -398,6 +399,7 @@ registerWatchCommand(program);
 registerMcpGatewayCommand(program);
 registerMcpServerCommand(program);
 registerMcpPinCommand(program);
+registerSkillPinCommand(program);
 
 // 7. CHECK (PreToolUse hook) + LOG (PostToolUse hook)
 registerCheckCommand(program);

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -14,6 +14,7 @@ import { shouldSnapshot } from '../../policy';
 import { buildNegotiationMessage } from '../../policy/negotiation';
 import { createShadowSnapshot } from '../../undo';
 import { autoStartDaemonAndWait } from '../daemon-starter';
+import { defaultSkillRoots, resolveUserSkillRoot, verifyAndPinRoots } from '../../skill-pin';
 
 function sanitize(value: string): string {
   // eslint-disable-next-line no-control-regex
@@ -223,6 +224,122 @@ export function registerCheckCommand(program: Command): void {
           }
 
           const meta = { agent, mcpServer };
+
+          // ── Skill pinning — supply chain & update drift defense (AST 02 + AST 07) ──
+          // First tool call of a session hashes all known skill roots and
+          // pins them. Every subsequent session re-hashes and compares; any
+          // drift quarantines the session and blocks further tool calls until
+          // a human reviews via `node9 skill pin update`.
+          //
+          // Per-session verification is memoised in ~/.node9/skill-sessions/
+          // so we only pay the hashing cost once per Claude/Gemini session id.
+          const rawSessionId = typeof payload.session_id === 'string' ? payload.session_id : '';
+          // Path-safety: filesystem name, limited charset + length, to defeat
+          // traversal via a malicious session_id.
+          const safeSessionId = /^[A-Za-z0-9_\-]{1,128}$/.test(rawSessionId) ? rawSessionId : '';
+          if (safeSessionId) {
+            try {
+              const sessionsDir = path.join(os.homedir(), '.node9', 'skill-sessions');
+              const flagPath = path.join(sessionsDir, `${safeSessionId}.json`);
+              let flag: { state?: string; detail?: string } | null = null;
+              try {
+                flag = JSON.parse(fs.readFileSync(flagPath, 'utf-8'));
+              } catch {
+                /* missing/unreadable — treat as fresh */
+              }
+
+              const writeFlag = (data: { state: string; detail?: string }) => {
+                try {
+                  fs.mkdirSync(sessionsDir, { recursive: true });
+                  fs.writeFileSync(
+                    flagPath,
+                    JSON.stringify({ ...data, timestamp: new Date().toISOString() }, null, 2),
+                    { mode: 0o600 }
+                  );
+                } catch {
+                  /* best effort — a failed flag write is not worth crashing the hook */
+                }
+              };
+
+              if (flag && flag.state === 'quarantined') {
+                sendBlock(
+                  `Node9: session quarantined due to skill drift — ${flag.detail ?? 'review required'}`,
+                  {
+                    blockedByLabel: 'Skill Pin Quarantine',
+                    recoveryCommand: 'node9 skill pin list',
+                  }
+                );
+                return;
+              }
+
+              if (!flag || flag.state !== 'verified') {
+                const absoluteCwd =
+                  typeof payload.cwd === 'string' && path.isAbsolute(payload.cwd)
+                    ? payload.cwd
+                    : undefined;
+                const extraRoots = Array.isArray(config.policy.skillRoots)
+                  ? config.policy.skillRoots
+                  : [];
+                const resolvedExtra = extraRoots
+                  .map((r) => resolveUserSkillRoot(r, absoluteCwd))
+                  .filter((r): r is string => typeof r === 'string');
+                const roots = [...defaultSkillRoots(absoluteCwd), ...resolvedExtra];
+
+                const result = verifyAndPinRoots(roots);
+                if (result.kind === 'corrupt') {
+                  writeFlag({
+                    state: 'quarantined',
+                    detail: `pin file corrupt: ${result.detail}`,
+                  });
+                  sendBlock('Node9: skill pin file is corrupt — fail-closed.', {
+                    blockedByLabel: 'Skill Pin Quarantine',
+                    recoveryCommand: 'node9 skill pin reset',
+                  });
+                  return;
+                }
+                if (result.kind === 'drift') {
+                  writeFlag({ state: 'quarantined', detail: result.summary });
+                  sendBlock(`Node9: skill drift detected — ${result.summary}`, {
+                    blockedByLabel: 'Skill Pin Quarantine',
+                    recoveryCommand: `node9 skill pin update ${result.changedRootKey}`,
+                  });
+                  return;
+                }
+                writeFlag({ state: 'verified' });
+
+                // Best-effort GC of session flags older than 7 days so the
+                // directory doesn't grow without bound across machine lifetime.
+                try {
+                  const cutoff = Date.now() - 7 * 24 * 60 * 60 * 1000;
+                  for (const name of fs.readdirSync(sessionsDir)) {
+                    const p = path.join(sessionsDir, name);
+                    try {
+                      const st = fs.statSync(p);
+                      if (st.mtimeMs < cutoff) fs.unlinkSync(p);
+                    } catch {
+                      /* ignore */
+                    }
+                  }
+                } catch {
+                  /* ignore */
+                }
+              }
+            } catch (err) {
+              // Unexpected error (not a corrupt pin file — that's handled above)
+              // → log for debugging, but fail open so a bug in the skill-pin
+              // path never bricks Claude Code. The same philosophy check.ts
+              // already follows for its top-level catch.
+              if (process.env.NODE9_DEBUG === '1') {
+                try {
+                  const dbg = path.join(os.homedir(), '.node9', 'hook-debug.log');
+                  const msg = err instanceof Error ? err.message : String(err);
+                  fs.appendFileSync(dbg, `[${new Date().toISOString()}] SKILL_PIN_ERROR: ${msg}\n`);
+                } catch {
+                  /* ignore */
+                }
+              }
+            }
+          }
 
           // Snapshot BEFORE the tool runs (PreToolUse) so undo can restore to
           // the state prior to this change. Snapshotting after (PostToolUse)

--- a/src/cli/commands/skill-pin.ts
+++ b/src/cli/commands/skill-pin.ts
@@ -1,33 +1,24 @@
 // src/cli/commands/skill-pin.ts
-// CLI commands for managing skill pin state (supply chain & update drift defense).
-// Registered under `node9 skill pin` by cli.ts.
+// CLI for managing skill pins (supply chain & update drift defense).
+// Registered under `node9 skill pin` by cli.ts. Mirrors src/cli/commands/mcp-pin.ts.
 //
-// Mirrors src/cli/commands/mcp-pin.ts with two additions:
-//   - `update` shows a per-file diff before re-pinning (accepts --yes for scripts)
-//   - `reset` wipes ~/.node9/skill-sessions/ so quarantined sessions don't persist
+// Subcommands:
+//   list                   — show pinned roots, hashes, file counts
+//   update <rootKey>       — remove a pin so next session re-pins with current state
+//   reset                  — clear all pins AND wipe quarantined session flags
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { confirm } from '@inquirer/prompts';
-import {
-  readSkillPins,
-  readSkillPinsSafe,
-  clearAllPins,
-  updatePin,
-  hashSkillRoot,
-  computePinDiff,
-} from '../../skill-pin';
-
-function skillSessionsDir(): string {
-  return path.join(os.homedir(), '.node9', 'skill-sessions');
-}
+import { readSkillPins, readSkillPinsSafe, removePin, clearAllPins } from '../../skill-pin';
 
 function wipeSkillSessions(): void {
-  const dir = skillSessionsDir();
   try {
-    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(path.join(os.homedir(), '.node9', 'skill-sessions'), {
+      recursive: true,
+      force: true,
+    });
   } catch {
     /* best effort */
   }
@@ -37,7 +28,6 @@ export function registerSkillPinCommand(program: Command): void {
   const skillCmd = program
     .command('skill')
     .description('Manage skill pinning (supply chain & update drift defense, AST 02 + AST 07)');
-
   const pinSubCmd = skillCmd.command('pin').description('Manage pinned skill roots');
 
   pinSubCmd
@@ -57,32 +47,25 @@ export function registerSkillPinCommand(program: Command): void {
         console.error(chalk.yellow('   Run: node9 skill pin reset\n'));
         process.exit(1);
       }
-
       const entries = Object.entries(result.pins.roots);
       if (entries.length === 0) {
-        console.log(chalk.gray('\nNo skill roots are pinned yet.'));
-        console.log(
-          chalk.gray('Pins are created automatically on the first tool call of each session.\n')
-        );
+        console.log(chalk.gray('\nNo skill roots are pinned yet.\n'));
         return;
       }
-
       console.log(chalk.bold('\n🔒 Pinned Skill Roots\n'));
       for (const [key, entry] of entries) {
-        const existsMarker = entry.exists ? '' : chalk.yellow(' (not present at pin time)');
-        console.log(`  ${chalk.cyan(key)}  ${chalk.gray(entry.rootPath)}${existsMarker}`);
+        const missing = entry.exists ? '' : chalk.yellow(' (not present at pin time)');
+        console.log(`  ${chalk.cyan(key)}  ${chalk.gray(entry.rootPath)}${missing}`);
         console.log(`    Files (${entry.fileCount})`);
         console.log(`    Hash:  ${chalk.gray(entry.contentHash.slice(0, 16))}...`);
-        console.log(`    Pinned: ${chalk.gray(entry.pinnedAt)}`);
-        console.log('');
+        console.log(`    Pinned: ${chalk.gray(entry.pinnedAt)}\n`);
       }
     });
 
   pinSubCmd
     .command('update <rootKey>')
-    .description('Review the diff for a pinned root and re-pin to the current state')
-    .option('-y, --yes', 'Skip confirmation (non-interactive)', false)
-    .action(async (rootKey: string, opts: { yes?: boolean }) => {
+    .description('Remove a pin so the next session re-pins with current state')
+    .action((rootKey: string) => {
       let pins;
       try {
         pins = readSkillPins();
@@ -91,68 +74,17 @@ export function registerSkillPinCommand(program: Command): void {
         console.error(chalk.yellow('   Run: node9 skill pin reset\n'));
         process.exit(1);
       }
-      const entry = pins.roots[rootKey];
-      if (!entry) {
+      if (!pins.roots[rootKey]) {
         console.error(chalk.red(`\n❌ No pin found for root key "${rootKey}"\n`));
         console.error(`Run ${chalk.cyan('node9 skill pin list')} to see pinned roots.\n`);
         process.exit(1);
       }
-
-      const diff = computePinDiff(entry, entry.rootPath);
-      console.log(chalk.bold(`\n🔍 Pin review for ${chalk.cyan(rootKey)}`));
-      console.log(chalk.gray(`   ${entry.rootPath}\n`));
-
-      if (diff.kind === 'unchanged') {
-        console.log(chalk.green('Root is unchanged — no diff to review.'));
-        console.log(chalk.gray('Re-pinning anyway will simply refresh the pinnedAt timestamp.\n'));
-      } else if (diff.kind === 'appeared') {
-        console.log(chalk.yellow('Root is NEW (did not exist at pin time; now present).\n'));
-      } else if (diff.kind === 'vanished') {
-        console.log(chalk.yellow('Root has VANISHED (present at pin time; now missing).\n'));
-      } else {
-        console.log(chalk.yellow('Content changed:\n'));
-        if (diff.added.length)
-          console.log(chalk.green(`  + added (${diff.added.length}):    ${diff.added.join(', ')}`));
-        if (diff.removed.length)
-          console.log(
-            chalk.red(`  - removed (${diff.removed.length}):  ${diff.removed.join(', ')}`)
-          );
-        if (diff.modified.length)
-          console.log(
-            chalk.cyan(`  ~ modified (${diff.modified.length}): ${diff.modified.join(', ')}`)
-          );
-        console.log('');
-      }
-
-      let approved = Boolean(opts.yes);
-      if (!approved) {
-        try {
-          approved = await confirm({
-            message: 'Approve and re-pin?',
-            default: false,
-          });
-        } catch {
-          // Inquirer throws on EOF / Ctrl+C — treat as abort.
-          approved = false;
-        }
-      }
-
-      if (!approved) {
-        console.log(chalk.gray('\nAborted — pin unchanged.\n'));
-        return;
-      }
-
-      const current = hashSkillRoot(entry.rootPath);
-      updatePin(
-        rootKey,
-        entry.rootPath,
-        current.contentHash,
-        current.exists,
-        current.fileCount,
-        current.fileManifest
-      );
-      console.log(chalk.green(`\n🔒 Re-pinned ${chalk.cyan(rootKey)}`));
-      console.log(chalk.gray(`   ${entry.rootPath}\n`));
+      const rootPath = pins.roots[rootKey].rootPath;
+      removePin(rootKey);
+      wipeSkillSessions();
+      console.log(chalk.green(`\n🔓 Pin removed for ${chalk.cyan(rootKey)}`));
+      console.log(chalk.gray(`   ${rootPath}`));
+      console.log(chalk.gray('   Next session will re-pin with current state.\n'));
     });
 
   pinSubCmd
@@ -169,6 +101,6 @@ export function registerSkillPinCommand(program: Command): void {
       clearAllPins();
       wipeSkillSessions();
       console.log(chalk.green(`\n🔓 Cleared ${count} skill pin(s).`));
-      console.log(chalk.gray('   Next session will re-pin with current skill state.\n'));
+      console.log(chalk.gray('   Next session will re-pin with current state.\n'));
     });
 }

--- a/src/cli/commands/skill-pin.ts
+++ b/src/cli/commands/skill-pin.ts
@@ -1,0 +1,174 @@
+// src/cli/commands/skill-pin.ts
+// CLI commands for managing skill pin state (supply chain & update drift defense).
+// Registered under `node9 skill pin` by cli.ts.
+//
+// Mirrors src/cli/commands/mcp-pin.ts with two additions:
+//   - `update` shows a per-file diff before re-pinning (accepts --yes for scripts)
+//   - `reset` wipes ~/.node9/skill-sessions/ so quarantined sessions don't persist
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { confirm } from '@inquirer/prompts';
+import {
+  readSkillPins,
+  readSkillPinsSafe,
+  clearAllPins,
+  updatePin,
+  hashSkillRoot,
+  computePinDiff,
+} from '../../skill-pin';
+
+function skillSessionsDir(): string {
+  return path.join(os.homedir(), '.node9', 'skill-sessions');
+}
+
+function wipeSkillSessions(): void {
+  const dir = skillSessionsDir();
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+}
+
+export function registerSkillPinCommand(program: Command): void {
+  const skillCmd = program
+    .command('skill')
+    .description('Manage skill pinning (supply chain & update drift defense, AST 02 + AST 07)');
+
+  const pinSubCmd = skillCmd.command('pin').description('Manage pinned skill roots');
+
+  pinSubCmd
+    .command('list')
+    .description('Show all pinned skill roots and their content hashes')
+    .action(() => {
+      const result = readSkillPinsSafe();
+      if (!result.ok) {
+        if (result.reason === 'missing') {
+          console.log(chalk.gray('\nNo skill roots are pinned yet.'));
+          console.log(
+            chalk.gray('Pins are created automatically on the first tool call of each session.\n')
+          );
+          return;
+        }
+        console.error(chalk.red(`\n❌ Pin file is corrupt: ${result.detail}`));
+        console.error(chalk.yellow('   Run: node9 skill pin reset\n'));
+        process.exit(1);
+      }
+
+      const entries = Object.entries(result.pins.roots);
+      if (entries.length === 0) {
+        console.log(chalk.gray('\nNo skill roots are pinned yet.'));
+        console.log(
+          chalk.gray('Pins are created automatically on the first tool call of each session.\n')
+        );
+        return;
+      }
+
+      console.log(chalk.bold('\n🔒 Pinned Skill Roots\n'));
+      for (const [key, entry] of entries) {
+        const existsMarker = entry.exists ? '' : chalk.yellow(' (not present at pin time)');
+        console.log(`  ${chalk.cyan(key)}  ${chalk.gray(entry.rootPath)}${existsMarker}`);
+        console.log(`    Files (${entry.fileCount})`);
+        console.log(`    Hash:  ${chalk.gray(entry.contentHash.slice(0, 16))}...`);
+        console.log(`    Pinned: ${chalk.gray(entry.pinnedAt)}`);
+        console.log('');
+      }
+    });
+
+  pinSubCmd
+    .command('update <rootKey>')
+    .description('Review the diff for a pinned root and re-pin to the current state')
+    .option('-y, --yes', 'Skip confirmation (non-interactive)', false)
+    .action(async (rootKey: string, opts: { yes?: boolean }) => {
+      let pins;
+      try {
+        pins = readSkillPins();
+      } catch {
+        console.error(chalk.red('\n❌ Pin file is corrupt.'));
+        console.error(chalk.yellow('   Run: node9 skill pin reset\n'));
+        process.exit(1);
+      }
+      const entry = pins.roots[rootKey];
+      if (!entry) {
+        console.error(chalk.red(`\n❌ No pin found for root key "${rootKey}"\n`));
+        console.error(`Run ${chalk.cyan('node9 skill pin list')} to see pinned roots.\n`);
+        process.exit(1);
+      }
+
+      const diff = computePinDiff(entry, entry.rootPath);
+      console.log(chalk.bold(`\n🔍 Pin review for ${chalk.cyan(rootKey)}`));
+      console.log(chalk.gray(`   ${entry.rootPath}\n`));
+
+      if (diff.kind === 'unchanged') {
+        console.log(chalk.green('Root is unchanged — no diff to review.'));
+        console.log(chalk.gray('Re-pinning anyway will simply refresh the pinnedAt timestamp.\n'));
+      } else if (diff.kind === 'appeared') {
+        console.log(chalk.yellow('Root is NEW (did not exist at pin time; now present).\n'));
+      } else if (diff.kind === 'vanished') {
+        console.log(chalk.yellow('Root has VANISHED (present at pin time; now missing).\n'));
+      } else {
+        console.log(chalk.yellow('Content changed:\n'));
+        if (diff.added.length)
+          console.log(chalk.green(`  + added (${diff.added.length}):    ${diff.added.join(', ')}`));
+        if (diff.removed.length)
+          console.log(
+            chalk.red(`  - removed (${diff.removed.length}):  ${diff.removed.join(', ')}`)
+          );
+        if (diff.modified.length)
+          console.log(
+            chalk.cyan(`  ~ modified (${diff.modified.length}): ${diff.modified.join(', ')}`)
+          );
+        console.log('');
+      }
+
+      let approved = Boolean(opts.yes);
+      if (!approved) {
+        try {
+          approved = await confirm({
+            message: 'Approve and re-pin?',
+            default: false,
+          });
+        } catch {
+          // Inquirer throws on EOF / Ctrl+C — treat as abort.
+          approved = false;
+        }
+      }
+
+      if (!approved) {
+        console.log(chalk.gray('\nAborted — pin unchanged.\n'));
+        return;
+      }
+
+      const current = hashSkillRoot(entry.rootPath);
+      updatePin(
+        rootKey,
+        entry.rootPath,
+        current.contentHash,
+        current.exists,
+        current.fileCount,
+        current.fileManifest
+      );
+      console.log(chalk.green(`\n🔒 Re-pinned ${chalk.cyan(rootKey)}`));
+      console.log(chalk.gray(`   ${entry.rootPath}\n`));
+    });
+
+  pinSubCmd
+    .command('reset')
+    .description('Clear all skill pins and wipe session verification flags')
+    .action(() => {
+      const result = readSkillPinsSafe();
+      if (!result.ok && result.reason === 'missing') {
+        wipeSkillSessions();
+        console.log(chalk.gray('\nNo pins to clear.\n'));
+        return;
+      }
+      const count = result.ok ? Object.keys(result.pins.roots).length : '?';
+      clearAllPins();
+      wipeSkillSessions();
+      console.log(chalk.green(`\n🔓 Cleared ${count} skill pin(s).`));
+      console.log(chalk.gray('   Next session will re-pin with current skill state.\n'));
+    });
+}

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -119,6 +119,10 @@ export const ConfigFileSchema = z
             scanIgnoredTools: z.boolean().optional(),
           })
           .optional(),
+        // Additional skill roots to pin beyond the defaults. Absolute paths,
+        // `~/`-prefixed paths, or paths relative to the hook payload's cwd.
+        // See src/skill-pin.ts for semantics (AST 02 + AST 07 defense).
+        skillRoots: z.array(z.string()).optional(),
       })
       .optional(),
     environments: z.record(z.object({ requireApproval: z.boolean().optional() })).optional(),

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -80,6 +80,8 @@ export interface Config {
       enabled: boolean;
       scanIgnoredTools: boolean;
     };
+    /** Additional skill roots to pin beyond the built-in defaults. */
+    skillRoots: string[];
   };
   environments: Record<string, EnvironmentConfig>;
 }
@@ -304,6 +306,7 @@ export const DEFAULT_CONFIG: Config = {
       },
     ],
     dlp: { enabled: true, scanIgnoredTools: true },
+    skillRoots: [],
   },
   environments: {},
 };
@@ -517,6 +520,7 @@ export function getConfig(cwd?: string): Config {
       ignorePaths: [...DEFAULT_CONFIG.policy.snapshot.ignorePaths],
     },
     dlp: { ...DEFAULT_CONFIG.policy.dlp },
+    skillRoots: [...DEFAULT_CONFIG.policy.skillRoots],
   };
   const mergedEnvironments: Record<string, EnvironmentConfig> = { ...DEFAULT_CONFIG.environments };
 
@@ -566,6 +570,11 @@ export function getConfig(cwd?: string): Config {
       const d = p.dlp as Partial<Config['policy']['dlp']>;
       if (d.enabled !== undefined) mergedPolicy.dlp.enabled = d.enabled;
       if (d.scanIgnoredTools !== undefined) mergedPolicy.dlp.scanIgnoredTools = d.scanIgnoredTools;
+    }
+    if (Array.isArray(p.skillRoots)) {
+      for (const r of p.skillRoots) {
+        if (typeof r === 'string' && r.length > 0) mergedPolicy.skillRoots.push(r);
+      }
     }
 
     const envs = (source.environments || {}) as Record<string, unknown>;
@@ -625,6 +634,7 @@ export function getConfig(cwd?: string): Config {
   mergedPolicy.sandboxPaths = [...new Set(mergedPolicy.sandboxPaths)];
   mergedPolicy.dangerousWords = [...new Set(mergedPolicy.dangerousWords)];
   mergedPolicy.ignoredTools = [...new Set(mergedPolicy.ignoredTools)];
+  mergedPolicy.skillRoots = [...new Set(mergedPolicy.skillRoots)];
   mergedPolicy.snapshot.tools = [...new Set(mergedPolicy.snapshot.tools)];
   mergedPolicy.snapshot.onlyPaths = [...new Set(mergedPolicy.snapshot.onlyPaths)];
   mergedPolicy.snapshot.ignorePaths = [...new Set(mergedPolicy.snapshot.ignorePaths)];

--- a/src/skill-pin.ts
+++ b/src/skill-pin.ts
@@ -6,8 +6,7 @@
 // the change via `node9 skill pin update <rootKey>`.
 //
 // Storage: ~/.node9/skill-pins.json (atomic writes, mode 0o600).
-// Pattern: mirrors src/mcp-pin.ts one-for-one; file-tree hashing below adds
-// the one piece the MCP variant didn't need.
+// Pattern: mirrors src/mcp-pin.ts; adds file-tree hashing for directory roots.
 
 import fs from 'fs';
 import path from 'path';
@@ -18,13 +17,6 @@ import crypto from 'crypto';
 // Types
 // ---------------------------------------------------------------------------
 
-export interface FileManifestEntry {
-  /** Relative path from the root (for single-file roots, this is the basename) */
-  relPath: string;
-  /** SHA-256 of the file's bytes */
-  fileHash: string;
-}
-
 export interface HashResult {
   /** Whether the root path existed at hash time */
   exists: boolean;
@@ -32,23 +24,14 @@ export interface HashResult {
   contentHash: string;
   /** 1 for single-file roots, N for directory roots, 0 when !exists */
   fileCount: number;
-  /** Per-file manifest (only for directory roots, used by the diff helper) */
-  fileManifest?: FileManifestEntry[];
 }
 
 export interface SkillPinEntry {
-  /** Absolute path that was pinned (for display) */
   rootPath: string;
-  /** Whether the root existed at pin time */
   exists: boolean;
-  /** SHA-256 of canonicalized tree (empty when !exists) */
   contentHash: string;
-  /** 1 for single-file roots, N for directory roots, 0 when !exists */
   fileCount: number;
-  /** ISO 8601 timestamp */
   pinnedAt: string;
-  /** Optional per-file manifest (written for directory roots to enable diffs) */
-  fileManifest?: FileManifestEntry[];
 }
 
 export interface SkillPinsFile {
@@ -67,22 +50,16 @@ function getPinsFilePath(): string {
 // Hashing
 // ---------------------------------------------------------------------------
 
-/** Safety caps so a pathological root can't hang the hook. */
 const MAX_FILES = 5000;
-const MAX_TOTAL_BYTES = 50 * 1024 * 1024; // 50 MB
+const MAX_TOTAL_BYTES = 50 * 1024 * 1024; // 50 MB safety cap
 
 function sha256Bytes(buf: Buffer): string {
   return crypto.createHash('sha256').update(buf).digest('hex');
 }
 
-/**
- * Walk a directory and return a sorted array of {relPath, fileHash} entries.
- * - Skips symlinks (never follows them into arbitrary filesystem locations).
- * - Skips any entries whose combined size would exceed MAX_TOTAL_BYTES.
- * - Caps the number of files at MAX_FILES.
- */
-function walkDir(root: string): FileManifestEntry[] {
-  const out: FileManifestEntry[] = [];
+/** Walk a directory and return sorted `relpath\0hash` tuples (symlink-safe, capped). */
+function walkDir(root: string): string[] {
+  const out: Array<{ rel: string; hash: string }> = [];
   let totalBytes = 0;
 
   const visit = (dir: string, relDir: string): void => {
@@ -93,14 +70,11 @@ function walkDir(root: string): FileManifestEntry[] {
     } catch {
       return;
     }
-    // Sort entries deterministically for stable traversal (also helps
-    // guarantee order-invariance even though we re-sort the final manifest).
     entries.sort((a, b) => a.name.localeCompare(b.name));
     for (const entry of entries) {
       if (out.length >= MAX_FILES) return;
       const full = path.join(dir, entry.name);
       const rel = relDir ? path.posix.join(relDir, entry.name) : entry.name;
-      // Guard against symlinks — lstat is authoritative for link-ness.
       let lst: fs.Stats;
       try {
         lst = fs.lstatSync(full);
@@ -117,22 +91,19 @@ function walkDir(root: string): FileManifestEntry[] {
       try {
         const buf = fs.readFileSync(full);
         totalBytes += buf.length;
-        out.push({ relPath: rel, fileHash: sha256Bytes(buf) });
+        out.push({ rel, hash: sha256Bytes(buf) });
       } catch {
-        // Permission / race — skip this entry rather than failing the whole hash.
+        /* permission/race — skip */
       }
     }
   };
 
   visit(root, '');
-  out.sort((a, b) => a.relPath.localeCompare(b.relPath));
-  return out;
+  out.sort((a, b) => a.rel.localeCompare(b.rel));
+  return out.map((e) => `${e.rel}\0${e.hash}`);
 }
 
-/**
- * Hash a skill root (file or directory). Missing paths return a well-defined
- * `!exists` result; the caller's `checkPin` treats exists-flip as drift.
- */
+/** Hash a skill root (file or directory). Missing paths return `!exists`. */
 export function hashSkillRoot(absPath: string): HashResult {
   let lst: fs.Stats;
   try {
@@ -140,39 +111,23 @@ export function hashSkillRoot(absPath: string): HashResult {
   } catch {
     return { exists: false, contentHash: '', fileCount: 0 };
   }
-  // Never follow a symlinked root — treat as missing to avoid escapes.
-  if (lst.isSymbolicLink()) {
-    return { exists: false, contentHash: '', fileCount: 0 };
-  }
+  if (lst.isSymbolicLink()) return { exists: false, contentHash: '', fileCount: 0 };
   if (lst.isFile()) {
     try {
-      const buf = fs.readFileSync(absPath);
-      const fileHash = sha256Bytes(buf);
-      return {
-        exists: true,
-        contentHash: fileHash,
-        fileCount: 1,
-      };
+      return { exists: true, contentHash: sha256Bytes(fs.readFileSync(absPath)), fileCount: 1 };
     } catch {
       return { exists: false, contentHash: '', fileCount: 0 };
     }
   }
   if (lst.isDirectory()) {
-    const manifest = walkDir(absPath);
-    const canonical = JSON.stringify(manifest);
-    const contentHash = crypto.createHash('sha256').update(canonical).digest('hex');
-    return {
-      exists: true,
-      contentHash,
-      fileCount: manifest.length,
-      fileManifest: manifest,
-    };
+    const entries = walkDir(absPath);
+    const contentHash = crypto.createHash('sha256').update(entries.join('\n')).digest('hex');
+    return { exists: true, contentHash, fileCount: entries.length };
   }
-  // Special file (socket, block device, etc.) — treat as missing.
   return { exists: false, contentHash: '', fileCount: 0 };
 }
 
-/** Derive a short root key from the absolute path. First 16 hex chars of sha256. */
+/** First 16 hex chars of sha256(absolutePath) — stable short identifier. */
 export function getRootKey(absPath: string): string {
   return crypto.createHash('sha256').update(absPath).digest('hex').slice(0, 16);
 }
@@ -186,33 +141,22 @@ export type SkillPinsReadResult =
   | { ok: false; reason: 'missing' }
   | { ok: false; reason: 'corrupt'; detail: string };
 
-/**
- * Read the pin registry from disk with explicit error reporting.
- * - File missing (ENOENT): `{ ok: false, reason: 'missing' }`
- * - File corrupt / unreadable: `{ ok: false, reason: 'corrupt' }`
- * - File valid: `{ ok: true, pins }`
- */
 export function readSkillPinsSafe(): SkillPinsReadResult {
   const filePath = getPinsFilePath();
   try {
     const raw = fs.readFileSync(filePath, 'utf-8');
-    if (!raw.trim()) {
-      return { ok: false, reason: 'corrupt', detail: 'empty file' };
-    }
+    if (!raw.trim()) return { ok: false, reason: 'corrupt', detail: 'empty file' };
     const parsed = JSON.parse(raw) as Partial<SkillPinsFile>;
     if (!parsed.roots || typeof parsed.roots !== 'object' || Array.isArray(parsed.roots)) {
       return { ok: false, reason: 'corrupt', detail: 'invalid structure: missing roots object' };
     }
     return { ok: true, pins: { roots: parsed.roots } };
   } catch (err: unknown) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-      return { ok: false, reason: 'missing' };
-    }
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { ok: false, reason: 'missing' };
     return { ok: false, reason: 'corrupt', detail: String(err) };
   }
 }
 
-/** Read the pin registry; returns empty roots on missing; throws on corrupt. */
 export function readSkillPins(): SkillPinsFile {
   const result = readSkillPinsSafe();
   if (result.ok) return result.pins;
@@ -220,8 +164,7 @@ export function readSkillPins(): SkillPinsFile {
   throw new Error(`[node9] skill pin file is corrupt: ${result.detail}`);
 }
 
-/** Atomic write of the pin registry to disk. Exported for batched updates. */
-export function writeSkillPins(data: SkillPinsFile): void {
+function writeSkillPins(data: SkillPinsFile): void {
   const filePath = getPinsFilePath();
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   const tmp = `${filePath}.${crypto.randomBytes(6).toString('hex')}.tmp`;
@@ -233,38 +176,25 @@ export function writeSkillPins(data: SkillPinsFile): void {
 // Pin operations
 // ---------------------------------------------------------------------------
 
-/**
- * Check whether a skill root's current state matches the pinned state.
- * Returns:
- *   'new'      — no pin exists for this root
- *   'match'    — content hash AND exists flag both match
- *   'mismatch' — hash differs OR exists flipped (possible drift)
- *   'corrupt'  — pin file exists but is unreadable/malformed (fail closed)
- */
 export function checkPin(
   rootKey: string,
   currentHash: string,
   currentExists: boolean
 ): 'match' | 'mismatch' | 'new' | 'corrupt' {
   const result = readSkillPinsSafe();
-  if (!result.ok) {
-    if (result.reason === 'missing') return 'new';
-    return 'corrupt';
-  }
+  if (!result.ok) return result.reason === 'missing' ? 'new' : 'corrupt';
   const entry = result.pins.roots[rootKey];
   if (!entry) return 'new';
   if (entry.exists !== currentExists) return 'mismatch';
   return entry.contentHash === currentHash ? 'match' : 'mismatch';
 }
 
-/** Save or overwrite a pin for a skill root. */
 export function updatePin(
   rootKey: string,
   rootPath: string,
   contentHash: string,
   exists: boolean,
-  fileCount: number,
-  fileManifest?: FileManifestEntry[]
+  fileCount: number
 ): void {
   const pins = readSkillPins();
   pins.roots[rootKey] = {
@@ -273,88 +203,74 @@ export function updatePin(
     contentHash,
     fileCount,
     pinnedAt: new Date().toISOString(),
-    ...(fileManifest ? { fileManifest } : {}),
   };
   writeSkillPins(pins);
 }
 
-/** Remove a single root's pin. */
 export function removePin(rootKey: string): void {
   const pins = readSkillPins();
   delete pins.roots[rootKey];
   writeSkillPins(pins);
 }
 
-/** Clear all pins (fresh start). */
 export function clearAllPins(): void {
   writeSkillPins({ roots: {} });
 }
 
 // ---------------------------------------------------------------------------
-// Diff (used by `node9 skill pin update` to explain what changed)
+// Batched verification (used by the check hook)
 // ---------------------------------------------------------------------------
 
-export type PinDiff =
-  | { kind: 'unchanged' }
-  | { kind: 'appeared'; rootPath: string }
-  | { kind: 'vanished'; rootPath: string }
-  | {
-      kind: 'changed';
-      rootPath: string;
-      added: string[];
-      removed: string[];
-      modified: string[];
-    };
+export type VerifyResult =
+  | { kind: 'verified' }
+  | { kind: 'corrupt'; detail: string }
+  | { kind: 'drift'; changedRootKey: string; changedRootPath: string; summary: string };
 
 /**
- * Compute a human-readable diff between a pin entry and the current state of
- * the root path. Used by the CLI `pin update` flow.
+ * Verify a set of skill roots against the pin registry in one pass.
+ * First drift short-circuits and returns `drift`. New roots are pinned in a
+ * single batched write.
  */
-export function computePinDiff(pin: SkillPinEntry, currentPath: string): PinDiff {
-  const current = hashSkillRoot(currentPath);
-  if (pin.exists && !current.exists) {
-    return { kind: 'vanished', rootPath: pin.rootPath };
+export function verifyAndPinRoots(roots: string[]): VerifyResult {
+  const pinsRead = readSkillPinsSafe();
+  if (!pinsRead.ok && pinsRead.reason === 'corrupt') {
+    return { kind: 'corrupt', detail: pinsRead.detail };
   }
-  if (!pin.exists && current.exists) {
-    return { kind: 'appeared', rootPath: pin.rootPath };
+  const pins: SkillPinsFile = pinsRead.ok ? pinsRead.pins : { roots: {} };
+  let mutated = false;
+
+  for (const rootPath of new Set(roots)) {
+    const rootKey = getRootKey(rootPath);
+    const current = hashSkillRoot(rootPath);
+    const existing = pins.roots[rootKey];
+    if (!existing) {
+      pins.roots[rootKey] = {
+        rootPath,
+        exists: current.exists,
+        contentHash: current.contentHash,
+        fileCount: current.fileCount,
+        pinnedAt: new Date().toISOString(),
+      };
+      mutated = true;
+      continue;
+    }
+    if (existing.exists !== current.exists || existing.contentHash !== current.contentHash) {
+      let summary: string;
+      if (existing.exists && !current.exists) summary = `vanished: ${rootPath}`;
+      else if (!existing.exists && current.exists) summary = `appeared: ${rootPath}`;
+      else summary = `changed: ${rootPath}`;
+      return { kind: 'drift', changedRootKey: rootKey, changedRootPath: rootPath, summary };
+    }
   }
-  if (!pin.exists && !current.exists) {
-    return { kind: 'unchanged' };
-  }
-  if (pin.contentHash === current.contentHash) {
-    return { kind: 'unchanged' };
-  }
-  // Both exist, hashes differ — build per-file diff if we have a manifest.
-  const oldManifest = pin.fileManifest ?? [];
-  const newManifest = current.fileManifest ?? [];
-  const oldMap = new Map(oldManifest.map((e) => [e.relPath, e.fileHash]));
-  const newMap = new Map(newManifest.map((e) => [e.relPath, e.fileHash]));
-  const added: string[] = [];
-  const removed: string[] = [];
-  const modified: string[] = [];
-  for (const [rel, hash] of newMap) {
-    const prev = oldMap.get(rel);
-    if (prev === undefined) added.push(rel);
-    else if (prev !== hash) modified.push(rel);
-  }
-  for (const rel of oldMap.keys()) {
-    if (!newMap.has(rel)) removed.push(rel);
-  }
-  added.sort();
-  removed.sort();
-  modified.sort();
-  return { kind: 'changed', rootPath: pin.rootPath, added, removed, modified };
+  if (mutated) writeSkillPins(pins);
+  return { kind: 'verified' };
 }
 
 // ---------------------------------------------------------------------------
-// Default skill roots (used by the check hook)
+// Root resolution (used by the check hook)
 // ---------------------------------------------------------------------------
 
-/**
- * Resolve the default set of skill roots Node9 protects. Global roots are
- * absolute paths; project roots are only returned when `cwd` is an absolute
- * path (per CLAUDE.md: validate external path inputs before filesystem use).
- */
+/** Built-in skill roots. Project-scoped roots are only included when cwd is absolute. */
 export function defaultSkillRoots(cwd: string | undefined): string[] {
   const home = os.homedir();
   const global = [
@@ -374,75 +290,10 @@ export function defaultSkillRoots(cwd: string | undefined): string[] {
   ];
 }
 
-/**
- * Verify a set of skill roots against the pin registry in one pass.
- * - First root that drifts returns `drift` (session should be quarantined).
- * - Corrupt pin file returns `corrupt` (session should be quarantined).
- * - Roots with no prior pin are pinned in a single batched write; result is `verified`.
- * - Roots whose content/existence matches the pin pass silently; result is `verified`.
- *
- * De-duplicates roots by path. Callers typically pass
- * `[...defaultSkillRoots(cwd), ...userProvided]`.
- */
-export type VerifyResult =
-  | { kind: 'verified' }
-  | { kind: 'corrupt'; detail: string }
-  | { kind: 'drift'; changedRootKey: string; changedRootPath: string; summary: string };
-
-export function verifyAndPinRoots(roots: string[]): VerifyResult {
-  const pinsRead = readSkillPinsSafe();
-  if (!pinsRead.ok && pinsRead.reason === 'corrupt') {
-    return { kind: 'corrupt', detail: pinsRead.detail };
-  }
-  const pins: SkillPinsFile = pinsRead.ok ? pinsRead.pins : { roots: {} };
-
-  // De-dup (different callers can construct the same path twice).
-  const unique = Array.from(new Set(roots));
-  let mutated = false;
-
-  for (const rootPath of unique) {
-    const rootKey = getRootKey(rootPath);
-    const current = hashSkillRoot(rootPath);
-    const existing = pins.roots[rootKey];
-    if (!existing) {
-      // First pin for this root — record it.
-      pins.roots[rootKey] = {
-        rootPath,
-        exists: current.exists,
-        contentHash: current.contentHash,
-        fileCount: current.fileCount,
-        pinnedAt: new Date().toISOString(),
-        ...(current.fileManifest ? { fileManifest: current.fileManifest } : {}),
-      };
-      mutated = true;
-      continue;
-    }
-    if (existing.exists !== current.exists || existing.contentHash !== current.contentHash) {
-      let summary: string;
-      if (existing.exists && !current.exists) summary = `vanished: ${rootPath}`;
-      else if (!existing.exists && current.exists) summary = `appeared: ${rootPath}`;
-      else summary = `changed: ${rootPath}`;
-      return { kind: 'drift', changedRootKey: rootKey, changedRootPath: rootPath, summary };
-    }
-    // Matches — no action.
-  }
-
-  if (mutated) {
-    writeSkillPins(pins);
-  }
-  return { kind: 'verified' };
-}
-
-/**
- * Resolve a user-supplied skill root. Absolute paths pass through; paths
- * starting with `~/` are expanded against the home directory; relative paths
- * are joined onto `cwd` if it is absolute, otherwise ignored (returns null).
- */
+/** Resolve a user-supplied entry: absolute, `~/`-prefixed, or cwd-relative. */
 export function resolveUserSkillRoot(entry: string, cwd: string | undefined): string | null {
   if (!entry) return null;
-  if (entry.startsWith('~/') || entry === '~') {
-    return path.join(os.homedir(), entry.slice(1));
-  }
+  if (entry.startsWith('~/') || entry === '~') return path.join(os.homedir(), entry.slice(1));
   if (path.isAbsolute(entry)) return entry;
   if (!cwd || !path.isAbsolute(cwd)) return null;
   return path.join(cwd, entry);

--- a/src/skill-pin.ts
+++ b/src/skill-pin.ts
@@ -1,0 +1,449 @@
+// src/skill-pin.ts
+// Skill pinning — supply chain & update drift defense (AST 02 + AST 07).
+// Records SHA-256 hashes of agent skill files/directories on first session use.
+// On subsequent sessions, compares hashes; if any skill root changed, the
+// session is quarantined and all tool calls are blocked until a human reviews
+// the change via `node9 skill pin update <rootKey>`.
+//
+// Storage: ~/.node9/skill-pins.json (atomic writes, mode 0o600).
+// Pattern: mirrors src/mcp-pin.ts one-for-one; file-tree hashing below adds
+// the one piece the MCP variant didn't need.
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import crypto from 'crypto';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FileManifestEntry {
+  /** Relative path from the root (for single-file roots, this is the basename) */
+  relPath: string;
+  /** SHA-256 of the file's bytes */
+  fileHash: string;
+}
+
+export interface HashResult {
+  /** Whether the root path existed at hash time */
+  exists: boolean;
+  /** SHA-256 hex of canonicalized tree (empty string when !exists) */
+  contentHash: string;
+  /** 1 for single-file roots, N for directory roots, 0 when !exists */
+  fileCount: number;
+  /** Per-file manifest (only for directory roots, used by the diff helper) */
+  fileManifest?: FileManifestEntry[];
+}
+
+export interface SkillPinEntry {
+  /** Absolute path that was pinned (for display) */
+  rootPath: string;
+  /** Whether the root existed at pin time */
+  exists: boolean;
+  /** SHA-256 of canonicalized tree (empty when !exists) */
+  contentHash: string;
+  /** 1 for single-file roots, N for directory roots, 0 when !exists */
+  fileCount: number;
+  /** ISO 8601 timestamp */
+  pinnedAt: string;
+  /** Optional per-file manifest (written for directory roots to enable diffs) */
+  fileManifest?: FileManifestEntry[];
+}
+
+export interface SkillPinsFile {
+  roots: Record<string, SkillPinEntry>;
+}
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+function getPinsFilePath(): string {
+  return path.join(os.homedir(), '.node9', 'skill-pins.json');
+}
+
+// ---------------------------------------------------------------------------
+// Hashing
+// ---------------------------------------------------------------------------
+
+/** Safety caps so a pathological root can't hang the hook. */
+const MAX_FILES = 5000;
+const MAX_TOTAL_BYTES = 50 * 1024 * 1024; // 50 MB
+
+function sha256Bytes(buf: Buffer): string {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+/**
+ * Walk a directory and return a sorted array of {relPath, fileHash} entries.
+ * - Skips symlinks (never follows them into arbitrary filesystem locations).
+ * - Skips any entries whose combined size would exceed MAX_TOTAL_BYTES.
+ * - Caps the number of files at MAX_FILES.
+ */
+function walkDir(root: string): FileManifestEntry[] {
+  const out: FileManifestEntry[] = [];
+  let totalBytes = 0;
+
+  const visit = (dir: string, relDir: string): void => {
+    if (out.length >= MAX_FILES) return;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    // Sort entries deterministically for stable traversal (also helps
+    // guarantee order-invariance even though we re-sort the final manifest).
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      if (out.length >= MAX_FILES) return;
+      const full = path.join(dir, entry.name);
+      const rel = relDir ? path.posix.join(relDir, entry.name) : entry.name;
+      // Guard against symlinks — lstat is authoritative for link-ness.
+      let lst: fs.Stats;
+      try {
+        lst = fs.lstatSync(full);
+      } catch {
+        continue;
+      }
+      if (lst.isSymbolicLink()) continue;
+      if (lst.isDirectory()) {
+        visit(full, rel);
+        continue;
+      }
+      if (!lst.isFile()) continue;
+      if (totalBytes + lst.size > MAX_TOTAL_BYTES) continue;
+      try {
+        const buf = fs.readFileSync(full);
+        totalBytes += buf.length;
+        out.push({ relPath: rel, fileHash: sha256Bytes(buf) });
+      } catch {
+        // Permission / race — skip this entry rather than failing the whole hash.
+      }
+    }
+  };
+
+  visit(root, '');
+  out.sort((a, b) => a.relPath.localeCompare(b.relPath));
+  return out;
+}
+
+/**
+ * Hash a skill root (file or directory). Missing paths return a well-defined
+ * `!exists` result; the caller's `checkPin` treats exists-flip as drift.
+ */
+export function hashSkillRoot(absPath: string): HashResult {
+  let lst: fs.Stats;
+  try {
+    lst = fs.lstatSync(absPath);
+  } catch {
+    return { exists: false, contentHash: '', fileCount: 0 };
+  }
+  // Never follow a symlinked root — treat as missing to avoid escapes.
+  if (lst.isSymbolicLink()) {
+    return { exists: false, contentHash: '', fileCount: 0 };
+  }
+  if (lst.isFile()) {
+    try {
+      const buf = fs.readFileSync(absPath);
+      const fileHash = sha256Bytes(buf);
+      return {
+        exists: true,
+        contentHash: fileHash,
+        fileCount: 1,
+      };
+    } catch {
+      return { exists: false, contentHash: '', fileCount: 0 };
+    }
+  }
+  if (lst.isDirectory()) {
+    const manifest = walkDir(absPath);
+    const canonical = JSON.stringify(manifest);
+    const contentHash = crypto.createHash('sha256').update(canonical).digest('hex');
+    return {
+      exists: true,
+      contentHash,
+      fileCount: manifest.length,
+      fileManifest: manifest,
+    };
+  }
+  // Special file (socket, block device, etc.) — treat as missing.
+  return { exists: false, contentHash: '', fileCount: 0 };
+}
+
+/** Derive a short root key from the absolute path. First 16 hex chars of sha256. */
+export function getRootKey(absPath: string): string {
+  return crypto.createHash('sha256').update(absPath).digest('hex').slice(0, 16);
+}
+
+// ---------------------------------------------------------------------------
+// File I/O
+// ---------------------------------------------------------------------------
+
+export type SkillPinsReadResult =
+  | { ok: true; pins: SkillPinsFile }
+  | { ok: false; reason: 'missing' }
+  | { ok: false; reason: 'corrupt'; detail: string };
+
+/**
+ * Read the pin registry from disk with explicit error reporting.
+ * - File missing (ENOENT): `{ ok: false, reason: 'missing' }`
+ * - File corrupt / unreadable: `{ ok: false, reason: 'corrupt' }`
+ * - File valid: `{ ok: true, pins }`
+ */
+export function readSkillPinsSafe(): SkillPinsReadResult {
+  const filePath = getPinsFilePath();
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    if (!raw.trim()) {
+      return { ok: false, reason: 'corrupt', detail: 'empty file' };
+    }
+    const parsed = JSON.parse(raw) as Partial<SkillPinsFile>;
+    if (!parsed.roots || typeof parsed.roots !== 'object' || Array.isArray(parsed.roots)) {
+      return { ok: false, reason: 'corrupt', detail: 'invalid structure: missing roots object' };
+    }
+    return { ok: true, pins: { roots: parsed.roots } };
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { ok: false, reason: 'missing' };
+    }
+    return { ok: false, reason: 'corrupt', detail: String(err) };
+  }
+}
+
+/** Read the pin registry; returns empty roots on missing; throws on corrupt. */
+export function readSkillPins(): SkillPinsFile {
+  const result = readSkillPinsSafe();
+  if (result.ok) return result.pins;
+  if (result.reason === 'missing') return { roots: {} };
+  throw new Error(`[node9] skill pin file is corrupt: ${result.detail}`);
+}
+
+/** Atomic write of the pin registry to disk. Exported for batched updates. */
+export function writeSkillPins(data: SkillPinsFile): void {
+  const filePath = getPinsFilePath();
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.${crypto.randomBytes(6).toString('hex')}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
+  fs.renameSync(tmp, filePath);
+}
+
+// ---------------------------------------------------------------------------
+// Pin operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a skill root's current state matches the pinned state.
+ * Returns:
+ *   'new'      — no pin exists for this root
+ *   'match'    — content hash AND exists flag both match
+ *   'mismatch' — hash differs OR exists flipped (possible drift)
+ *   'corrupt'  — pin file exists but is unreadable/malformed (fail closed)
+ */
+export function checkPin(
+  rootKey: string,
+  currentHash: string,
+  currentExists: boolean
+): 'match' | 'mismatch' | 'new' | 'corrupt' {
+  const result = readSkillPinsSafe();
+  if (!result.ok) {
+    if (result.reason === 'missing') return 'new';
+    return 'corrupt';
+  }
+  const entry = result.pins.roots[rootKey];
+  if (!entry) return 'new';
+  if (entry.exists !== currentExists) return 'mismatch';
+  return entry.contentHash === currentHash ? 'match' : 'mismatch';
+}
+
+/** Save or overwrite a pin for a skill root. */
+export function updatePin(
+  rootKey: string,
+  rootPath: string,
+  contentHash: string,
+  exists: boolean,
+  fileCount: number,
+  fileManifest?: FileManifestEntry[]
+): void {
+  const pins = readSkillPins();
+  pins.roots[rootKey] = {
+    rootPath,
+    exists,
+    contentHash,
+    fileCount,
+    pinnedAt: new Date().toISOString(),
+    ...(fileManifest ? { fileManifest } : {}),
+  };
+  writeSkillPins(pins);
+}
+
+/** Remove a single root's pin. */
+export function removePin(rootKey: string): void {
+  const pins = readSkillPins();
+  delete pins.roots[rootKey];
+  writeSkillPins(pins);
+}
+
+/** Clear all pins (fresh start). */
+export function clearAllPins(): void {
+  writeSkillPins({ roots: {} });
+}
+
+// ---------------------------------------------------------------------------
+// Diff (used by `node9 skill pin update` to explain what changed)
+// ---------------------------------------------------------------------------
+
+export type PinDiff =
+  | { kind: 'unchanged' }
+  | { kind: 'appeared'; rootPath: string }
+  | { kind: 'vanished'; rootPath: string }
+  | {
+      kind: 'changed';
+      rootPath: string;
+      added: string[];
+      removed: string[];
+      modified: string[];
+    };
+
+/**
+ * Compute a human-readable diff between a pin entry and the current state of
+ * the root path. Used by the CLI `pin update` flow.
+ */
+export function computePinDiff(pin: SkillPinEntry, currentPath: string): PinDiff {
+  const current = hashSkillRoot(currentPath);
+  if (pin.exists && !current.exists) {
+    return { kind: 'vanished', rootPath: pin.rootPath };
+  }
+  if (!pin.exists && current.exists) {
+    return { kind: 'appeared', rootPath: pin.rootPath };
+  }
+  if (!pin.exists && !current.exists) {
+    return { kind: 'unchanged' };
+  }
+  if (pin.contentHash === current.contentHash) {
+    return { kind: 'unchanged' };
+  }
+  // Both exist, hashes differ — build per-file diff if we have a manifest.
+  const oldManifest = pin.fileManifest ?? [];
+  const newManifest = current.fileManifest ?? [];
+  const oldMap = new Map(oldManifest.map((e) => [e.relPath, e.fileHash]));
+  const newMap = new Map(newManifest.map((e) => [e.relPath, e.fileHash]));
+  const added: string[] = [];
+  const removed: string[] = [];
+  const modified: string[] = [];
+  for (const [rel, hash] of newMap) {
+    const prev = oldMap.get(rel);
+    if (prev === undefined) added.push(rel);
+    else if (prev !== hash) modified.push(rel);
+  }
+  for (const rel of oldMap.keys()) {
+    if (!newMap.has(rel)) removed.push(rel);
+  }
+  added.sort();
+  removed.sort();
+  modified.sort();
+  return { kind: 'changed', rootPath: pin.rootPath, added, removed, modified };
+}
+
+// ---------------------------------------------------------------------------
+// Default skill roots (used by the check hook)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the default set of skill roots Node9 protects. Global roots are
+ * absolute paths; project roots are only returned when `cwd` is an absolute
+ * path (per CLAUDE.md: validate external path inputs before filesystem use).
+ */
+export function defaultSkillRoots(cwd: string | undefined): string[] {
+  const home = os.homedir();
+  const global = [
+    path.join(home, '.claude', 'skills'),
+    path.join(home, '.claude', 'CLAUDE.md'),
+    path.join(home, '.claude', 'rules'),
+  ];
+  if (!cwd || !path.isAbsolute(cwd)) return global;
+  return [
+    ...global,
+    path.join(cwd, '.claude', 'CLAUDE.md'),
+    path.join(cwd, '.claude', 'CLAUDE.local.md'),
+    path.join(cwd, '.claude', 'rules'),
+    path.join(cwd, '.cursor', 'rules'),
+    path.join(cwd, 'AGENTS.md'),
+    path.join(cwd, 'CLAUDE.md'),
+  ];
+}
+
+/**
+ * Verify a set of skill roots against the pin registry in one pass.
+ * - First root that drifts returns `drift` (session should be quarantined).
+ * - Corrupt pin file returns `corrupt` (session should be quarantined).
+ * - Roots with no prior pin are pinned in a single batched write; result is `verified`.
+ * - Roots whose content/existence matches the pin pass silently; result is `verified`.
+ *
+ * De-duplicates roots by path. Callers typically pass
+ * `[...defaultSkillRoots(cwd), ...userProvided]`.
+ */
+export type VerifyResult =
+  | { kind: 'verified' }
+  | { kind: 'corrupt'; detail: string }
+  | { kind: 'drift'; changedRootKey: string; changedRootPath: string; summary: string };
+
+export function verifyAndPinRoots(roots: string[]): VerifyResult {
+  const pinsRead = readSkillPinsSafe();
+  if (!pinsRead.ok && pinsRead.reason === 'corrupt') {
+    return { kind: 'corrupt', detail: pinsRead.detail };
+  }
+  const pins: SkillPinsFile = pinsRead.ok ? pinsRead.pins : { roots: {} };
+
+  // De-dup (different callers can construct the same path twice).
+  const unique = Array.from(new Set(roots));
+  let mutated = false;
+
+  for (const rootPath of unique) {
+    const rootKey = getRootKey(rootPath);
+    const current = hashSkillRoot(rootPath);
+    const existing = pins.roots[rootKey];
+    if (!existing) {
+      // First pin for this root — record it.
+      pins.roots[rootKey] = {
+        rootPath,
+        exists: current.exists,
+        contentHash: current.contentHash,
+        fileCount: current.fileCount,
+        pinnedAt: new Date().toISOString(),
+        ...(current.fileManifest ? { fileManifest: current.fileManifest } : {}),
+      };
+      mutated = true;
+      continue;
+    }
+    if (existing.exists !== current.exists || existing.contentHash !== current.contentHash) {
+      let summary: string;
+      if (existing.exists && !current.exists) summary = `vanished: ${rootPath}`;
+      else if (!existing.exists && current.exists) summary = `appeared: ${rootPath}`;
+      else summary = `changed: ${rootPath}`;
+      return { kind: 'drift', changedRootKey: rootKey, changedRootPath: rootPath, summary };
+    }
+    // Matches — no action.
+  }
+
+  if (mutated) {
+    writeSkillPins(pins);
+  }
+  return { kind: 'verified' };
+}
+
+/**
+ * Resolve a user-supplied skill root. Absolute paths pass through; paths
+ * starting with `~/` are expanded against the home directory; relative paths
+ * are joined onto `cwd` if it is absolute, otherwise ignored (returns null).
+ */
+export function resolveUserSkillRoot(entry: string, cwd: string | undefined): string | null {
+  if (!entry) return null;
+  if (entry.startsWith('~/') || entry === '~') {
+    return path.join(os.homedir(), entry.slice(1));
+  }
+  if (path.isAbsolute(entry)) return entry;
+  if (!cwd || !path.isAbsolute(cwd)) return null;
+  return path.join(cwd, entry);
+}


### PR DESCRIPTION
## Summary

- Extends the existing **MCP tool pinning** primitive (PR #81 / v1.5.0) to **agent skill files** — `~/.claude/skills/`, `~/.claude/CLAUDE.md`, `~/.claude/rules/`, project `.claude/CLAUDE.md`, `.claude/CLAUDE.local.md`, `.claude/rules/`, `.cursor/rules/`, `AGENTS.md`, `CLAUDE.md`. On the **first tool call of a session** the hook records SHA-256 hashes of every skill file; subsequent sessions re-hash and compare. Any drift **quarantines** the session and blocks every tool call until a human reviews with `node9 skill pin update <rootKey>`.
- **One feature, two threats covered**: **AST 02 Supply Chain Compromise** and **AST 07 Update Drift**.
- **Moat:** first/only runtime defense at the skills layer — competitors (Keycard / Microsoft AGT / Invariant) have no equivalent today.
- **Slim by design:** ~1,150 LOC total. Mirrors `src/mcp-pin.ts` 1:1; no new dependencies.

_(Re-opened from personal fork; supersedes closed #88.)_

## What's new

- **`src/skill-pin.ts`** (~300 lines) — SHA-256 content hashing (files or recursive directories, symlink-safe, 5000 files / 50 MB caps), atomic writes to `~/.node9/skill-pins.json` (mode 0o600), per-root `exists` flag so "appeared" and "vanished" both count as drift, batched `verifyAndPinRoots()`.
- **`src/cli/commands/skill-pin.ts`** (~100 lines) — `node9 skill pin list | update <rootKey> | reset`, mirroring `node9 mcp pin`. `update` removes the named pin so the next session re-pins; `reset` clears all pins and wipes session verification flags.
- **Hook integration in `src/cli/commands/check.ts`** (+117 lines) — first tool call of a session verifies; result memoised in `~/.node9/skill-sessions/<session_id>.json` so hashing runs once per session, not per tool call. Session IDs restricted to `/^[A-Za-z0-9_-]{1,128}$/` to defeat path traversal. Corrupt pin file → fail-closed. Unexpected errors → fail-open (debug-logged) so a bug here cannot brick Claude Code.
- **`policy.skillRoots: string[]` config field** — user-extensible list of extra skill paths.

## Security properties

- Fail-closed on corrupt `skill-pins.json` (recovery: `node9 skill pin reset`)
- Symlink-safe (`lstat` + explicit `isSymbolicLink()`; never follows out of the tree)
- Size-bounded (5000 files / 50 MB per root)
- Path-traversal-safe session IDs
- Atomic writes, mode 0o600

## Test plan

- [x] **30 new tests** across 4 files — all pass:
  - `skill-pin.unit.test.ts` (16): hash contract, order-invariance, add/remove/modify sensitivity, symlink skip, pin round-trip, exists-flip detection, mode 0o600, fail-closed
  - `skill-pin-cli.integration.test.ts` (6, `spawnSync`): list empty/populated/corrupt, update unknown/known, reset clears + wipes session flags
  - `check-skill-pin.integration.test.ts` (4, `spawnSync`): first-call pins + allows, new-session drift blocks with JSON-RPC payload + quarantines, corrupt fails closed, missing `session_id` skips
  - `skill-roots-config.spec.ts` (4): default empty, merge, dedup, defensive filter
- [x] Full suite: `npm test` → **1170 / 1171** pass (the one failure is a pre-existing environmental flake in `hud.spec.ts` — fails whenever `~/.claude/CLAUDE.md` exists on the test machine; passes under isolated HOME)
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run build` — all clean

### End-to-end verified against a realistic scenario

Simulated a developer's real setup (global `~/.claude/CLAUDE.md` + skill, project `CLAUDE.md` + `.cursor/rules/`) across two days of Claude Code sessions:

1. **Monday 9am, fresh session** → exit 0, 9 roots pinned, verified flag written with mode 0o600 ✅
2. **Same session, subsequent calls** → short-circuit via verified flag (~150ms incl. Node startup) ✅
3. **Overnight, attacker rewrites `my-project/CLAUDE.md`** with a prompt-injection backdoor
4. **Tuesday 9am, new session** → exit 2, JSON `decision: "block"`, reason names the exact `node9 skill pin update b73aad6c0b08ef42` recovery command, session flag persists as `{state: "quarantined", detail: "changed: .../my-project/CLAUDE.md"}` ✅
5. **Developer restores file + runs `skill pin update <key>`** → fresh session allows again ✅
6. **`skill pin reset`** → clears all pins + wipes `skill-sessions/` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)