### PR TITLE
feat(blast): add Willow sovereign stack sensitive paths

### DIFF
--- a/src/cli/commands/blast.ts
+++ b/src/cli/commands/blast.ts
@@ -85,6 +85,24 @@ function buildSensitivePaths(home: string, cwd: string): Array<SensitivePath & {
       score: 10,
     },
     {
+      full: path.join(home, '.willow', 'secrets', '.willow_master.key'),
+      label: '~/.willow/secrets/.willow_master.key',
+      description: 'Willow Fernet master key — decrypts all vault credentials',
+      score: 20,
+    },
+    {
+      full: path.join(home, '.willow', 'secrets', '.willow_creds.db'),
+      label: '~/.willow/secrets/.willow_creds.db',
+      description: 'Willow encrypted credential vault (SQLite + Fernet)',
+      score: 10,
+    },
+    {
+      full: path.join(home, '.willow', 'secrets', 'credentials.json'),
+      label: '~/.willow/secrets/credentials.json',
+      description: 'Willow plaintext credential fallback — API keys in clear text',
+      score: 15,
+    },
+    {
       full: path.join(cwd, '.env'),
       label: '.env  (current folder)',
       description: 'App secrets — database passwords, API keys',


### PR DESCRIPTION
## Summary

Adds three credential paths from the [Willow](https://github.com/rudi193-cmd/willow-1.9) local-first AI agent stack to `buildSensitivePaths()`:

- `~/.willow/secrets/.willow_master.key` — Fernet master key that decrypts the entire credential vault; scored 20 (same as SSH private keys)
- `~/.willow/secrets/.willow_creds.db` — encrypted SQLite vault; scored 10 (fingerprints the install even without the master key)
- `~/.willow/secrets/credentials.json` — plaintext fallback store used when the vault is unavailable; API keys in clear text; scored 15

These follow the same pattern as the existing `~/.node9/credentials.json` entry. Willow users running `node9 blast` in their AI sessions will now see these paths flagged if readable, consistent with the project-jail CTA.

## Test plan

- [ ] `node9 blast` on a machine with Willow installed shows the three new paths if readable
- [ ] `node9 blast` on a machine without Willow shows no change
- [ ] Existing unit tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)