### PR TITLE
ci: dogfood node9 agent-security check on PRs

### DIFF
--- a/.github/workflows/agent-security.yml
+++ b/.github/workflows/agent-security.yml
@@ -1,0 +1,15 @@
+# node9 dogfood: scan this repo's agent-security surface on every PR.
+# Report-only for now (fail-on: never) — flip to a threshold to gate merges.
+name: node9 agent-security
+on: pull_request
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: node9-ai/agent-security-action@0d55b80556dbcc14630c1dc9274924d16a43666a # v1
+        with:
+          fail-on: never


### PR DESCRIPTION
Wires the node9 agent-security Action into node9-proxy — report-only. This PR should itself trigger the new `node9 agent-security` check + comment (node9-proxy is clean, so expect ✅).