### PR TITLE
feat(connect): node9 connect <token> — one-command machine onboarding

### DIFF
--- a/src/__tests__/connect-url.unit.test.ts
+++ b/src/__tests__/connect-url.unit.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { resolveConnectUrl } from '../cli/commands/connect';
+
+describe('resolveConnectUrl', () => {
+  const prev = process.env.NODE9_API_URL;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.NODE9_API_URL;
+    else process.env.NODE9_API_URL = prev;
+  });
+
+  it('uses --api-url when given (wins over env + default)', () => {
+    process.env.NODE9_API_URL = 'https://x/api/v1/intercept';
+    expect(resolveConnectUrl('http://localhost:9/cli/connect')).toBe(
+      'http://localhost:9/cli/connect'
+    );
+  });
+
+  it('derives from NODE9_API_URL by swapping /intercept → /cli/connect', () => {
+    process.env.NODE9_API_URL = 'https://dev-api.node9.ai/api/v1/intercept';
+    expect(resolveConnectUrl()).toBe('https://dev-api.node9.ai/api/v1/cli/connect');
+  });
+
+  it('tolerates a trailing slash on NODE9_API_URL', () => {
+    process.env.NODE9_API_URL = 'https://dev-api.node9.ai/api/v1/intercept/';
+    expect(resolveConnectUrl()).toBe('https://dev-api.node9.ai/api/v1/cli/connect');
+  });
+
+  it('falls back to the prod default when nothing is set', () => {
+    delete process.env.NODE9_API_URL;
+    expect(resolveConnectUrl()).toBe('https://api.node9.ai/api/v1/cli/connect');
+  });
+});

--- a/src/__tests__/connect.integration.test.ts
+++ b/src/__tests__/connect.integration.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { spawn } from 'child_process';
+import * as http from 'http';
+import type { AddressInfo } from 'net';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const CLI = path.resolve(__dirname, '../../dist/cli.js');
+
+// Spawns `dist/cli.js connect <token>` against a local mock of POST /cli/connect.
+// Uses async spawn (NOT spawnSync) so the parent event loop stays free to serve
+// the in-process mock. NODE9_TESTING=1 skips the post-connect cloud sync.
+describe('node9 connect (integration)', () => {
+  let server: http.Server;
+  let port: number;
+  let mode: 'ok' | '401' = 'ok';
+  let tmpHome: string;
+
+  beforeAll(
+    () =>
+      new Promise<void>((resolve) => {
+        server = http.createServer((req, res) => {
+          if (req.method === 'POST' && req.url === '/cli/connect') {
+            if (mode === '401') {
+              res.writeHead(401);
+              res.end('expired');
+              return;
+            }
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(
+              JSON.stringify({
+                apiKey: 'n9_live_test',
+                workspaceId: 'ws-1',
+                workspaceName: 'Acme',
+              })
+            );
+          } else {
+            res.writeHead(404);
+            res.end();
+          }
+        });
+        server.listen(0, '127.0.0.1', () => {
+          port = (server.address() as AddressInfo).port;
+          resolve();
+        });
+      })
+  );
+
+  afterAll(() => new Promise<void>((resolve) => server.close(() => resolve())));
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-connect-'));
+  });
+  afterEach(() => fs.rmSync(tmpHome, { recursive: true, force: true }));
+
+  function runConnect(
+    token: string
+  ): Promise<{ status: number | null; stdout: string; stderr: string }> {
+    return new Promise((resolve) => {
+      const child = spawn(
+        process.execPath,
+        [CLI, 'connect', token, '--api-url', `http://127.0.0.1:${port}/cli/connect`],
+        {
+          env: {
+            ...process.env,
+            NODE9_TESTING: '1',
+            NODE9_NO_AUTO_DAEMON: '1',
+            HOME: tmpHome,
+            USERPROFILE: tmpHome,
+          },
+        }
+      );
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (d) => (stdout += d));
+      child.stderr.on('data', (d) => (stderr += d));
+      child.on('close', (status) => resolve({ status, stdout, stderr }));
+    });
+  }
+
+  const credsPath = () => path.join(tmpHome, '.node9', 'credentials.json');
+
+  it('exchanges a token → writes creds + prints connected', async () => {
+    mode = 'ok';
+    const r = await runConnect('n9_connect_valid');
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/Connected to Acme/);
+    const creds = JSON.parse(fs.readFileSync(credsPath(), 'utf-8'));
+    expect(creds.default.apiKey).toBe('n9_live_test');
+  });
+
+  it('rejects an expired/used token → exit 1, no creds written', async () => {
+    mode = '401';
+    const r = await runConnect('n9_connect_expired');
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/expired or was already used/);
+    expect(fs.existsSync(credsPath())).toBe(false);
+  });
+});

--- a/src/__tests__/credentials.unit.test.ts
+++ b/src/__tests__/credentials.unit.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { writeCredentialsAndConfig } from '../credentials';
+
+describe('writeCredentialsAndConfig', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-creds-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const creds = () =>
+    JSON.parse(fs.readFileSync(path.join(tmp, '.node9', 'credentials.json'), 'utf-8'));
+  const config = () =>
+    JSON.parse(fs.readFileSync(path.join(tmp, '.node9', 'config.json'), 'utf-8'));
+
+  it('writes the default profile key + an approvers config (cloud on)', () => {
+    const r = writeCredentialsAndConfig('n9_live_abc', { homeDir: tmp });
+    expect(r).toEqual({ profileName: 'default', effectiveCloud: true });
+    expect(creds().default.apiKey).toBe('n9_live_abc');
+    expect(config().settings.approvers.cloud).toBe(true);
+  });
+
+  it('--local (isLocal) turns cloud approvals off', () => {
+    const r = writeCredentialsAndConfig('n9_live_abc', { isLocal: true, homeDir: tmp });
+    expect(r.effectiveCloud).toBe(false);
+    expect(config().settings.approvers.cloud).toBe(false);
+  });
+
+  it('a named profile writes creds but not the default config.json', () => {
+    const r = writeCredentialsAndConfig('n9_live_x', { profileName: 'work', homeDir: tmp });
+    expect(r).toEqual({ profileName: 'work', effectiveCloud: null });
+    expect(creds().work.apiKey).toBe('n9_live_x');
+    expect(fs.existsSync(path.join(tmp, '.node9', 'config.json'))).toBe(false);
+  });
+
+  it('merges a new profile alongside an existing one', () => {
+    writeCredentialsAndConfig('k1', { homeDir: tmp });
+    writeCredentialsAndConfig('k2', { profileName: 'work', homeDir: tmp });
+    const c = creds();
+    expect(c.default.apiKey).toBe('k1');
+    expect(c.work.apiKey).toBe('k2');
+  });
+
+  it('migrates the legacy single-key shape into the profile map', () => {
+    fs.mkdirSync(path.join(tmp, '.node9'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, '.node9', 'credentials.json'),
+      JSON.stringify({ apiKey: 'old', apiUrl: 'u' })
+    );
+    writeCredentialsAndConfig('new', { profileName: 'work', homeDir: tmp });
+    const c = creds();
+    expect(c.default.apiKey).toBe('old');
+    expect(c.work.apiKey).toBe('new');
+  });
+});

--- a/src/__tests__/setup-noninteractive.unit.test.ts
+++ b/src/__tests__/setup-noninteractive.unit.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { isNonInteractive } from '../setup';
+
+describe('isNonInteractive (setup prompt guard)', () => {
+  const prev = process.env.NODE9_NONINTERACTIVE;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.NODE9_NONINTERACTIVE;
+    else process.env.NODE9_NONINTERACTIVE = prev;
+  });
+
+  it('is true when NODE9_NONINTERACTIVE=1 (how `connect` forces it)', () => {
+    process.env.NODE9_NONINTERACTIVE = '1';
+    expect(isNonInteractive()).toBe(true);
+  });
+
+  it('is false when the env flag is unset (interactive by default)', () => {
+    delete process.env.NODE9_NONINTERACTIVE;
+    expect(isNonInteractive()).toBe(false);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ import {
 } from './setup';
 import { AGENT_TEARDOWNS, resolveAgentTeardown, agentTeardownTargets } from './agent-teardowns';
 import { getAgentWiring } from './agent-wiring';
+import { writeCredentialsAndConfig } from './credentials';
 import { stopDaemon } from './daemon/index';
 import chalk from 'chalk';
 import fs from 'fs';
@@ -76,62 +77,10 @@ program
   .option('--local', 'Save key for audit/logging only — local config still controls all decisions')
   .option('--profile <name>', 'Save as a named profile (default: "default")')
   .action((apiKey, options: { local?: boolean; profile?: string }) => {
-    const DEFAULT_API_URL = 'https://api.node9.ai/api/v1/intercept';
-    const credPath = path.join(os.homedir(), '.node9', 'credentials.json');
-    if (!fs.existsSync(path.dirname(credPath)))
-      fs.mkdirSync(path.dirname(credPath), { recursive: true });
-
-    const profileName = options.profile || 'default';
-    let existingCreds: Record<string, unknown> = {};
-    try {
-      if (fs.existsSync(credPath)) {
-        const raw = JSON.parse(fs.readFileSync(credPath, 'utf-8')) as Record<string, unknown>;
-        if (raw.apiKey) {
-          existingCreds = {
-            default: { apiKey: raw.apiKey, apiUrl: raw.apiUrl || DEFAULT_API_URL },
-          };
-        } else {
-          existingCreds = raw;
-        }
-      }
-    } catch {}
-
-    existingCreds[profileName] = { apiKey, apiUrl: DEFAULT_API_URL };
-    fs.writeFileSync(credPath, JSON.stringify(existingCreds, null, 2), { mode: 0o600 });
-
-    let effectiveCloud: boolean | null = null;
-    if (profileName === 'default') {
-      const configPath = path.join(os.homedir(), '.node9', 'config.json');
-      let config: Record<string, unknown> = {};
-      try {
-        if (fs.existsSync(configPath))
-          config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
-      } catch {}
-      if (!config.settings || typeof config.settings !== 'object') config.settings = {};
-      const s = config.settings as Record<string, unknown>;
-      const approvers = (s.approvers as Record<string, unknown>) || {
-        native: true,
-        browser: true,
-        cloud: true,
-        terminal: true,
-      };
-      // Only change cloud setting when --local is explicitly passed.
-      // Without --local, preserve whatever the user had before so that
-      // re-running `node9 login` to refresh an API key doesn't silently
-      // re-enable cloud approvals for users who had turned them off.
-      if (options.local) {
-        approvers.cloud = false;
-      }
-      s.approvers = approvers;
-      if (!fs.existsSync(path.dirname(configPath)))
-        fs.mkdirSync(path.dirname(configPath), { recursive: true });
-      fs.writeFileSync(configPath, JSON.stringify(config, null, 2), { mode: 0o600 });
-      // What is ACTUALLY in effect after the write. A pre-existing
-      // approvers object with cloud:false (or missing — the merged default
-      // is false) stays off; the success message must say so instead of
-      // claiming "agent mode" while nothing syncs.
-      effectiveCloud = approvers.cloud === true;
-    }
+    const { profileName, effectiveCloud } = writeCredentialsAndConfig(apiKey, {
+      profileName: options.profile,
+      isLocal: options.local,
+    });
 
     if (options.profile && profileName !== 'default') {
       console.log(chalk.green(`✅ Profile "${profileName}" saved`));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,6 +43,7 @@ import { registerReportCommand } from './cli/commands/report';
 import { registerDaemonCommand } from './cli/commands/daemon-cmd';
 import { registerStatusCommand } from './cli/commands/status';
 import { registerInitCommand } from './cli/commands/init';
+import { registerConnectCommand } from './cli/commands/connect';
 import { registerUndoCommand } from './cli/commands/undo';
 import { registerMcpGatewayCommand } from './cli/commands/mcp-gateway';
 import { registerMcpServerCommand } from './cli/commands/mcp-server';
@@ -443,6 +444,7 @@ program
 
 // 3. INIT
 registerInitCommand(program);
+registerConnectCommand(program);
 
 // 4. AUDIT
 registerAuditCommand(program);

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -1,0 +1,130 @@
+import type { Command } from 'commander';
+import http from 'http';
+import https from 'https';
+import { URL } from 'url';
+import chalk from 'chalk';
+import { writeCredentialsAndConfig } from '../../credentials';
+import { setupDetectedAgents } from '../../setup';
+import { runCloudSync } from '../../daemon/sync';
+import { isTestingMode } from '../daemon-starter';
+
+// node9 connect <token> — the onboarding bridge. Exchanges a dashboard connect
+// token for a workspace key (POST /cli/connect), writes credentials + config,
+// wires detected agents non-interactively, and fires one sync so the machine
+// shows up in the dashboard. No raw key is ever copy-pasted by the user.
+const DEFAULT_CONNECT_URL = 'https://api.node9.ai/api/v1/cli/connect';
+
+interface ConnectResponse {
+  apiKey: string;
+  workspaceId: string;
+  workspaceName: string;
+}
+
+// --api-url wins; else derive from NODE9_API_URL (the intercept base) so a dev
+// pointing the daemon at staging also connects there; else prod default.
+export function resolveConnectUrl(apiUrl?: string): string {
+  if (apiUrl) return apiUrl;
+  const base = process.env.NODE9_API_URL;
+  if (base) return base.replace(/\/intercept\/?$/, '') + '/cli/connect';
+  return DEFAULT_CONNECT_URL;
+}
+
+function postConnect(url: string, token: string): Promise<ConnectResponse> {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify({ token });
+    const u = new URL(url);
+    const lib = u.protocol === 'http:' ? http : https;
+    const req = lib.request(
+      {
+        method: 'POST',
+        hostname: u.hostname,
+        port: u.port || (u.protocol === 'http:' ? 80 : 443),
+        path: u.pathname + u.search,
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+        },
+        timeout: 15000,
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (c) => (data += c));
+        res.on('end', () => {
+          const code = res.statusCode ?? 0;
+          if (code >= 200 && code < 300) {
+            try {
+              resolve(JSON.parse(data) as ConnectResponse);
+            } catch {
+              reject(new Error('Unexpected response from the server.'));
+            }
+          } else if (code === 400 || code === 401) {
+            reject(
+              new Error(
+                'This connect link expired or was already used — generate a new one in the dashboard.'
+              )
+            );
+          } else {
+            reject(new Error(`Connect failed (HTTP ${code}).`));
+          }
+        });
+      }
+    );
+    req.on('error', (e) => reject(e));
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('Connection timed out.'));
+    });
+    req.write(body);
+    req.end();
+  });
+}
+
+export function registerConnectCommand(program: Command): void {
+  program
+    .command('connect')
+    .argument('<token>', 'A connect token from the dashboard')
+    .option('--profile <name>', 'Save as a named profile (default: "default")')
+    .option('--api-url <url>', 'Override the connect endpoint (self-host / dev)')
+    .description('Connect this machine to a node9 workspace using a dashboard token')
+    .action(async (token: string, options: { profile?: string; apiUrl?: string }) => {
+      let resp: ConnectResponse;
+      try {
+        resp = await postConnect(resolveConnectUrl(options.apiUrl), token);
+      } catch (e) {
+        console.error(chalk.red(`✗ ${e instanceof Error ? e.message : 'Connect failed.'}`));
+        process.exitCode = 1;
+        return;
+      }
+
+      // Reuse login's writer (credentials.json + config.json approvers).
+      writeCredentialsAndConfig(resp.apiKey, { profileName: options.profile });
+
+      // Wire detected agents without prompting (curl | sh has no TTY).
+      process.env.NODE9_NONINTERACTIVE = '1';
+      let wired: string[] = [];
+      try {
+        wired = await setupDetectedAgents();
+      } catch {
+        // Agent wiring is best-effort; the connection itself already succeeded.
+      }
+
+      // Register the machine with the cloud so the dashboard shows it. Skipped
+      // under the test runner (no live cloud).
+      if (!isTestingMode()) {
+        try {
+          await runCloudSync();
+        } catch {
+          // Best-effort — the first hook call will sync anyway.
+        }
+      }
+
+      console.log(chalk.green(`✅ Connected to ${resp.workspaceName}`));
+      if (wired.length) {
+        console.log(chalk.gray(`   Wired: ${wired.join(', ')}`));
+      } else {
+        console.log(
+          chalk.gray('   No agents detected yet — run `node9 init` after installing one.')
+        );
+      }
+    });
+}

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -7,22 +7,7 @@ import path from 'path';
 import os from 'os';
 import https from 'https';
 import { DEFAULT_CONFIG } from '../../core';
-import {
-  setupClaude,
-  setupGemini,
-  setupAntigravity,
-  setupCopilot,
-  setupCursor,
-  setupCodex,
-  setupWindsurf,
-  setupVSCode,
-  setupClaudeDesktop,
-  setupOpencode,
-  setupPi,
-  setupHermes,
-  detectAgents,
-  node9Version,
-} from '../../setup';
+import { setupAgent, detectAgents, node9Version } from '../../setup';
 import { readActiveShields, writeActiveShields, migrateRenamedRuleKeys } from '../../shields';
 import { installDaemonService, isDaemonServiceInstalled } from '../../daemon/service';
 import { autoStartDaemonAndWait, isTestingMode } from '../daemon-starter';
@@ -240,18 +225,7 @@ export function registerInitCommand(program: Command): void {
 
         for (const agent of found) {
           console.log(chalk.bold(`Wiring ${agent}...`));
-          if (agent === 'claude') await setupClaude();
-          else if (agent === 'gemini') await setupGemini();
-          else if (agent === 'antigravity') await setupAntigravity();
-          else if (agent === 'copilot') await setupCopilot();
-          else if (agent === 'cursor') await setupCursor();
-          else if (agent === 'codex') await setupCodex();
-          else if (agent === 'windsurf') await setupWindsurf();
-          else if (agent === 'vscode') await setupVSCode();
-          else if (agent === 'claudeDesktop') await setupClaudeDesktop();
-          else if (agent === 'opencode') await setupOpencode();
-          else if (agent === 'pi') await setupPi();
-          else if (agent === 'hermes') setupHermes();
+          await setupAgent(agent);
           console.log('');
         }
 

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1,0 +1,78 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Shared credential + config writer — used by both `node9 login` and the
+// onboarding `node9 connect`. Writes ~/.node9/credentials.json (profile-merged,
+// 0o600) and, for the default profile, the ~/.node9/config.json approvers block.
+// Returns the effective cloud state so callers can print the right message.
+const DEFAULT_API_URL = 'https://api.node9.ai/api/v1/intercept';
+
+export function writeCredentialsAndConfig(
+  apiKey: string,
+  opts: { profileName?: string; isLocal?: boolean; homeDir?: string } = {}
+): { profileName: string; effectiveCloud: boolean | null } {
+  const profileName = opts.profileName || 'default';
+  const home = opts.homeDir ?? os.homedir();
+
+  const credPath = path.join(home, '.node9', 'credentials.json');
+  if (!fs.existsSync(path.dirname(credPath))) {
+    fs.mkdirSync(path.dirname(credPath), { recursive: true });
+  }
+  let existingCreds: Record<string, unknown> = {};
+  try {
+    if (fs.existsSync(credPath)) {
+      const raw = JSON.parse(fs.readFileSync(credPath, 'utf-8')) as Record<string, unknown>;
+      // Migrate the legacy single-key shape into the profile map.
+      existingCreds = raw.apiKey
+        ? { default: { apiKey: raw.apiKey, apiUrl: raw.apiUrl || DEFAULT_API_URL } }
+        : raw;
+    }
+  } catch {
+    // Corrupt creds file — overwrite rather than fail the login/connect.
+  }
+  existingCreds[profileName] = { apiKey, apiUrl: DEFAULT_API_URL };
+  fs.writeFileSync(credPath, JSON.stringify(existingCreds, null, 2), {
+    mode: 0o600,
+  });
+
+  // The approvers block lives on the default profile only.
+  let effectiveCloud: boolean | null = null;
+  if (profileName === 'default') {
+    const configPath = path.join(home, '.node9', 'config.json');
+    let config: Record<string, unknown> = {};
+    try {
+      if (fs.existsSync(configPath)) {
+        config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+      }
+    } catch {
+      // Corrupt config — start fresh.
+    }
+    if (!config.settings || typeof config.settings !== 'object') {
+      config.settings = {};
+    }
+    const s = config.settings as Record<string, unknown>;
+    const approvers = (s.approvers as Record<string, unknown>) || {
+      native: true,
+      browser: true,
+      cloud: true,
+      terminal: true,
+    };
+    // Only force cloud off when --local is explicit; otherwise preserve the
+    // user's prior choice (re-running login to refresh a key must not silently
+    // re-enable cloud approvals for someone who turned them off).
+    if (opts.isLocal) {
+      approvers.cloud = false;
+    }
+    s.approvers = approvers;
+    if (!fs.existsSync(path.dirname(configPath))) {
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    }
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), {
+      mode: 0o600,
+    });
+    effectiveCloud = approvers.cloud === true;
+  }
+
+  return { profileName, effectiveCloud };
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -3,12 +3,54 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import chalk from 'chalk';
-import { confirm } from '@inquirer/prompts';
+import { confirm as rawConfirm } from '@inquirer/prompts';
 import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
 import * as yaml from 'yaml';
 import { seedMcpPinsIfMissing } from './mcp-pin';
 import { renderOpencodeShim } from './setup-opencode-shim';
 import { renderPiShim } from './setup-pi-shim';
+
+// Non-interactive guard for setup prompts. Under `curl | sh` (no TTY) or when a
+// caller (e.g. `node9 connect`, or an installer one-liner) sets
+// NODE9_NONINTERACTIVE=1, every confirm() resolves to its declared `default`
+// instead of hanging on stdin. Every prompt's default is the safe choice
+// (wrap=true; remove-legacy-hooks=false), so this preserves intent while making
+// setup runnable unattended. Gated on the explicit flag only — a missing TTY is
+// NOT a reliable signal (test runners lack one).
+export function isNonInteractive(): boolean {
+  return process.env.NODE9_NONINTERACTIVE === '1';
+}
+async function confirm(opts: { message: string; default?: boolean }): Promise<boolean> {
+  if (isNonInteractive()) return opts.default ?? false;
+  return rawConfirm(opts);
+}
+
+// Wire one agent by key (the dispatch shared by `init` and `connect`).
+export async function setupAgent(agent: string): Promise<void> {
+  if (agent === 'claude') await setupClaude();
+  else if (agent === 'gemini') await setupGemini();
+  else if (agent === 'antigravity') await setupAntigravity();
+  else if (agent === 'copilot') await setupCopilot();
+  else if (agent === 'cursor') await setupCursor();
+  else if (agent === 'codex') await setupCodex();
+  else if (agent === 'windsurf') await setupWindsurf();
+  else if (agent === 'vscode') await setupVSCode();
+  else if (agent === 'claudeDesktop') await setupClaudeDesktop();
+  else if (agent === 'opencode') await setupOpencode();
+  else if (agent === 'pi') await setupPi();
+  else if (agent === 'hermes') setupHermes();
+}
+
+// Detect installed agents and wire each (non-interactive when the caller sets
+// NODE9_NONINTERACTIVE / there's no TTY). Returns the wired agent keys.
+export async function setupDetectedAgents(): Promise<string[]> {
+  const detected = detectAgents();
+  const found = (Object.keys(detected) as Array<keyof typeof detected>).filter((k) => detected[k]);
+  for (const agent of found) {
+    await setupAgent(agent as string);
+  }
+  return found;
+}
 
 interface McpServer {
   type?: string;


### PR DESCRIPTION
Phase 2 of the onboarding install→connect bridge (design: `node9Firewall doc/roadmap/active/onboarding-connect-flow-tech-design.md`). Adds **`node9 connect <token>`** — one command replaces the manual "copy 64-char key → `node9 login <key>` → `node9 setup`" dance, and **the raw API key never touches a human**.

## What it does
`node9 connect <token>`:
1. Exchanges the dashboard connect token for a workspace key — `POST /api/v1/cli/connect` (Phase 1, firewall).
2. Writes `credentials.json` + the `config.json` approvers block (shared `login` writer).
3. Wires detected agents **non-interactively** (`NODE9_NONINTERACTIVE` → `confirm()` resolves to safe defaults, so `curl | sh` doesn't hang).
4. Fires one cloud sync so the machine shows up in the dashboard.
5. Prints `✅ Connected to <workspace>`; clean error on an expired/used token (no creds written).

## Structure (3 enabling refactors + the command)
- `refactor`: factored `writeCredentialsAndConfig()` out of `login` (behavior-preserving) so `connect` reuses it.
- `feat(setup)`: non-interactive guard on the only prompt type (`confirm`); extracted `setupAgent()` / `setupDetectedAgents()` from `init`'s inline loop (init now shares it).
- `feat(connect)`: the command + `resolveConnectUrl` (`--api-url` > `NODE9_API_URL`-derived > prod default) + protocol-aware HTTP.

## Tests
`credentials` unit (5), non-interactive guard (2), `resolveConnectUrl` (4), and **`connect` integration (2: happy + expired)** — spawns `dist/cli.js` against a mock server (async spawn so the in-process mock can serve; network-free via `NODE9_TESTING`). Full suite **3072** green; tc/lint/format clean.

## ⚠️ Dependency
`connect` POSTs to `/api/v1/cli/connect`, which only exists in prod once the **firewall Phase 1** ships to `main` (currently on dev, PR node9Firewall#131). The command is shippable now but the end-to-end loop needs that endpoint live.

Next: the `get.node9.ai` installer one-liner + the dashboard Connect-CLI panel (one-liner + live "Connected ✓").

🤖 Generated with [Claude Code](https://claude.com/claude-code)