### PR TITLE
feat(config): apply managed DLP with baseline+lock (Managed Config M2c)

### DIFF
--- a/src/__tests__/managed.test.ts
+++ b/src/__tests__/managed.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { modeRank, resolveManagedMode, applyManagedEgress } from '../config/managed';
+import {
+  modeRank,
+  resolveManagedMode,
+  applyManagedEgress,
+  applyManagedDlp,
+} from '../config/managed';
 
 const localEgress = (over: Partial<{ enabled: boolean; mode: string }> = {}) => ({
   enabled: false,
@@ -7,6 +12,13 @@ const localEgress = (over: Partial<{ enabled: boolean; mode: string }> = {}) => 
   allow: ['local.example.com'],
   deny: [],
   allowPrivate: true,
+  ...over,
+});
+
+const localDlp = (over: Partial<{ enabled: boolean; pii: string }> = {}) => ({
+  enabled: true,
+  scanIgnoredTools: true,
+  pii: 'off' as string,
   ...over,
 });
 
@@ -88,5 +100,32 @@ describe('managed egress (baseline+lock) — M2b', () => {
   it('ignores an unrankable managed egress mode', () => {
     const out = applyManagedEgress(localEgress({ mode: 'block' }), { mode: 'garbage' }, []);
     expect(out.mode).toBe('block');
+  });
+});
+
+describe('managed dlp (baseline+lock) — M2c', () => {
+  it('enabled is force-on', () => {
+    expect(applyManagedDlp(localDlp({ enabled: false }), { enabled: true }, []).enabled).toBe(true);
+  });
+
+  it('pii: raises off → block (the cloud floor)', () => {
+    expect(applyManagedDlp(localDlp({ pii: 'off' }), { pii: 'block' }, []).pii).toBe('block');
+  });
+
+  it('pii: keeps a stricter local block over a cloud off (dev can be safer)', () => {
+    expect(applyManagedDlp(localDlp({ pii: 'block' }), { pii: 'off' }, []).pii).toBe('block');
+  });
+
+  it('pii: a locked value wins over a stricter local', () => {
+    expect(applyManagedDlp(localDlp({ pii: 'block' }), { pii: 'off' }, ['dlpPii']).pii).toBe('off');
+  });
+
+  it('leaves untouched local fields (scanIgnoredTools) intact', () => {
+    const out = applyManagedDlp(localDlp(), { enabled: true, pii: 'block' }, []);
+    expect(out.scanIgnoredTools).toBe(true);
+  });
+
+  it('ignores an unrankable managed pii', () => {
+    expect(applyManagedDlp(localDlp({ pii: 'block' }), { pii: 'garbage' }, []).pii).toBe('block');
   });
 });

--- a/src/__tests__/sync.test.ts
+++ b/src/__tests__/sync.test.ts
@@ -734,6 +734,38 @@ describe('getConfig — cloud-pushed runtime flags', () => {
     expect(getConfig().settings.mode).toBe('observe');
   });
 
+  it('managed dlp (M2c): force-on + raises pii to the cloud floor', () => {
+    mockFiles({
+      [CONFIG_PATH]: JSON.stringify({
+        settings: { mode: 'standard' },
+        policy: { dlp: { enabled: false, scanIgnoredTools: true, pii: 'off' } },
+      }),
+      [CACHE_PATH]: JSON.stringify({
+        fetchedAt: '2026-06-29T00:00:00.000Z',
+        rules: [],
+        managedConfig: { dlp: { enabled: true, pii: 'block' }, locked: [] },
+      }),
+    });
+    const dlp = getConfig().policy.dlp;
+    expect(dlp.enabled).toBe(true);
+    expect(dlp.pii).toBe('block');
+  });
+
+  it('managed dlp (M2c): a locked pii wins over a stricter local', () => {
+    mockFiles({
+      [CONFIG_PATH]: JSON.stringify({
+        settings: { mode: 'standard' },
+        policy: { dlp: { enabled: true, scanIgnoredTools: true, pii: 'block' } },
+      }),
+      [CACHE_PATH]: JSON.stringify({
+        fetchedAt: '2026-06-29T00:00:00.000Z',
+        rules: [],
+        managedConfig: { dlp: { pii: 'off' }, locked: ['dlpPii'] },
+      }),
+    });
+    expect(getConfig().policy.dlp.pii).toBe('off');
+  });
+
   it('no managedConfig leaves mode unchanged — zero-regression', () => {
     mockFiles({
       [CONFIG_PATH]: JSON.stringify({ settings: { mode: 'standard' } }),

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import os from 'os';
 import { sanitizeConfig } from '../config-schema';
 import { readActiveShields, readShieldOverrides, getShield } from '../shields';
-import { resolveManagedMode, applyManagedEgress } from './managed';
+import { resolveManagedMode, applyManagedEgress, applyManagedDlp } from './managed';
 
 // SmartCondition + SmartRule are now defined in @node9/policy-engine.
 // Re-exported here so existing import paths (`from '../config'`) keep
@@ -729,6 +729,7 @@ export function getConfig(cwd?: string): Config {
         const mc = raw.managedConfig as {
           mode?: unknown;
           egress?: { enabled?: unknown; mode?: unknown };
+          dlp?: { enabled?: unknown; pii?: unknown };
           locked?: unknown;
         };
         const locked: string[] = Array.isArray(mc.locked)
@@ -750,6 +751,17 @@ export function getConfig(cwd?: string): Config {
             {
               enabled: typeof mc.egress.enabled === 'boolean' ? mc.egress.enabled : undefined,
               mode: typeof mc.egress.mode === 'string' ? mc.egress.mode : undefined,
+            },
+            locked
+          );
+        }
+        // M2c: policy.dlp. enabled force-on; pii floor over off<block.
+        if (mc.dlp && typeof mc.dlp === 'object') {
+          mergedPolicy.dlp = applyManagedDlp(
+            mergedPolicy.dlp,
+            {
+              enabled: typeof mc.dlp.enabled === 'boolean' ? mc.dlp.enabled : undefined,
+              pii: typeof mc.dlp.pii === 'string' ? mc.dlp.pii : undefined,
             },
             locked
           );

--- a/src/config/managed.ts
+++ b/src/config/managed.ts
@@ -83,3 +83,39 @@ export function applyManagedEgress<T extends { enabled: boolean; mode: string }>
   }
   return next;
 }
+
+// Managed DLP fields (M2c). `enabled` is force-on; `pii` gates SSN/credit-card in
+// tool args (off = detect-only, block = deny in realtime), ordered off<block.
+export const DLP_PII_ORDER = ['off', 'block'] as const;
+export interface ManagedDlp {
+  enabled?: boolean;
+  pii?: string;
+}
+
+/**
+ * Apply managed DLP to the machine's local dlp object (baseline+lock), same
+ * model as egress: `enabled` force-on, `pii` a floor over off<block. Generic so
+ * the precise caller type is preserved; untouched fields (scanIgnoredTools)
+ * carry through.
+ */
+export function applyManagedDlp<T extends { enabled: boolean; pii?: string }>(
+  local: T,
+  managed: ManagedDlp,
+  locked: string[]
+): T {
+  const next: T = { ...local };
+  if (typeof managed.enabled === 'boolean') {
+    next.enabled = locked.includes('dlpEnabled')
+      ? managed.enabled
+      : local.enabled || managed.enabled;
+  }
+  if (typeof managed.pii === 'string') {
+    next.pii = resolveByOrder(
+      DLP_PII_ORDER,
+      local.pii ?? 'off',
+      managed.pii,
+      locked.includes('dlpPii')
+    ) as T['pii'];
+  }
+  return next;
+}

--- a/src/daemon/sync.ts
+++ b/src/daemon/sync.ts
@@ -152,10 +152,11 @@ export interface RulesCache {
   managedConfig?: ManagedConfigCache;
 }
 
-/** Cloud-managed settings persisted in the cache (M2: mode + egress). */
+/** Cloud-managed settings persisted in the cache (M2: mode + egress + dlp). */
 export interface ManagedConfigCache {
   mode?: string;
   egress?: { enabled?: boolean; mode?: string };
+  dlp?: { enabled?: boolean; pii?: string };
   locked: string[];
 }
 
@@ -176,6 +177,7 @@ interface CloudPolicyBody {
   managedConfig?: {
     mode?: unknown;
     egress?: { enabled?: unknown; mode?: unknown };
+    dlp?: { enabled?: unknown; pii?: unknown };
     locked?: unknown;
   }; // M2 settings
 }
@@ -342,8 +344,17 @@ export function extractManagedConfig(body: CloudPolicyBody): ManagedConfigCache 
     if (typeof mc.egress.mode === 'string') e.mode = mc.egress.mode;
     if (e.enabled !== undefined || e.mode !== undefined) out.egress = e;
   }
+  // M2c: dlp.enabled (bool) + dlp.pii (string).
+  if (mc.dlp && typeof mc.dlp === 'object') {
+    const d: { enabled?: boolean; pii?: string } = {};
+    if (typeof mc.dlp.enabled === 'boolean') d.enabled = mc.dlp.enabled;
+    if (typeof mc.dlp.pii === 'string') d.pii = mc.dlp.pii;
+    if (d.enabled !== undefined || d.pii !== undefined) out.dlp = d;
+  }
   // Nothing actually managed → omit entirely.
-  return out.mode !== undefined || out.egress !== undefined ? out : undefined;
+  return out.mode !== undefined || out.egress !== undefined || out.dlp !== undefined
+    ? out
+    : undefined;
 }
 
 /**


### PR DESCRIPTION
The proxy half of **M2c**. When the dashboard manages DLP (node9Firewall #128), the sync carries `managedConfig.dlp`; `getConfig` applies it to `policy.dlp`: **`enabled` force-on**, **`pii` a floor** over off<block a dev can only tighten — unless **locked**.

## Change
- **config/managed.ts:** `DLP_PII_ORDER` + `applyManagedDlp(local, managed, locked)`, reusing the generalized `resolveByOrder`.
- **config/index:** apply `mc.dlp` to `mergedPolicy.dlp` (same block as mode/egress; before shadow/panic).
- **daemon/sync:** `extractManagedConfig` carries nested dlp.

⚠️ **Stacked on the egress PR #226** (needs its `resolveByOrder`) — merge #226 first; this narrows to dlp-only after. Pairs with **node9Firewall #128**. Additive (zero-regression, tested).

## Tests
`applyManagedDlp` (force-on / pii baseline / locked / untouched / unrankable) + `getConfig` integration. **Full suite 3059**, tc/lint clean. `/review-pr` clean.

Design: `doc/roadmap/active/config-home-tech-design.md` (P0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)