### PR TITLE
fix(daemon): restore macOS detection — drop ss probe (v1.19.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## v1.19.3 — macOS daemon-detection hotfix
+
+### Fixed
+
+- **`node9 doctor` reported the daemon as not running on macOS even when it was running** (issue #162). `isDaemonRunning()` shelled out to `ss` (Linux iproute2) to verify the TCP port was bound. On macOS `ss` does not exist, so `spawnSync` returned `ENOENT` and the function always returned `false` — even when the daemon process was up and the PID file was valid. This caused `node9 daemon status` (PID-file based) and `node9 doctor` (port-probe based) to disagree on macOS, and made browser/native approvals appear unavailable.
+
+  Fix: drop the TCP probe from the sync hot path. `isDaemonRunning()` now relies on PID-file validity + `process.kill(pid, 0)` — cross-platform and faster (no per-hook `spawnSync`). Callers needing strict HTTP-liveness should use the new `isDaemonReachable()` async helper. The orphan-adoption path in `daemon/server.ts` (rare, fires on `EADDRINUSE` without a PID file) keeps a port probe but now falls back from `ss` to `lsof` on macOS.
+
+  Adds a regression test asserting `isDaemonRunning()` does not invoke `spawnSync` — guards against re-introducing a Linux-only binary dependency.
+
+- **Misleading "browser dashboard" messages.** `node9 doctor` claimed _"Browser dashboard running → http://127.0.0.1:7391/"_ and the daemon banner printed _"🛡️ Node9 Guard LIVE: http://127.0.0.1:7391"_ — but the local browser dashboard was retired in the v3 browser-removal sprint and `GET /` now 404s. Updated both messages to describe what actually exists (terminal & native approvals; SSE/JSON-RPC for `node9 tail` and the MCP gateway).
+
+- **`undo` legacy-fallback inherited `GIT_DIR` from caller env.** `buildGitEnv()`'s shadow-absent path returned `{ ...process.env }` without stripping `GIT_DIR` / `GIT_WORK_TREE`. If those happened to be set in the caller's environment (e.g. running under `git commit` inside a git worktree), the legacy fallback would inherit a worktree pointer it shouldn't use. Now explicitly deletes both before returning.
+
+---
+
 ## v1.10.0 — Installed Skill Pinning (AST 02 + AST 07)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node9/proxy",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "description": "The Sudo Command for AI Agents. Execution Security for Claude Code & MCP.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/__tests__/core.test.ts
+++ b/src/__tests__/core.test.ts
@@ -2056,7 +2056,7 @@ describe('shouldSnapshot', () => {
 
 describe('isDaemonRunning', () => {
   it('returns false when PID file does not exist', () => {
-    // existsSpy returns false (set in beforeEach); spawnSync mock returns status:1 (no match)
+    // existsSpy returns false (set in beforeEach)
     expect(isDaemonRunning()).toBe(false);
   });
 
@@ -2069,55 +2069,37 @@ describe('isDaemonRunning', () => {
     expect(isDaemonRunning()).toBe(false);
   });
 
-  it('returns true when PID exists, process is alive, and port is open', async () => {
+  it('returns true when PID file is valid and process is alive', () => {
     const pidPath = path.join('/mock/home', '.node9', 'daemon.pid');
     existsSpy.mockImplementation((p) => String(p) === pidPath);
     readSpy.mockImplementation((p) =>
       // Use current process PID so kill(pid, 0) succeeds
       String(p) === pidPath ? JSON.stringify({ pid: process.pid, port: 7391 }) : ''
     );
-    // Also mock ss to confirm port is open — isDaemonRunning now requires both
-    // PID-alive AND TCP port listening to return true.
-    const { spawnSync: mockSpawnSync } = await import('child_process');
-    vi.mocked(mockSpawnSync).mockReturnValueOnce({
-      status: 0,
-      stdout: 'LISTEN 0 128 127.0.0.1:7391 0.0.0.0:* users:(("node",pid=12345,fd=18))',
-      stderr: '',
-      pid: 0,
-      output: [],
-      signal: null,
-      error: undefined,
-    });
     expect(isDaemonRunning()).toBe(true);
   });
 
-  it('returns true when no PID file but ss detects orphaned daemon on port', async () => {
+  // Regression for issue #162 (macOS: daemon silently failing).
+  //
+  // A previous version added a TCP probe via `spawnSync('ss', ...)` after
+  // process.kill(pid, 0). On macOS, `ss` (Linux iproute2) does not exist,
+  // so spawnSync returned { error: ENOENT, status: null } and the function
+  // always returned false — even when the daemon was running. This caused
+  // `node9 doctor` to incorrectly report the daemon as not running on macOS.
+  //
+  // We assert that isDaemonRunning() does not invoke spawnSync at all: the
+  // sync hot path must be cross-platform without depending on any external
+  // binary. Callers needing HTTP-liveness should use isDaemonReachable().
+  it('does not shell out to ss/lsof — works on systems without iproute2 (macOS)', async () => {
+    const pidPath = path.join('/mock/home', '.node9', 'daemon.pid');
+    existsSpy.mockImplementation((p) => String(p) === pidPath);
+    readSpy.mockImplementation((p) =>
+      String(p) === pidPath ? JSON.stringify({ pid: process.pid, port: 7391 }) : ''
+    );
     const { spawnSync: mockSpawnSync } = await import('child_process');
-    vi.mocked(mockSpawnSync).mockReturnValueOnce({
-      status: 0,
-      stdout: 'LISTEN 0 128 127.0.0.1:7391 0.0.0.0:* users:(("node",pid=12345,fd=18))',
-      stderr: '',
-      pid: 0,
-      output: [],
-      signal: null,
-      error: undefined,
-    });
-    // existsSpy already returns false (set in beforeEach)
+    vi.mocked(mockSpawnSync).mockClear();
     expect(isDaemonRunning()).toBe(true);
-  });
-
-  it('returns false when no PID file and ss finds nothing on port', async () => {
-    const { spawnSync: mockSpawnSync } = await import('child_process');
-    vi.mocked(mockSpawnSync).mockReturnValueOnce({
-      status: 0,
-      stdout: '',
-      stderr: '',
-      pid: 0,
-      output: [],
-      signal: null,
-      error: undefined,
-    });
-    expect(isDaemonRunning()).toBe(false);
+    expect(mockSpawnSync).not.toHaveBeenCalled();
   });
 
   it('returns false when PID file contains invalid JSON', () => {

--- a/src/auth/daemon.ts
+++ b/src/auth/daemon.ts
@@ -4,7 +4,6 @@ import fs from 'fs';
 import net from 'net';
 import path from 'path';
 import os from 'os';
-import { spawnSync } from 'child_process';
 import { type RiskMetadata } from '../context-sniper';
 
 const ACTIVITY_SOCKET_PATH =
@@ -134,27 +133,35 @@ export function isDaemonRunning(): boolean {
       return false;
     }
 
-    // Verify the TCP port is actually accepting connections.
-    // process.kill(pid,0) only confirms the process exists — it could still
-    // be in early startup before server.listen() completes, or the PID could
-    // be reused by an unrelated process. A TCP probe is the authoritative check.
-    const r = spawnSync('ss', ['-Htnp', `sport = :${DAEMON_PORT}`], {
-      encoding: 'utf8',
-      timeout: 300,
-    });
-    if (r.status === 0 && (r.stdout ?? '').includes(`:${DAEMON_PORT}`)) return true;
-    // PID alive but port not open yet (daemon starting) or PID reuse by another
-    // process. Don't clean the PID file — daemon may still be initializing.
-    return false;
+    // PID file present, JSON valid, port matches, PID validates, process exists.
+    // We treat that as "running". A previous version also spawned `ss` to verify
+    // the TCP port was bound — but `ss` is Linux-only (iproute2), causing this
+    // function to always return false on macOS even when the daemon was up.
+    // Callers that genuinely need HTTP-liveness (e.g. daemon-starter polling)
+    // should use isDaemonReachable() instead.
+    return true;
   }
 
-  // No PID file — port check catches orphaned daemons (PID file was lost)
+  // No PID file — daemon not running. Detecting orphaned daemons (process up,
+  // PID file lost) requires a port probe; that probe is portable only via
+  // spawning `lsof`/`ss`, which we deliberately avoid here to keep this hot
+  // path sync, fast, and cross-platform. The orphan case is recovered at
+  // daemon startup via the EADDRINUSE handler in src/daemon/server.ts.
+  return false;
+}
+
+/**
+ * Async HTTP-liveness probe. Use this when a caller genuinely needs to know
+ * the daemon's HTTP server is accepting requests right now (e.g. after
+ * spawning the daemon, before issuing the first /check call). isDaemonRunning()
+ * is the cheap sync check — sufficient for most call sites.
+ */
+export async function isDaemonReachable(timeoutMs = 500): Promise<boolean> {
   try {
-    const r = spawnSync('ss', ['-Htnp', `sport = :${DAEMON_PORT}`], {
-      encoding: 'utf8',
-      timeout: 300,
+    const res = await fetch(`http://${DAEMON_HOST}:${DAEMON_PORT}/settings`, {
+      signal: AbortSignal.timeout(timeoutMs),
     });
-    return r.status === 0 && (r.stdout ?? '').includes(`:${DAEMON_PORT}`);
+    return res.ok;
   } catch {
     return false;
   }

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -178,10 +178,12 @@ export function registerDoctorCommand(program: Command, version: string): void {
       // ── Daemon ───────────────────────────────────────────────────────────────
       section('Daemon (optional)');
       if (isDaemonRunning()) {
-        pass(`Browser dashboard running → http://${DAEMON_HOST}:${DAEMON_PORT}/`);
+        pass(
+          `Daemon running on ${DAEMON_HOST}:${DAEMON_PORT} — terminal & native approvals enabled`
+        );
       } else {
         warn(
-          'Daemon not running — browser approvals unavailable',
+          'Daemon not running — terminal & native approvals unavailable',
           'Run: node9 daemon --background'
         );
       }

--- a/src/cli/daemon-starter.ts
+++ b/src/cli/daemon-starter.ts
@@ -9,7 +9,7 @@
 import { spawn } from 'child_process';
 import path from 'path';
 import fs from 'fs';
-import { isDaemonRunning, DAEMON_PORT, DAEMON_HOST } from '../auth/daemon';
+import { isDaemonRunning, isDaemonReachable } from '../auth/daemon';
 
 export function isTestingMode(): boolean {
   return /^(1|true|yes)$/i.test(process.env.NODE9_TESTING ?? '');
@@ -38,17 +38,11 @@ export async function autoStartDaemonAndWait(): Promise<boolean> {
     for (let i = 0; i < 20; i++) {
       await new Promise((r) => setTimeout(r, 250));
       if (!isDaemonRunning()) continue;
-      // Verify the HTTP server is actually accepting connections, not just that
-      // the process is alive. isDaemonRunning() only checks the PID file, which
-      // could be stale (OS PID reuse) or written before the socket is fully ready.
-      try {
-        const res = await fetch(`http://${DAEMON_HOST}:${DAEMON_PORT}/settings`, {
-          signal: AbortSignal.timeout(500),
-        });
-        if (res.ok) return true;
-      } catch {
-        // HTTP not ready yet — keep polling
-      }
+      // isDaemonRunning() is the cheap sync check (PID file + process.kill);
+      // confirm the HTTP server is actually accepting connections before
+      // returning true so callers don't get ECONNREFUSED on their first
+      // request. The process may be alive but still mid-listen().
+      if (await isDaemonReachable()) return true;
     }
   } catch {}
   return false;

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -5,7 +5,6 @@
 //   daemon/service.ts — login service install/uninstall (launchd / systemd)
 import fs from 'fs';
 import chalk from 'chalk';
-import { spawnSync } from 'child_process';
 
 export { startDaemon } from './server';
 export {
@@ -69,16 +68,11 @@ export function daemonStatus(): void {
       processStatus = chalk.yellow('not running (stale PID file)');
     }
   } else {
-    // No PID file — check if port is in use (orphaned daemon)
-    const r = spawnSync('ss', ['-Htnp', `sport = :${DAEMON_PORT}`], {
-      encoding: 'utf8',
-      timeout: 500,
-    });
-    if (r.status === 0 && (r.stdout ?? '').includes(`:${DAEMON_PORT}`)) {
-      processStatus = chalk.yellow(`running (orphaned — no PID file)`);
-    } else {
-      processStatus = chalk.yellow('not running');
-    }
+    // No PID file — daemon not running. Detecting orphaned daemons (process
+    // up, PID file lost) previously shelled out to `ss`, which only exists on
+    // Linux; on macOS that probe always failed. The orphan case is recovered
+    // at daemon startup via the EADDRINUSE handler in src/daemon/server.ts.
+    processStatus = chalk.yellow('not running');
   }
 
   console.log(`\n  Process : ${processStatus}`);

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -1124,14 +1124,33 @@ export function startDaemon(): void {
       })
         .then((res) => {
           if (res.ok) {
+            // Try to recover the orphan's PID and re-create the PID file so
+            // future stop/status calls can find it. Try `ss` first (Linux,
+            // fast); fall back to `lsof` (macOS + portable Linux).
             try {
-              const r = spawnSync('ss', ['-Htnp', `sport = :${DAEMON_PORT}`], {
+              let orphanPid: number | null = null;
+              const ss = spawnSync('ss', ['-Htnp', `sport = :${DAEMON_PORT}`], {
                 encoding: 'utf8',
                 timeout: 1000,
               });
-              const match = r.stdout?.match(/pid=(\d+)/);
-              if (match) {
-                const orphanPid = parseInt(match[1], 10);
+              if (!ss.error && ss.status === 0) {
+                const m = ss.stdout?.match(/pid=(\d+)/);
+                if (m) orphanPid = parseInt(m[1], 10);
+              } else if (
+                (ss.error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT' ||
+                ss.status === null
+              ) {
+                const lsof = spawnSync(
+                  'lsof',
+                  ['-nP', `-iTCP:${DAEMON_PORT}`, '-sTCP:LISTEN', '-t'],
+                  { encoding: 'utf8', timeout: 1000 }
+                );
+                if (!lsof.error && lsof.status === 0) {
+                  const first = (lsof.stdout ?? '').split('\n')[0].trim();
+                  if (/^\d+$/.test(first)) orphanPid = parseInt(first, 10);
+                }
+              }
+              if (orphanPid !== null) {
                 process.kill(orphanPid, 0);
                 atomicWriteSync(
                   DAEMON_PID_FILE,
@@ -1170,7 +1189,7 @@ export function startDaemon(): void {
       JSON.stringify({ pid: process.pid, port: DAEMON_PORT, internalToken, autoStarted }),
       { mode: 0o600 }
     );
-    console.error(chalk.green(`🛡️  Node9 Guard LIVE: http://127.0.0.1:${DAEMON_PORT}`));
+    console.error(chalk.green(`🛡️  Node9 Guard LIVE on 127.0.0.1:${DAEMON_PORT}`));
   });
 
   // ── Flight Recorder ──────────────────────────────────────────────────────

--- a/src/undo.ts
+++ b/src/undo.ts
@@ -260,8 +260,14 @@ function buildGitEnv(cwd: string): NodeJS.ProcessEnv {
   if (check.status === 0) {
     return { ...process.env, GIT_DIR: shadowDir, GIT_WORK_TREE: cwd };
   }
-  // Legacy fallback: use ambient git context (user's .git or none)
-  return { ...process.env };
+  // Legacy fallback: use ambient git context (user's .git or none).
+  // Strip any inherited GIT_DIR / GIT_WORK_TREE so we don't accidentally
+  // operate in a worktree pointer that happens to be set in our env
+  // (e.g. when running under `git commit` inside a worktree).
+  const env = { ...process.env };
+  delete env.GIT_DIR;
+  delete env.GIT_WORK_TREE;
+  return env;
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #162.

`node9 doctor` reported the daemon as not running on macOS even when it was running. Root cause: `isDaemonRunning()` shelled out to `ss` (Linux iproute2) to verify the TCP port was bound. On macOS `ss` does not exist, so `spawnSync` returned `ENOENT` and the function always returned `false` — even with a valid PID file. This caused `node9 daemon status` (PID-file based) and `node9 doctor` (port-probe based) to disagree on macOS.

Introduced in 1.19.0 by 2e757a0 (defensive PID-reuse / startup-race guard placed on a sync hot path called from ~30 sites). Shipped broken in 1.19.0, 1.19.1, 1.19.2.

## Fix

- **Drop the TCP probe from the sync hot path.** `isDaemonRunning()` now relies on PID-file validity + `process.kill(pid, 0)` — cross-platform, faster (no per-hook spawnSync), no external binary dependency.
- **New `isDaemonReachable()` async helper** for callers that genuinely need HTTP-liveness. `daemon-starter.ts` migrated to use it (replaces inline fetch block).
- **Orphan-adoption path** in `daemon/server.ts` (rare, fires on `EADDRINUSE` without a PID file) keeps a port probe but now falls back from `ss` to `lsof` on macOS.

## Companion fixes (same root-cause confusion)

- `doctor.ts`: stop claiming _"Browser dashboard running → http://..."_ — local browser dashboard was retired in v3 and `GET /` returns 404. Updated to describe what actually exists (terminal & native approvals).
- `daemon/server.ts`: LIVE banner no longer prints `http://` URL that 404s.
- `undo.ts`: `buildGitEnv()` legacy fallback strips inherited `GIT_DIR`/`GIT_WORK_TREE` (caught while running pre-commit hook inside a worktree).

## Regression test

`src/__tests__/core.test.ts` — asserts `isDaemonRunning()` does not invoke `spawnSync`. Strongest possible cross-platform guarantee: if no external binary is invoked, no platform-specific binary can break the function. Guards against re-introducing a Linux-only dependency.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors, pre-existing warnings only)
- [x] `npm run format:check` passes
- [x] `npm test` passes (1829 passed, 22 skipped, 0 failed)
- [x] Pre-commit hook re-ran full pipeline successfully
- [x] Self-review (`/review-pr`) passed — only opinion-level UX nit remaining
- [ ] Confirm CI green on PR
- [ ] Reporter validates on actual macOS (post-release)

## Followups (separate PRs)

- Add `macos-latest` to CI matrix to catch future Linux-only binary deps before they ship
- Cherry-pick to `dev` after this merges (auth/daemon.ts unchanged on dev → conflict-free)

🤖 Generated with [Claude Code](https://claude.com/claude-code)