### PR TITLE
feat(preferences): apply managed reviewChannel + approvalTimeoutMs

### DIFF
--- a/src/__tests__/managed.test.ts
+++ b/src/__tests__/managed.test.ts
@@ -6,6 +6,7 @@ import {
   applyManagedDlp,
   applyManagedApprovers,
 } from '../config/managed';
+import { extractManagedConfig } from '../daemon/sync';
 
 const localEgress = (
   over: Partial<{
@@ -197,5 +198,22 @@ describe('managed approvers (Preferences)', () => {
 
   it('a managed false forces a surface off', () => {
     expect(applyManagedApprovers(local, { terminal: false }).terminal).toBe(false);
+  });
+});
+
+describe('extractManagedConfig — reviewChannel + approvalTimeoutMs (Preferences v2)', () => {
+  it('keeps a valid reviewChannel + numeric timeout', () => {
+    const out = extractManagedConfig({
+      managedConfig: { reviewChannel: 'ask', approvalTimeoutMs: 30000, locked: [] },
+    });
+    expect(out?.reviewChannel).toBe('ask');
+    expect(out?.approvalTimeoutMs).toBe(30000);
+  });
+
+  it('drops an invalid reviewChannel and a negative timeout', () => {
+    const out = extractManagedConfig({
+      managedConfig: { reviewChannel: 'bogus', approvalTimeoutMs: -1, locked: [] },
+    });
+    expect(out).toBeUndefined();
   });
 });

--- a/src/__tests__/managed.test.ts
+++ b/src/__tests__/managed.test.ts
@@ -4,6 +4,7 @@ import {
   resolveManagedMode,
   applyManagedEgress,
   applyManagedDlp,
+  applyManagedApprovers,
 } from '../config/managed';
 
 const localEgress = (
@@ -179,5 +180,22 @@ describe('managed dlp (baseline+lock) — M2c', () => {
 
   it('ignores an unrankable managed pii', () => {
     expect(applyManagedDlp(localDlp({ pii: 'block' }), { pii: 'garbage' }, []).pii).toBe('block');
+  });
+});
+
+describe('managed approvers (Preferences)', () => {
+  const local = { native: true, browser: false, cloud: false, terminal: true };
+
+  it('replaces present managed fields, keeps the rest (org owns the surface)', () => {
+    const out = applyManagedApprovers(local, { cloud: true, terminal: false });
+    expect(out).toEqual({ native: true, browser: false, cloud: true, terminal: false });
+  });
+
+  it('an empty managed object leaves local untouched', () => {
+    expect(applyManagedApprovers(local, {})).toEqual(local);
+  });
+
+  it('a managed false forces a surface off', () => {
+    expect(applyManagedApprovers(local, { terminal: false }).terminal).toBe(false);
   });
 });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -7,7 +7,12 @@ import path from 'path';
 import os from 'os';
 import { sanitizeConfig } from '../config-schema';
 import { readActiveShields, readShieldOverrides, getShield } from '../shields';
-import { resolveManagedMode, applyManagedEgress, applyManagedDlp } from './managed';
+import {
+  resolveManagedMode,
+  applyManagedEgress,
+  applyManagedDlp,
+  applyManagedApprovers,
+} from './managed';
 
 // SmartCondition + SmartRule are now defined in @node9/policy-engine.
 // Re-exported here so existing import paths (`from '../config'`) keep
@@ -736,6 +741,12 @@ export function getConfig(cwd?: string): Config {
             allowPrivate?: unknown;
           };
           dlp?: { enabled?: unknown; pii?: unknown };
+          approvers?: {
+            native?: unknown;
+            browser?: unknown;
+            cloud?: unknown;
+            terminal?: unknown;
+          };
           locked?: unknown;
         };
         const locked: string[] = Array.isArray(mc.locked)
@@ -777,6 +788,18 @@ export function getConfig(cwd?: string): Config {
             },
             locked
           );
+        }
+        // Preferences: settings.approvers — the org owns where approvals happen,
+        // so a managed value replaces the local surface per-field.
+        if (mc.approvers && typeof mc.approvers === 'object') {
+          const bool = (v: unknown): boolean | undefined =>
+            typeof v === 'boolean' ? v : undefined;
+          mergedSettings.approvers = applyManagedApprovers(mergedSettings.approvers, {
+            native: bool(mc.approvers.native),
+            browser: bool(mc.approvers.browser),
+            cloud: bool(mc.approvers.cloud),
+            terminal: bool(mc.approvers.terminal),
+          });
         }
       }
       if (raw.panicMode === true) {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -747,6 +747,8 @@ export function getConfig(cwd?: string): Config {
             cloud?: unknown;
             terminal?: unknown;
           };
+          reviewChannel?: unknown;
+          approvalTimeoutMs?: unknown;
           locked?: unknown;
         };
         const locked: string[] = Array.isArray(mc.locked)
@@ -800,6 +802,14 @@ export function getConfig(cwd?: string): Config {
             cloud: bool(mc.approvers.cloud),
             terminal: bool(mc.approvers.terminal),
           });
+        }
+        // Preferences v2: reviewChannel + approvalTimeoutMs — plain scalars, the
+        // org's value replaces local when set (admin owns these approval knobs).
+        if (mc.reviewChannel === 'ask' || mc.reviewChannel === 'approver') {
+          mergedSettings.reviewChannel = mc.reviewChannel;
+        }
+        if (typeof mc.approvalTimeoutMs === 'number' && mc.approvalTimeoutMs >= 0) {
+          mergedSettings.approvalTimeoutMs = mc.approvalTimeoutMs;
         }
       }
       if (raw.panicMode === true) {

--- a/src/config/managed.ts
+++ b/src/config/managed.ts
@@ -141,3 +141,24 @@ export function applyManagedDlp<T extends { enabled: boolean; pii?: string }>(
   }
   return next;
 }
+
+// Managed approver surfaces (Preferences v1). The org owns WHERE approvals happen
+// (force cloud, forbid terminal self-approve), so a present managed value
+// REPLACES the local one per-field.
+export interface ManagedApprovers {
+  native?: boolean;
+  browser?: boolean;
+  cloud?: boolean;
+  terminal?: boolean;
+}
+export function applyManagedApprovers<
+  T extends { native: boolean; browser: boolean; cloud: boolean; terminal: boolean },
+>(local: T, managed: ManagedApprovers): T {
+  return {
+    ...local,
+    native: typeof managed.native === 'boolean' ? managed.native : local.native,
+    browser: typeof managed.browser === 'boolean' ? managed.browser : local.browser,
+    cloud: typeof managed.cloud === 'boolean' ? managed.cloud : local.cloud,
+    terminal: typeof managed.terminal === 'boolean' ? managed.terminal : local.terminal,
+  };
+}

--- a/src/daemon/sync.ts
+++ b/src/daemon/sync.ts
@@ -163,6 +163,7 @@ export interface ManagedConfigCache {
     allowPrivate?: boolean;
   };
   dlp?: { enabled?: boolean; pii?: string };
+  approvers?: { native?: boolean; browser?: boolean; cloud?: boolean; terminal?: boolean };
   locked: string[];
 }
 
@@ -190,6 +191,7 @@ interface CloudPolicyBody {
       allowPrivate?: unknown;
     };
     dlp?: { enabled?: unknown; pii?: unknown };
+    approvers?: { native?: unknown; browser?: unknown; cloud?: unknown; terminal?: unknown };
     locked?: unknown;
   }; // M2 settings
 }
@@ -418,8 +420,19 @@ export function extractManagedConfig(body: CloudPolicyBody): ManagedConfigCache 
     if (typeof mc.dlp.pii === 'string') d.pii = mc.dlp.pii;
     if (d.enabled !== undefined || d.pii !== undefined) out.dlp = d;
   }
+  // Preferences: approvers (4 bools — where approvals may happen).
+  if (mc.approvers && typeof mc.approvers === 'object') {
+    const a: NonNullable<ManagedConfigCache['approvers']> = {};
+    for (const k of ['native', 'browser', 'cloud', 'terminal'] as const) {
+      if (typeof mc.approvers[k] === 'boolean') a[k] = mc.approvers[k] as boolean;
+    }
+    if (Object.keys(a).length > 0) out.approvers = a;
+  }
   // Nothing actually managed → omit entirely.
-  return out.mode !== undefined || out.egress !== undefined || out.dlp !== undefined
+  return out.mode !== undefined ||
+    out.egress !== undefined ||
+    out.dlp !== undefined ||
+    out.approvers !== undefined
     ? out
     : undefined;
 }

--- a/src/daemon/sync.ts
+++ b/src/daemon/sync.ts
@@ -164,6 +164,8 @@ export interface ManagedConfigCache {
   };
   dlp?: { enabled?: boolean; pii?: string };
   approvers?: { native?: boolean; browser?: boolean; cloud?: boolean; terminal?: boolean };
+  reviewChannel?: string;
+  approvalTimeoutMs?: number;
   locked: string[];
 }
 
@@ -192,6 +194,8 @@ interface CloudPolicyBody {
     };
     dlp?: { enabled?: unknown; pii?: unknown };
     approvers?: { native?: unknown; browser?: unknown; cloud?: unknown; terminal?: unknown };
+    reviewChannel?: unknown;
+    approvalTimeoutMs?: unknown;
     locked?: unknown;
   }; // M2 settings
 }
@@ -428,11 +432,20 @@ export function extractManagedConfig(body: CloudPolicyBody): ManagedConfigCache 
     }
     if (Object.keys(a).length > 0) out.approvers = a;
   }
+  // Preferences v2: reviewChannel ('ask'|'approver') + approvalTimeoutMs (number).
+  if (mc.reviewChannel === 'ask' || mc.reviewChannel === 'approver') {
+    out.reviewChannel = mc.reviewChannel;
+  }
+  if (typeof mc.approvalTimeoutMs === 'number' && mc.approvalTimeoutMs >= 0) {
+    out.approvalTimeoutMs = mc.approvalTimeoutMs;
+  }
   // Nothing actually managed → omit entirely.
   return out.mode !== undefined ||
     out.egress !== undefined ||
     out.dlp !== undefined ||
-    out.approvers !== undefined
+    out.approvers !== undefined ||
+    out.reviewChannel !== undefined ||
+    out.approvalTimeoutMs !== undefined
     ? out
     : undefined;
 }


### PR DESCRIPTION
Proxy companion to Preferences v2. Applies the two managed scalars — reviewChannel ('ask'=inline-ask / 'approver') and approvalTimeoutMs — replacing local when set. extractManagedConfig + config apply, validated. Full suite 3104 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)