### PR TITLE
fix(setup): preserve a user's Claude statusLine on init & uninstall (#186)

### DIFF
--- a/src/__tests__/setup.test.ts
+++ b/src/__tests__/setup.test.ts
@@ -24,6 +24,8 @@ import {
   teardownOpencode,
   teardownPi,
   teardownHermes,
+  teardownHud,
+  isNode9StatusLine,
   detectAgents,
 } from '../setup.js';
 
@@ -159,6 +161,20 @@ describe('setupClaude', () => {
     const written = writtenTo(hooksPath);
     expect(written).not.toBeNull(); // hooks were added → file written
     expect(written.statusLine).toEqual(userStatusLine); // preserved, NOT replaced by node9 HUD
+  });
+
+  // Ownership check must be precise: a user statusLine whose command merely
+  // CONTAINS "node9" (e.g. in a path) but isn't the node9 HUD must be preserved.
+  it('preserves a non-node9 statusLine even when its command contains "node9"', async () => {
+    const userStatusLine = { type: 'command', command: '/home/node9dev/.local/bin/mystatusline' };
+    withExistingFiles({
+      [hooksPath]: { statusLine: userStatusLine },
+      [mcpPath]: { mcpServers: { node9: NODE9_MCP_ENTRY } },
+    });
+    await setupClaude();
+    const written = writtenTo(hooksPath);
+    expect(written).not.toBeNull();
+    expect(written.statusLine).toEqual(userStatusLine);
   });
 
   it('does not re-add UserPromptSubmit hook if already present', async () => {
@@ -408,6 +424,54 @@ describe('setupHud', () => {
     setupHud();
     const written = writtenTo(hooksPath);
     expect(String(written.statusLine.command)).toContain('hud');
+  });
+});
+
+// ── teardownHud (remove side) ─────────────────────────────────────────────────
+
+describe('teardownHud', () => {
+  const hooksPath = path.join(os.homedir(), '.claude', 'settings.json');
+
+  it('removes node9 HUD from statusLine', () => {
+    withExistingFiles({ [hooksPath]: { statusLine: { type: 'command', command: 'node9 hud' } } });
+    teardownHud();
+    const written = writtenTo(hooksPath);
+    expect(written).not.toBeNull();
+    expect(written.statusLine).toBeUndefined(); // node9's HUD removed
+  });
+
+  it('preserves a non-node9 statusLine (must NOT delete ccstatusline)', () => {
+    const userStatusLine = { type: 'command', command: 'npx -y ccstatusline@latest' };
+    withExistingFiles({ [hooksPath]: { statusLine: userStatusLine } });
+    teardownHud();
+    expect(writtenTo(hooksPath)).toBeNull(); // returned early → nothing written → preserved
+  });
+
+  it('does not delete a non-node9 statusLine that merely contains "node9"', () => {
+    const userStatusLine = { type: 'command', command: '/home/node9dev/.local/bin/mystatusline' };
+    withExistingFiles({ [hooksPath]: { statusLine: userStatusLine } });
+    teardownHud();
+    expect(writtenTo(hooksPath)).toBeNull(); // preserved
+  });
+});
+
+// ── isNode9StatusLine (shared ownership check) ────────────────────────────────
+
+describe('isNode9StatusLine', () => {
+  it('true for node9 HUD command shapes', () => {
+    expect(isNode9StatusLine('node9 hud')).toBe(true);
+    expect(isNode9StatusLine('"/usr/local/bin/node9" hud')).toBe(true);
+    expect(isNode9StatusLine('"/usr/bin/node" "/x/node9-proxy/dist/cli.js" hud')).toBe(true);
+  });
+  it('false for a user statusLine with no node9', () => {
+    expect(isNode9StatusLine('npx -y ccstatusline@latest')).toBe(false);
+  });
+  it('false for a non-hud command that merely contains "node9" (the edge)', () => {
+    expect(isNode9StatusLine('/home/node9dev/.local/bin/mystatusline')).toBe(false);
+  });
+  it('false for undefined/empty', () => {
+    expect(isNode9StatusLine(undefined)).toBe(false);
+    expect(isNode9StatusLine('')).toBe(false);
   });
 });
 

--- a/src/__tests__/setup.test.ts
+++ b/src/__tests__/setup.test.ts
@@ -14,6 +14,7 @@ import {
   setupOpencode,
   setupPi,
   setupHermes,
+  setupHud,
   teardownClaude,
   teardownGemini,
   teardownAntigravity,
@@ -142,6 +143,22 @@ describe('setupClaude', () => {
     const written = writtenTo(hooksPath);
     expect(written.hooks.UserPromptSubmit).toBeDefined();
     expect(written.hooks.UserPromptSubmit[0].hooks[0].command).toBe('node9 check');
+  });
+
+  // Regression: `node9 init` must NOT overwrite a statusLine it didn't set.
+  // A user with e.g. ccstatusline who ran `node9 init` had it silently replaced
+  // by node9's HUD — and then lost entirely on uninstall. node9 must leave a
+  // non-node9 statusLine alone.
+  it('preserves a non-node9 statusLine instead of clobbering it (ccstatusline)', async () => {
+    const userStatusLine = { type: 'command', command: 'npx -y ccstatusline@latest' };
+    withExistingFiles({
+      [hooksPath]: { statusLine: userStatusLine }, // user's statusLine, no node9 hooks yet
+      [mcpPath]: { mcpServers: { node9: NODE9_MCP_ENTRY } }, // node9 MCP present → no wrap prompt
+    });
+    await setupClaude();
+    const written = writtenTo(hooksPath);
+    expect(written).not.toBeNull(); // hooks were added → file written
+    expect(written.statusLine).toEqual(userStatusLine); // preserved, NOT replaced by node9 HUD
   });
 
   it('does not re-add UserPromptSubmit hook if already present', async () => {
@@ -371,6 +388,26 @@ describe('setupClaude', () => {
     const allOutput = consoleSpy.mock.calls.map(([msg]) => String(msg)).join('\n');
     expect(allOutput).not.toMatch(/--openui/);
     consoleSpy.mockRestore();
+  });
+});
+
+// ── setupHud ─────────────────────────────────────────────────────────────────
+
+describe('setupHud', () => {
+  const hooksPath = path.join(os.homedir(), '.claude', 'settings.json');
+
+  it('does not overwrite a user-set (non-node9) statusLine', () => {
+    const userStatusLine = { type: 'command', command: 'npx -y ccstatusline@latest' };
+    withExistingFiles({ [hooksPath]: { statusLine: userStatusLine } });
+    setupHud();
+    expect(writtenTo(hooksPath)).toBeNull(); // nothing written → the user's statusLine is preserved
+  });
+
+  it('sets the node9 HUD when no statusLine exists', () => {
+    withExistingFiles({ [hooksPath]: {} });
+    setupHud();
+    const written = writtenTo(hooksPath);
+    expect(String(written.statusLine.command)).toContain('hud');
   });
 });
 

--- a/src/__tests__/uninstall.integration.test.ts
+++ b/src/__tests__/uninstall.integration.test.ts
@@ -79,4 +79,39 @@ describe('node9 uninstall — removes plugin-shim agents (Opencode + Pi)', () =>
     expect(r.stdout).toMatch(/no node9 hooks or plugin shims remain/i);
     fs.rmSync(h, { recursive: true, force: true });
   });
+
+  // Full-flow regression for the statusLine bug: uninstall must remove node9's
+  // hooks but NEVER delete a statusLine the user set (e.g. ccstatusline). #186.
+  it('uninstall removes node9 hooks but preserves a user statusLine', () => {
+    const h = makeHome();
+    const settingsPath = path.join(h, '.claude', 'settings.json');
+    const userStatusLine = { type: 'command', command: 'npx -y ccstatusline@latest' };
+    write(
+      settingsPath,
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [{ matcher: '*', hooks: [{ type: 'command', command: 'node9 check' }] }],
+          PostToolUse: [{ matcher: '*', hooks: [{ type: 'command', command: 'node9 log' }] }],
+        },
+        statusLine: userStatusLine,
+      })
+    );
+    const r = run(h, ['uninstall']);
+    expect(r.status).toBe(0);
+    const after = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    expect(after.statusLine).toEqual(userStatusLine); // user's statusLine preserved
+    expect(JSON.stringify(after.hooks ?? {})).not.toContain('node9'); // node9 hooks removed
+    fs.rmSync(h, { recursive: true, force: true });
+  });
+
+  it("uninstall removes node9's own HUD from statusLine", () => {
+    const h = makeHome();
+    const settingsPath = path.join(h, '.claude', 'settings.json');
+    write(settingsPath, JSON.stringify({ statusLine: { type: 'command', command: 'node9 hud' } }));
+    const r = run(h, ['uninstall']);
+    expect(r.status).toBe(0);
+    const after = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    expect(after.statusLine).toBeUndefined(); // node9 HUD removed
+    fs.rmSync(h, { recursive: true, force: true });
+  });
 });

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -565,7 +565,12 @@ export async function setupClaude(): Promise<void> {
     | undefined;
   const existingStatusCommand =
     typeof existingStatusLine === 'object' ? existingStatusLine?.command : existingStatusLine;
-  if (existingStatusCommand !== hudCommand) {
+  // Only set node9's HUD when there's no statusLine yet, or the existing one is
+  // already node9's (e.g. self-heal a stale path). NEVER overwrite a statusLine
+  // the user set themselves (e.g. ccstatusline) — silently doing so destroys
+  // their config, and uninstall then leaves them with nothing.
+  const isNode9OrEmpty = !existingStatusCommand || String(existingStatusCommand).includes('node9');
+  if (isNode9OrEmpty && existingStatusCommand !== hudCommand) {
     settings.statusLine = statusLineObj as unknown as string;
     hooksChanged = true;
     anythingChanged = true;
@@ -1827,13 +1832,18 @@ export function setupHud(): void {
     return;
   }
 
-  if (existing && existingCommand !== hudCommand) {
+  // Never overwrite a statusLine the user set themselves (e.g. ccstatusline).
+  // Only set node9's HUD when the slot is empty or already a node9 HUD (stale
+  // path → self-heal). Otherwise leave it and tell the user how to opt in.
+  if (existing && existingCommand !== hudCommand && !String(existingCommand).includes('node9')) {
     console.log(
       chalk.yellow(
         `  ⚠️  statusLine is already set to: "${existingCommand}"\n` +
-          `     Overwriting with node9 HUD.`
+          `     Leaving it as-is — node9 won't overwrite a statusLine you configured.\n` +
+          `     Remove it from ~/.claude/settings.json first if you want the node9 HUD.`
       )
     );
+    return;
   }
 
   settings.statusLine = statusLineObj as unknown as string;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -178,6 +178,19 @@ function toForwardSlashes(p: string): string {
 }
 
 /**
+ * True if `command` is a node9 HUD statusLine command — across install shapes
+ * (`node9 hud`, a global binary path, dev `node cli.js hud`, or a stale path).
+ * Used so node9 only ever sets/removes ITS OWN statusLine and never touches one
+ * the user configured (e.g. ccstatusline). Tighter than a bare `includes('node9')`
+ * so a user statusLine that merely contains "node9" in its path isn't clobbered. (#186)
+ */
+export function isNode9StatusLine(command: string | undefined): boolean {
+  if (!command) return false;
+  const c = String(command).trim();
+  return c.includes('node9') && /(^|\s)hud$/.test(c);
+}
+
+/**
  * A previously-installed Node9 hook command can outlive the install that
  * wrote it — `npm uninstall -g node9-ai` deletes the cli.js but leaves the
  * stored command in `~/.claude/settings.json` pointing at a vanished path.
@@ -569,7 +582,7 @@ export async function setupClaude(): Promise<void> {
   // already node9's (e.g. self-heal a stale path). NEVER overwrite a statusLine
   // the user set themselves (e.g. ccstatusline) — silently doing so destroys
   // their config, and uninstall then leaves them with nothing.
-  const isNode9OrEmpty = !existingStatusCommand || String(existingStatusCommand).includes('node9');
+  const isNode9OrEmpty = !existingStatusCommand || isNode9StatusLine(existingStatusCommand);
   if (isNode9OrEmpty && existingStatusCommand !== hudCommand) {
     settings.statusLine = statusLineObj as unknown as string;
     hooksChanged = true;
@@ -1835,7 +1848,7 @@ export function setupHud(): void {
   // Never overwrite a statusLine the user set themselves (e.g. ccstatusline).
   // Only set node9's HUD when the slot is empty or already a node9 HUD (stale
   // path → self-heal). Otherwise leave it and tell the user how to opt in.
-  if (existing && existingCommand !== hudCommand && !String(existingCommand).includes('node9')) {
+  if (existing && existingCommand !== hudCommand && !isNode9StatusLine(existingCommand)) {
     console.log(
       chalk.yellow(
         `  ⚠️  statusLine is already set to: "${existingCommand}"\n` +
@@ -1866,7 +1879,7 @@ export function teardownHud(): void {
 
   const existing = settings.statusLine as { command?: string } | string | undefined;
   const existingCommand = typeof existing === 'object' ? existing?.command : existing;
-  if (!existingCommand || !String(existingCommand).includes('node9')) {
+  if (!isNode9StatusLine(existingCommand)) {
     console.log(chalk.blue('  ℹ️  node9 HUD not found in ~/.claude/settings.json'));
     return;
   }


### PR DESCRIPTION
## What
Hardens node9 so it never overwrites or deletes a Claude `statusLine` it didn't set (e.g. ccstatusline). Surfaced by #186 — a user lost their statusline on `node9 init`, then entirely on uninstall.

## Changes
- **`setupClaude` / `node9 init`** — only set node9's HUD when the slot is empty or already node9's; leave a user-set statusLine alone (was silently overwriting it).
- **`setupHud`** — warn + skip instead of overwriting a user's statusLine.
- **`isNode9StatusLine()`** — one shared, precise ownership check (requires `node9` *and* the `hud` subcommand) replacing a bare `includes('node9')` duplicated in 3 places, so a user statusLine merely containing "node9" in a path isn't clobbered.

## Tests
- Unit: setupClaude/setupHud preserve a non-node9 statusLine (incl. a "node9"-in-path one); `isNode9StatusLine` cases incl. the edge.
- Integration (real CLI): full `node9 uninstall` removes node9 hooks + its own HUD but **preserves a user statusLine**.
- Full suite green (3099 passed). typecheck / lint / format clean.

Refs #186. Merging cuts a patch release (fix-only commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)