### PR TITLE
feat(egress): apply dashboard-managed egress allowlist/deny/allowPrivate

### DIFF
--- a/src/__tests__/managed.test.ts
+++ b/src/__tests__/managed.test.ts
@@ -6,7 +6,15 @@ import {
   applyManagedDlp,
 } from '../config/managed';
 
-const localEgress = (over: Partial<{ enabled: boolean; mode: string }> = {}) => ({
+const localEgress = (
+  over: Partial<{
+    enabled: boolean;
+    mode: string;
+    allow: string[];
+    deny: string[];
+    allowPrivate: boolean;
+  }> = {}
+) => ({
   enabled: false,
   mode: 'review',
   allow: ['local.example.com'],
@@ -100,6 +108,50 @@ describe('managed egress (baseline+lock) — M2b', () => {
   it('ignores an unrankable managed egress mode', () => {
     const out = applyManagedEgress(localEgress({ mode: 'block' }), { mode: 'garbage' }, []);
     expect(out.mode).toBe('block');
+  });
+
+  it('allow: a managed allowlist REPLACES the local one (org owns it)', () => {
+    const out = applyManagedEgress(localEgress(), { allow: ['api.node9.ai'] }, []);
+    expect(out.allow).toEqual(['api.node9.ai']);
+  });
+
+  it('allow: an empty managed allowlist leaves the local one untouched', () => {
+    const out = applyManagedEgress(localEgress(), { allow: [] }, []);
+    expect(out.allow).toEqual(['local.example.com']);
+  });
+
+  it('deny: a managed denylist UNIONS with the local one (tightens)', () => {
+    const out = applyManagedEgress(
+      localEgress({ deny: ['bad.local'] }),
+      { deny: ['evil.example.com', 'bad.local'] },
+      []
+    );
+    expect(out.deny.sort()).toEqual(['bad.local', 'evil.example.com']);
+  });
+
+  it('allowPrivate: a managed false forces private access off', () => {
+    const out = applyManagedEgress(
+      localEgress({ allowPrivate: true }),
+      { allowPrivate: false },
+      []
+    );
+    expect(out.allowPrivate).toBe(false);
+  });
+
+  it('allowPrivate: a managed true leaves a stricter local false', () => {
+    const out = applyManagedEgress(
+      localEgress({ allowPrivate: false }),
+      { allowPrivate: true },
+      []
+    );
+    expect(out.allowPrivate).toBe(false);
+  });
+
+  it('allowPrivate: a locked value wins outright', () => {
+    const out = applyManagedEgress(localEgress({ allowPrivate: false }), { allowPrivate: true }, [
+      'egressAllowPrivate',
+    ]);
+    expect(out.allowPrivate).toBe(true);
   });
 });
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -728,7 +728,13 @@ export function getConfig(cwd?: string): Config {
       if (raw.managedConfig && typeof raw.managedConfig === 'object') {
         const mc = raw.managedConfig as {
           mode?: unknown;
-          egress?: { enabled?: unknown; mode?: unknown };
+          egress?: {
+            enabled?: unknown;
+            mode?: unknown;
+            allow?: unknown;
+            deny?: unknown;
+            allowPrivate?: unknown;
+          };
           dlp?: { enabled?: unknown; pii?: unknown };
           locked?: unknown;
         };
@@ -743,14 +749,20 @@ export function getConfig(cwd?: string): Config {
             locked.includes('mode')
           );
         }
-        // M2b: policy.egress (a policy field, not a setting). enabled is
-        // force-on; mode is off<review<block. The allowlist is NOT managed.
+        // M2b + Step 2: policy.egress. enabled force-on; mode off<review<block;
+        // allow replaces local; deny unions; allowPrivate floor boolean.
         if (mc.egress && typeof mc.egress === 'object') {
+          const hosts = (v: unknown): string[] | undefined =>
+            Array.isArray(v) ? v.filter((h): h is string => typeof h === 'string') : undefined;
           mergedPolicy.egress = applyManagedEgress(
             mergedPolicy.egress,
             {
               enabled: typeof mc.egress.enabled === 'boolean' ? mc.egress.enabled : undefined,
               mode: typeof mc.egress.mode === 'string' ? mc.egress.mode : undefined,
+              allow: hosts(mc.egress.allow),
+              deny: hosts(mc.egress.deny),
+              allowPrivate:
+                typeof mc.egress.allowPrivate === 'boolean' ? mc.egress.allowPrivate : undefined,
             },
             locked
           );

--- a/src/config/managed.ts
+++ b/src/config/managed.ts
@@ -45,28 +45,37 @@ export function resolveManagedMode(local: string, cloud: string, locked: boolean
   return resolveByOrder(MODE_ORDER, local, cloud, locked);
 }
 
-// The managed-egress fields the proxy applies (M2b). `enabled` is force-on only
-// (false is the weakest, so it's never a meaningful floor); `mode` is ordered.
-// The allowlist is intentionally NOT managed here — it LOOSENS access (adds
-// reachable hosts), which doesn't fit "baseline = only tighten"; deferred.
+// The managed-egress fields the proxy applies (M2b + Step 2 lists). `enabled` is
+// force-on; `mode` is ordered; `allow` REPLACES the local allowlist (the org owns
+// it — a dev can't widen past it); `deny` UNIONS with local (only tightens);
+// `allowPrivate` is a floor boolean (managed `false` forces private nets off).
 export interface ManagedEgress {
   enabled?: boolean;
   mode?: string;
+  allow?: string[];
+  deny?: string[];
+  allowPrivate?: boolean;
 }
 /**
  * Apply managed egress to the machine's local egress object (baseline+lock).
  *  - enabled: force-on — locked → cloud value; else `local || cloud` (a managed
  *    `true` turns egress on; a dev can't turn a managed-on egress off).
  *  - mode: resolveByOrder over off<review<block.
+ *  - allow: managed list, when non-empty, REPLACES local (org owns the allowlist).
+ *  - deny: union of local + managed (always tightens).
+ *  - allowPrivate: locked → cloud; else `local && managed` so a managed `false`
+ *    forces private access off, while `true` leaves the dev's stricter choice.
  * Generic over the local egress type so the precise caller type is preserved.
- * Returns a NEW object; untouched local fields (allow/deny/allowPrivate) carry
- * through unchanged.
  */
-export function applyManagedEgress<T extends { enabled: boolean; mode: string }>(
-  local: T,
-  managed: ManagedEgress,
-  locked: string[]
-): T {
+export function applyManagedEgress<
+  T extends {
+    enabled: boolean;
+    mode: string;
+    allow?: string[];
+    deny?: string[];
+    allowPrivate?: boolean;
+  },
+>(local: T, managed: ManagedEgress, locked: string[]): T {
   const next: T = { ...local };
   if (typeof managed.enabled === 'boolean') {
     next.enabled = locked.includes('egressEnabled')
@@ -80,6 +89,19 @@ export function applyManagedEgress<T extends { enabled: boolean; mode: string }>
       managed.mode,
       locked.includes('egressMode')
     ) as T['mode'];
+  }
+  if (Array.isArray(managed.allow) && managed.allow.length > 0) {
+    next.allow = [...managed.allow] as T['allow'];
+  }
+  if (Array.isArray(managed.deny) && managed.deny.length > 0) {
+    next.deny = [...new Set([...(local.deny ?? []), ...managed.deny])] as T['deny'];
+  }
+  if (typeof managed.allowPrivate === 'boolean') {
+    next.allowPrivate = (
+      locked.includes('egressAllowPrivate')
+        ? managed.allowPrivate
+        : (local.allowPrivate ?? true) && managed.allowPrivate
+    ) as T['allowPrivate'];
   }
   return next;
 }

--- a/src/daemon/sync.ts
+++ b/src/daemon/sync.ts
@@ -155,7 +155,13 @@ export interface RulesCache {
 /** Cloud-managed settings persisted in the cache (M2: mode + egress + dlp). */
 export interface ManagedConfigCache {
   mode?: string;
-  egress?: { enabled?: boolean; mode?: string };
+  egress?: {
+    enabled?: boolean;
+    mode?: string;
+    allow?: string[];
+    deny?: string[];
+    allowPrivate?: boolean;
+  };
   dlp?: { enabled?: boolean; pii?: string };
   locked: string[];
 }
@@ -176,7 +182,13 @@ interface CloudPolicyBody {
   shields?: unknown[]; // cloud-managed shield names (Managed Config M1)
   managedConfig?: {
     mode?: unknown;
-    egress?: { enabled?: unknown; mode?: unknown };
+    egress?: {
+      enabled?: unknown;
+      mode?: unknown;
+      allow?: unknown;
+      deny?: unknown;
+      allowPrivate?: unknown;
+    };
     dlp?: { enabled?: unknown; pii?: unknown };
     locked?: unknown;
   }; // M2 settings
@@ -374,12 +386,30 @@ export function extractManagedConfig(body: CloudPolicyBody): ManagedConfigCache 
       : [],
   };
   if (typeof mc.mode === 'string') out.mode = mc.mode;
-  // M2b: egress.enabled (bool) + egress.mode (string). Allowlist not managed.
+  // M2b + Step 2: egress.enabled (bool) + mode (string) + allow/deny (string[])
+  // + allowPrivate (bool).
   if (mc.egress && typeof mc.egress === 'object') {
-    const e: { enabled?: boolean; mode?: string } = {};
+    const e: ManagedConfigCache['egress'] = {};
     if (typeof mc.egress.enabled === 'boolean') e.enabled = mc.egress.enabled;
     if (typeof mc.egress.mode === 'string') e.mode = mc.egress.mode;
-    if (e.enabled !== undefined || e.mode !== undefined) out.egress = e;
+    const cleanHosts = (v: unknown): string[] =>
+      Array.isArray(v) ? v.filter((h): h is string => typeof h === 'string') : [];
+    const allow = cleanHosts(mc.egress.allow);
+    const deny = cleanHosts(mc.egress.deny);
+    if (allow.length) e.allow = allow;
+    if (deny.length) e.deny = deny;
+    if (typeof mc.egress.allowPrivate === 'boolean') {
+      e.allowPrivate = mc.egress.allowPrivate;
+    }
+    if (
+      e.enabled !== undefined ||
+      e.mode !== undefined ||
+      e.allow !== undefined ||
+      e.deny !== undefined ||
+      e.allowPrivate !== undefined
+    ) {
+      out.egress = e;
+    }
   }
   // M2c: dlp.enabled (bool) + dlp.pii (string).
   if (mc.dlp && typeof mc.dlp === 'object') {


### PR DESCRIPTION
Proxy companion to node9Firewall egress Step 2. Applies the managed egress fields the dashboard now sends:
- **allow** REPLACES local (org owns the allowlist; dev can't widen past it)
- **deny** unions with local (tightens)
- **allowPrivate** floor boolean (managed `false` forces private nets off; locked → cloud)

Wired through extractManagedConfig → ManagedConfigCache → applyManagedEgress with host sanitization. 26 managed tests, tc/lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)