### PR TITLE
feat: posture front-door (P3.1) + stable MCP config identity + pause-DLP fix

### DIFF
--- a/src/__tests__/check.integration.test.ts
+++ b/src/__tests__/check.integration.test.ts
@@ -269,6 +269,30 @@ describe('ignored tools fast-path', () => {
     expect(r.stdout).toBe('');
   });
 
+  it('UserPromptSubmit DLP is SILENCED while node9 is paused (pause bug, dogfound 2026-07-05)', () => {
+    // `node9 pause` must silence the prompt-DLP gate exactly like the tool-call
+    // path (orchestrator honors checkPause; this branch didn't) — a paused
+    // node9 that still blocks prompts reads as "pause is broken".
+    const fakeAwsKey = 'AKIA' + 'QWERTYASDFGHJKLM'; // composed so this file never trips DLP itself
+    fs.writeFileSync(
+      path.join(tmpHome, '.node9', 'PAUSED'),
+      JSON.stringify({ expiry: Date.now() + 60_000, duration: '1m' })
+    );
+    const r = runCheck(
+      {
+        session_id: 's1',
+        turn_id: 't1',
+        cwd: '/tmp',
+        hook_event_name: 'UserPromptSubmit',
+        prompt: `help me debug: aws_access_key_id=${fakeAwsKey}`,
+      },
+      { HOME: tmpHome },
+      tmpHome
+    );
+    expect(r.status).toBe(0); // allowed through — pause wins
+    expect(r.stdout).toBe(''); // no block JSON
+  });
+
   it('Codex UserPromptSubmit with AWS key in prompt is blocked + audited without leaking secret', () => {
     // Compose the fake credential at runtime so this test file itself doesn't
     // trip Node9's own DLP scanner during code edits. Neither half matches

--- a/src/__tests__/mcp-reconciler.spec.ts
+++ b/src/__tests__/mcp-reconciler.spec.ts
@@ -113,4 +113,60 @@ describe('mcp reconcile pass', () => {
     runMcpReconcile();
     expect(sendSpy).toHaveBeenCalledTimes(0);
   });
+
+  // R1 Layer 1 — the refresh pass: back-fill --config-name on governed servers.
+  const claudeServer = (name: string) =>
+    JSON.parse(fs.readFileSync(path.join(home, '.claude.json'), 'utf-8')).mcpServers[name];
+
+  it('refresh: back-fills --config-name on a governed server that lacks it — SILENTLY, upstream preserved', () => {
+    writeClaude({
+      redis: {
+        command: 'node9',
+        args: ['mcp-gateway', '--upstream', 'npx redis-mcp redis://h:6379'],
+      },
+    });
+    runMcpReconcile();
+    const args = claudeServer('redis').args as string[];
+    expect(args).toContain('--config-name');
+    expect(args[args.indexOf('--config-name') + 1]).toBe('redis'); // stamped with the config key
+    expect(args[args.indexOf('--upstream') + 1]).toBe('npx redis-mcp redis://h:6379'); // serverKey preserved
+    expect(sendSpy).toHaveBeenCalledTimes(0); // NO popup (R2 fatigue)
+  });
+
+  it('refresh: leaves an already-stamped server untouched (idempotent, no double)', () => {
+    writeClaude({
+      redis: {
+        command: 'node9',
+        args: ['mcp-gateway', '--config-name', 'redis', '--upstream', 'npx x'],
+      },
+    });
+    runMcpReconcile();
+    const args = claudeServer('redis').args as string[];
+    expect(args.filter((a) => a === '--config-name')).toHaveLength(1);
+  });
+
+  it("refresh: never overrides a user's custom --config-name (don't fight the user)", () => {
+    writeClaude({
+      redis: {
+        command: 'node9',
+        args: ['mcp-gateway', '--config-name', 'my-custom', '--upstream', 'npx x'],
+      },
+    });
+    runMcpReconcile();
+    const args = claudeServer('redis').args as string[];
+    expect(args[args.indexOf('--config-name') + 1]).toBe('my-custom');
+  });
+
+  it('refresh: does NOT auto-rewrite a governed TOML (Codex) server (fix #8)', () => {
+    const codexDir = path.join(home, '.codex');
+    fs.mkdirSync(codexDir, { recursive: true });
+    const toml =
+      '[mcp_servers.git]\ncommand = "node9"\nargs = ["mcp-gateway", "--upstream", "uvx git"]\n';
+    fs.writeFileSync(path.join(codexDir, 'config.toml'), toml);
+    runMcpReconcile();
+    // TOML untouched — no --config-name injected (smol-toml would reformat the file).
+    expect(fs.readFileSync(path.join(codexDir, 'config.toml'), 'utf-8')).not.toContain(
+      '--config-name'
+    );
+  });
 });

--- a/src/__tests__/mcp-status.spec.ts
+++ b/src/__tests__/mcp-status.spec.ts
@@ -128,6 +128,41 @@ describe('resolveEntryStatus', () => {
     e.args = ['mcp-gateway']; // hand-corrupted: no --upstream
     expect(resolveEntryStatus(e, {}, {}, NOW).connection).toBe('pending-launch');
   });
+
+  // R1 Layer 1 — identity-join: a launched server stamped with its config key is
+  // connected via ground truth, WITHOUT resolving env (the daemon-env-differs bug).
+  const stampedTools = (name: string, key = 'realkey123', lastSeenAt = NOW): McpToolsConfig => ({
+    [key]: { name, tools: [{ name: 'get' }], disabled: [], status: 'approved', lastSeenAt },
+  });
+
+  it('identity-join: a config-key-stamped server is CONNECTED even when env is unresolvable (R1 live repro)', () => {
+    // config upstream needs ${REDIS_PROD_URL} (unset here) — the legacy path would
+    // short-circuit to `unlaunchable`. But a connected entry is stamped "redis-prod".
+    const e = gatewayed('redis-prod', 'npx -y @x/server-redis ${REDIS_PROD_URL}');
+    const out = resolveEntryStatus(e, stampedTools('redis-prod'), {}, NOW); // env {} — no var
+    expect(out.connection).toBe('connected');
+    expect(out.serverKey).toBe('realkey123');
+    expect(out.connectedTools).toBe(1);
+  });
+
+  it('identity-join reports stale when the stamped entry is old', () => {
+    const e = gatewayed('redis-prod', 'npx -y @x/server-redis ${REDIS_PROD_URL}');
+    const out = resolveEntryStatus(
+      e,
+      stampedTools('redis-prod', 'k', NOW - (STALE_MS + 1)),
+      {},
+      NOW
+    );
+    expect(out.connection).toBe('stale');
+  });
+
+  it('UNstamped (name mismatch) falls through to the env path — no regression', () => {
+    // connected entry still carries the derived name "redis", not the config key.
+    const e = gatewayed('redis-prod', 'npx -y @x/server-redis ${REDIS_PROD_URL}');
+    const out = resolveEntryStatus(e, stampedTools('redis'), {}, NOW); // env {} → env path
+    expect(out.connection).toBe('unlaunchable');
+    expect(out.missingEnv).toContain('REDIS_PROD_URL');
+  });
 });
 
 // The freshness stamp the resolver relies on — proven against the REAL writer

--- a/src/__tests__/posture.integration.test.ts
+++ b/src/__tests__/posture.integration.test.ts
@@ -70,8 +70,11 @@ describe('node9 posture (integration)', () => {
     expect(Array.isArray(parsed.findings)).toBe(true);
     expect(typeof parsed.tier).toBe('string');
     expect(parsed.checksRun).toBe(8);
-    // Bare home is not wired → the headline's #1 action is to wire node9.
+    // Bare home is not wired → the headline's #1 action is install-aware (a cold
+    // `npx node9-ai posture` reader has no `node9` on PATH), so it leads with the
+    // install so the rest of the scorecard's `node9 …` fixes actually work.
     expect(parsed.headline).toBeTruthy();
+    expect(parsed.headline.action).toMatch(/npm i -g node9-ai/i);
     expect(parsed.headline.action).toMatch(/node9 init/i);
   });
 

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -8,6 +8,7 @@ import { spawn } from 'child_process';
 import path from 'path';
 import os from 'os';
 import { authorizeHeadless } from '../../auth/orchestrator';
+import { checkPause } from '../../auth/state';
 import { isDaemonRunning } from '../../auth/daemon';
 import { getConfig, type Config } from '../../config';
 import { shouldSnapshot } from '../../policy';
@@ -265,6 +266,12 @@ export function registerCheckCommand(program: Command): void {
             }
 
             if (!prompt) process.exit(0);
+
+            // `node9 pause` must silence this gate too — the tool-call path
+            // honors it in authorizeHeadless (orchestrator.ts:273); without
+            // this, prompts stayed BLOCKED while everything else was paused
+            // (dogfound 2026-07-05). Same guard pair as the orchestrator.
+            if (process.env.NODE9_PAUSED === '1' || checkPause().paused) process.exit(0);
 
             const dlpMatch = scanArgs({ prompt });
             if (!dlpMatch) process.exit(0);

--- a/src/daemon/mcp-reconciler.ts
+++ b/src/daemon/mcp-reconciler.ts
@@ -8,10 +8,11 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import crypto from 'crypto';
-import { inventoryMcp, toGateway, writeMcpEntry, type McpEntry } from '../mcp-wrap';
+import { inventoryMcp, toGateway, fromGateway, writeMcpEntry, type McpEntry } from '../mcp-wrap';
 import { sendDesktopNotification } from '../ui/native';
 import { getConfig, getCredentials } from '../config';
 import { auditLocalAllow } from '../auth/cloud';
+import { appendToLog, HOOK_DEBUG_LOG } from '../audit/index.js';
 
 const BASELINE_FILE = path.join(os.homedir(), '.node9', 'mcp-baseline.json');
 const BASELINE_CAP = 500;
@@ -75,9 +76,45 @@ export function runMcpReconcile(): void {
   // nudge-only unattended; the user can wrap it explicitly via the CLI (which
   // backs the file up). (fix #8)
   const autoWrap = getConfig().settings.mcpAutoWrap === true;
+  const inv = inventoryMcp(); // once per pass — refresh + wrap read the same snapshot
+
+  // ── R1 Layer 1: refresh the `--config-name` stamp on governed servers ──────────
+  // A governed server wrapped before `--config-name` existed has no stable identity,
+  // so the config-vs-connected join guesses env and phantoms (redis-prod). Re-wrap it
+  // WITH the stamp — `toGateway(fromGateway(raw), configKey)` — reusing the same
+  // primitives `--rewrap` uses. serverKey is unchanged (pins/app-perm rules survive),
+  // writeMcpEntry backs up, and it's reversible via `ungateway`. Constraints:
+  //   • SILENT — no desktop popup (R2 notification fatigue); a hook-debug line instead.
+  //   • JSON only — never auto-rewrite TOML/Codex (smol-toml reformats the file, fix #8).
+  //   • MISSING-only — never touch a user's deliberate custom `--config-name` (don't
+  //     fight the user); already-stamped entries don't match, so it's idempotent.
+  for (const e of inv) {
+    if (e.state !== 'gatewayed' || e.format === 'toml') continue;
+    if (e.args.includes('--config-name')) continue;
+    const orig = fromGateway(e.raw);
+    if (!orig) continue; // corrupt wrapper (no parseable --upstream) — leave it
+    try {
+      writeMcpEntry(e.mcpFile, e.format, e.name, toGateway(orig, e.name));
+      appendToLog(HOOK_DEBUG_LOG, {
+        event: 'mcp-config-name-refreshed',
+        agent: e.agent,
+        name: e.name,
+      });
+    } catch (err) {
+      // Leave it; next tick retries. Never popup / crash the loop over a refresh —
+      // but log so a PERMANENT failure (e.g. read-only config) is diagnosable
+      // instead of retrying invisibly forever (CLAUDE.md: log guarded catches).
+      appendToLog(HOOK_DEBUG_LOG, {
+        event: 'mcp-config-name-refresh-failed',
+        name: e.name,
+        error: (err as Error)?.message,
+      });
+    }
+  }
+
   const baseline = loadBaseline();
   const creds = getCredentials(); // once per pass (fix #10)
-  const fresh = inventoryMcp().filter((e) => e.state === 'ungoverned' && !baseline.has(idKey(e)));
+  const fresh = inv.filter((e) => e.state === 'ungoverned' && !baseline.has(idKey(e)));
   if (fresh.length === 0) return;
 
   const wrappedAgents = new Set<string>();

--- a/src/mcp-status.ts
+++ b/src/mcp-status.ts
@@ -93,10 +93,37 @@ export function resolveEntryStatus(
   if (e.state === 'remote') return { ...base, connection: 'remote' };
   if (e.state === 'ungoverned') return { ...base, connection: 'ungoverned' };
 
-  // gatewayed → resolve the upstream, lint env, then join by serverKey.
+  // Build the connected/stale result for a matched mcp-tools.json entry. Shared by
+  // the identity-join and the (legacy) serverKey-join so the two never drift.
+  const connectedRow = (serverKey: string, connected: (typeof tools)[string]): McpStatusEntry => {
+    const lastSeenAt = connected.lastSeenAt;
+    const stale = typeof lastSeenAt === 'number' && now - lastSeenAt > STALE_MS;
+    return {
+      ...base,
+      connection: stale ? 'stale' : 'connected',
+      lastSeenAt,
+      connectedTools: connected.tools.length,
+      serverKey,
+    };
+  };
+
   const upstream = upstreamOf(e);
   if (!upstream) return { ...base, connection: 'pending-launch' };
 
+  // IDENTITY JOIN (R1 Layer 1) — the ROBUST path. A launched server the gateway
+  // stamped with THIS config key (`--config-name`, so mcp-tools name === e.name)
+  // is ground truth: connected, using its real serverKey, WITHOUT resolving env.
+  // This kills the daemon-env-differs phantom at the source (before the env lint
+  // below can mis-return `unlaunchable`), and on EVERY resolveMcpStatus surface —
+  // the snapshot AND `node9 mcp status` — not just the snapshot's build.ts dedup.
+  // An unstamped server (name still command-derived, ≠ e.name) falls through to
+  // the legacy env path unchanged (no regression); the reconciler refresh pass
+  // migrates it. (L1 imprecision: the key is a name string — see L2's identity map.)
+  const stamped = Object.entries(tools).find(([, cfg]) => cfg.name === e.name);
+  if (stamped) return connectedRow(stamped[0], stamped[1]);
+
+  // Legacy env path — only reached when there is NO stamped identity match, so it
+  // classifies a genuinely-not-connected server and can't collide with a real one.
   const { resolved, missing } = substituteEnv(upstream, env);
   if (missing.length > 0) {
     return { ...base, connection: 'unlaunchable', missingEnv: missing };
@@ -105,18 +132,7 @@ export function resolveEntryStatus(
   const serverKey = getServerKey(resolved);
   const connected = tools[serverKey];
   if (!connected) return { ...base, connection: 'pending-launch', serverKey };
-
-  // Present in mcp-tools.json → it launched at least once. Undated legacy entries
-  // count as connected (they DID launch; we just didn't stamp the time).
-  const lastSeenAt = connected.lastSeenAt;
-  const stale = typeof lastSeenAt === 'number' && now - lastSeenAt > STALE_MS;
-  return {
-    ...base,
-    connection: stale ? 'stale' : 'connected',
-    lastSeenAt,
-    connectedTools: connected.tools.length,
-    serverKey,
-  };
+  return connectedRow(serverKey, connected);
 }
 
 /** The full merged status across every agent's MCP servers. */

--- a/src/posture/headline.ts
+++ b/src/posture/headline.ts
@@ -70,7 +70,11 @@ export function deriveHeadline(allFindings: Finding[]): Headline | null {
   // ── The one next step: highest leverage first ────────────────────────────
   let action: string;
   if (notWired) {
-    action = 'Run `node9 init` — node9 is not in-path yet, so nothing here is enforced.';
+    // node9 isn't in-path — and whoever's reading this may not even have it
+    // installed (e.g. they ran `npx node9-ai posture` cold), so lead with an
+    // install+init chain that works either way (`npm i -g` is a no-op if present).
+    action =
+      'Install node9 and put it in-path: `npm i -g node9-ai && node9 init` — nothing here is enforced until you do.';
   } else if (observeOnly) {
     action = 'Switch node9 to enforcing mode — right now it is only watching, not blocking.';
   } else if (egressOpen) {

--- a/src/posture/index.ts
+++ b/src/posture/index.ts
@@ -90,7 +90,13 @@ export async function runPosture(opts: RunPostureOptions = {}): Promise<PostureR
   } = await runChecks(POSTURE_CHECKS, ctx);
 
   // Decide what node9 is already enforcing — at the real gating layer.
-  await annotateCoverage(rawFindings, ctx);
+  // Best-effort: this runs OUTSIDE runChecks' per-check catch, so guard it — a
+  // stranger's box (npx, no config) must get a scorecard, never a stack trace.
+  try {
+    await annotateCoverage(rawFindings, ctx);
+  } catch {
+    /* coverage stays unannotated; the rest of the scorecard still renders */
+  }
 
   // Drop findings that are open ONLY because node9 isn't enforcing (Coverage
   // already reports that gap) — no double-surfacing.


### PR DESCRIPTION
Merges `dev` → `main` for the next release. Three changes since v1.56.0:

- **feat(posture):** make the scorecard a cold-runnable front door (P3.1) — `npx node9-ai posture` works zero-install; CTAs are install-aware; `annotateCoverage` wrapped so a stranger's box never crashes.
- **fix(mcp):** stable config-vs-connected identity (R1 Layer 1) — resolver identity-join classifies a config-key-stamped server as connected WITHOUT re-substituting env (kills the daemon-env phantom on both the snapshot and `node9 mcp status`); a silent, JSON-only, missing-only reconciler refresh pass back-fills `--config-name`. serverKey unchanged → pins/app-perm rules survive. Live-verified.
- **fix(dlp):** `node9 pause` now silences the `UserPromptSubmit` prompt-DLP gate (it honored the tool-call path but not prompts). Failing-test-first + live-verified.

Full suite green, typecheck/lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)