### PR TITLE
refactor(scan): lift watermark regex constants into the policy engine

### DIFF
--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -105,3 +105,14 @@ export {
   LOOP_THRESHOLD_FOR_WASTE,
   COST_PER_LOOP_ITER_USD,
 } from './scan';
+
+// Regex detectors for destructive ops / privilege escalation / sensitive
+// paths. Used by the daemon watermark scanner; will also feed the upcoming
+// canonical extractor that unifies CLI scan, daemon, and --upload-history
+// behind one detection pipeline.
+export {
+  DESTRUCTIVE_OP_RE,
+  PRIVILEGE_ESCALATION_RE,
+  SENSITIVE_PATH_RE,
+  FILE_TOOLS,
+} from './scan/destructive-regex';

--- a/packages/policy-engine/src/scan/destructive-regex.ts
+++ b/packages/policy-engine/src/scan/destructive-regex.ts
@@ -1,0 +1,53 @@
+// Regex-based detectors for destructive operations, privilege escalation,
+// and sensitive-path reads. Used by the daemon watermark scanner today and
+// reused by the upcoming canonical extractor (so the live daemon, the
+// `--upload-history` backfill, and any other consumer share one source of
+// truth instead of redefining the same patterns locally).
+//
+// Pure regex constants. No fs/path/os/process imports.
+
+/**
+ * Destructive-op regex. Word-boundary anchored so partial matches don't
+ * fire (e.g. "term" inside "terminate" wouldn't match `\brm\b`). Each
+ * pattern is independently provable as destructive — no fuzzy heuristics.
+ */
+export const DESTRUCTIVE_OP_RE =
+  /\brm\s+-[rRf]+\b|\bDROP\s+(TABLE|DATABASE|COLLECTION|SCHEMA)\b|\bTRUNCATE\s+TABLE\b|\bgit\s+push\s+(--force|-f)\b|\bFLUSHALL\b|\bFLUSHDB\b|\bkubectl\s+delete\b|\bhelm\s+uninstall\b/i;
+
+/**
+ * Privilege-escalation regex. Standalone tokens only — `\bsudo\b` not
+ * `sudo` to avoid matching e.g. `pseudo` substrings.
+ */
+export const PRIVILEGE_ESCALATION_RE =
+  /\b(sudo|su)\b\s+[a-z]|\bchmod\s+(0?777|\+x)\b|\bchown\s+root\b/i;
+
+/**
+ * Sensitive file paths the agent shouldn't be reading via tool calls.
+ * Mirrors the blast walker's path set — same files matter, here detected
+ * at tool-call-time rather than fs-walk-time.
+ *
+ * `\b` boundaries on names so substring noise doesn't trigger; the
+ * patterns assume the proxy normalises ~ in inputs (which it does
+ * via path expansion before we see them).
+ */
+export const SENSITIVE_PATH_RE =
+  /\.aws\/(credentials|config)\b|\.ssh\/(id_rsa|id_ed25519|id_ecdsa|id_dsa)\b|\.env(\.|$|\b)|\.config\/gcloud\/credentials\.db\b|\.docker\/config\.json\b|\.netrc\b|\.npmrc\b|\.node9\/credentials\.json\b/i;
+
+/**
+ * Tool names that read or grep file contents. Used to gate SENSITIVE_PATH_RE
+ * to file-reading tools so the same path appearing in a Bash command doesn't
+ * double-count against a Read of the same file.
+ */
+export const FILE_TOOLS = new Set<string>([
+  'read',
+  'read_file',
+  'edit',
+  'edit_file',
+  'write',
+  'write_file',
+  'multiedit',
+  'grep',
+  'grep_search',
+  'glob',
+  'list_files',
+]);

--- a/src/daemon/scan-watermark.ts
+++ b/src/daemon/scan-watermark.ts
@@ -19,7 +19,15 @@ import os from 'os';
 import path from 'path';
 import readline from 'readline';
 import { scanArgs } from '../dlp.js';
-import { analyzePipeChain, detectDangerousShellExec, type ScanFinding } from '@node9/policy-engine';
+import {
+  analyzePipeChain,
+  detectDangerousShellExec,
+  DESTRUCTIVE_OP_RE,
+  PRIVILEGE_ESCALATION_RE,
+  SENSITIVE_PATH_RE,
+  FILE_TOOLS,
+  type ScanFinding,
+} from '@node9/policy-engine';
 
 const PROJECTS_DIR = () => path.join(os.homedir(), '.claude', 'projects');
 const WATERMARK_FILE = () => path.join(os.homedir(), '.node9', 'scan-watermark.json');
@@ -328,14 +336,6 @@ export function extractFindingsFromLine(
 }
 
 /**
- * Destructive-op regex. Word-boundary anchored so partial matches don't
- * fire (e.g. "term" inside "terminate" wouldn't match `\brm\b`). Each
- * pattern is independently provable as destructive — no fuzzy heuristics.
- */
-const DESTRUCTIVE_OP_RE =
-  /\brm\s+-[rRf]+\b|\bDROP\s+(TABLE|DATABASE|COLLECTION|SCHEMA)\b|\bTRUNCATE\s+TABLE\b|\bgit\s+push\s+(--force|-f)\b|\bFLUSHALL\b|\bFLUSHDB\b|\bkubectl\s+delete\b|\bhelm\s+uninstall\b/i;
-
-/**
  * Threshold for "long output" — tool results larger than this are
  * counted as redaction-eligible. 100KB is the value the proxy's
  * runtime redaction layer uses too; staying consistent makes the
@@ -343,37 +343,9 @@ const DESTRUCTIVE_OP_RE =
  */
 const LONG_OUTPUT_THRESHOLD_BYTES = 100 * 1024;
 
-/**
- * Tool names that read or grep file contents. Used to decide whether
- * the file_path/path/pattern arg is worth running against
- * SENSITIVE_PATH_RE — restricts the check to file-reading tools so a
- * Bash command containing the same path doesn't double-count.
- */
-const FILE_TOOLS = new Set([
-  'read',
-  'read_file',
-  'edit',
-  'edit_file',
-  'write',
-  'write_file',
-  'multiedit',
-  'grep',
-  'grep_search',
-  'glob',
-  'list_files',
-]);
-
-/**
- * Sensitive file paths the agent shouldn't be reading via tool calls.
- * Mirrors the blast walker's path set — same files matter, here
- * detected at tool-call-time rather than fs-walk-time.
- *
- * `\b` boundaries on names so substring noise doesn't trigger; the
- * patterns assume the proxy normalises ~ in inputs (which it does
- * via path expansion before we see them).
- */
-const SENSITIVE_PATH_RE =
-  /\.aws\/(credentials|config)\b|\.ssh\/(id_rsa|id_ed25519|id_ecdsa|id_dsa)\b|\.env(\.|$|\b)|\.config\/gcloud\/credentials\.db\b|\.docker\/config\.json\b|\.netrc\b|\.npmrc\b|\.node9\/credentials\.json\b/i;
+// DESTRUCTIVE_OP_RE, PRIVILEGE_ESCALATION_RE, SENSITIVE_PATH_RE, FILE_TOOLS
+// now live in @node9/policy-engine (scan/destructive-regex.ts) so the live
+// daemon and the canonical extractor share one source of truth.
 
 /**
  * Detect PII patterns in a string. Returns an array of finding pattern
@@ -407,12 +379,6 @@ const PII_PHONE_RE = /\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}\b/;
 // (51-55, 2221-2720), Amex (34/37), Discover (6). 16-digit grouping with
 // optional dashes/spaces between groups of 4.
 const PII_CC_RE = /\b(?:4\d{3}|5[1-5]\d{2}|3[47]\d{2}|6\d{3})[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b/;
-
-/**
- * Privilege-escalation regex. Standalone tokens only — `\bsudo\b` not
- * `sudo` to avoid matching e.g. `pseudo` substrings.
- */
-const PRIVILEGE_ESCALATION_RE = /\b(sudo|su)\b\s+[a-z]|\bchmod\s+(0?777|\+x)\b|\bchown\s+root\b/i;
 
 /**
  * Result of one tick — what was scanned and what was found. Caller pushes


### PR DESCRIPTION
## Summary

- \`DESTRUCTIVE_OP_RE\`, \`PRIVILEGE_ESCALATION_RE\`, \`SENSITIVE_PATH_RE\`, and \`FILE_TOOLS\` move from \`src/daemon/scan-watermark.ts\` into \`packages/policy-engine/src/scan/destructive-regex.ts\`.
- Pure relocation — the regex patterns are character-identical to the prior local copies, and \`scan-watermark.ts\` continues to use them via \`import { ... } from '@node9/policy-engine'\`.
- No behavior change. All 1716 existing tests pass without modification.

## Why

This is **Step 1** of the canonical-extractor plan. Any future consumer (\`--upload-history\` backfill, the unified extractor in Step 2, the SaaS-side detector if we ever move detection there) can now import the same constants instead of redefining them. That eliminates the drift risk currently producing inconsistent counts in the SaaS dashboard between the daemon's "Scan (X)" numbers and the CLI's \`node9 scan\` output.

## Independent of PR #152

This PR is branched directly from \`dev\` and does not depend on PR #152 (the live-hook AST tier). They can review and merge in either order. If both land, the canonical extractor in Step 2 will use the constants exported here AND the AST detection wired up by #152.

## Test plan

- [x] \`npm test\` — 1716 passed, 21 skipped, 0 failed (unchanged from \`dev\` baseline)
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` — 0 errors
- [x] \`npm run format:check\` clean
- [x] Pre-commit hook passed all four checks
- [x] \`grep DESTRUCTIVE_OP_RE\` and friends across the repo confirms the only definition is now in the engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)