### PR TITLE
Report v3 P1: regroup dimensions to canon (loops→Detection)

### DIFF
--- a/src/__tests__/dashboard-report-panels.unit.test.tsx
+++ b/src/__tests__/dashboard-report-panels.unit.test.tsx
@@ -68,9 +68,11 @@ function emptyAudit(overrides: Partial<BuildReportJsonInput> = {}): AggregateRes
     dimensions: {
       network: { blocked: 0 },
       data: { blocked: 0, observed: 0 },
+      detection: { loops: 0, pinMismatches: 0, injections: 0 },
       approvals: { approved: 0, denied: 0, timedOut: 0 },
       files: { blocked: 0 },
-      toolRules: { blocked: 0, mcp: 0, loops: 0 },
+      toolRules: { blocked: 0 },
+      apps: { blocked: 0 },
       cost: { totalUSD: 0 },
     },
     generatedAt: '2026-05-10T15:00:00Z',

--- a/src/__tests__/dashboard-score-banner.unit.test.tsx
+++ b/src/__tests__/dashboard-score-banner.unit.test.tsx
@@ -61,9 +61,11 @@ function makeAudit(spend: number = 0): AggregateResult {
     dimensions: {
       network: { blocked: 0 },
       data: { blocked: 0, observed: 0 },
+      detection: { loops: 0, pinMismatches: 0, injections: 0 },
       approvals: { approved: 0, denied: 0, timedOut: 0 },
       files: { blocked: 0 },
-      toolRules: { blocked: 0, mcp: 0, loops: 0 },
+      toolRules: { blocked: 0 },
+      apps: { blocked: 0 },
       cost: { totalUSD: 0 },
     },
     generatedAt: '2026-05-10T15:00:00Z',

--- a/src/__tests__/report-audit-aggregate.unit.test.ts
+++ b/src/__tests__/report-audit-aggregate.unit.test.ts
@@ -899,7 +899,7 @@ describe('aggregateReportFromAudit — dimension buckets', () => {
     expect(data.dimensions.files.blocked).toBe(1);
   });
 
-  it('attributes an MCP app-permission block to the tool-rules dimension', () => {
+  it('attributes an MCP app-permission block to the apps dimension (canon)', () => {
     writeLog([
       {
         ts: at('10:03:00'),
@@ -912,7 +912,24 @@ describe('aggregateReportFromAudit — dimension buckets', () => {
       },
     ]);
     const { data } = aggregateReportFromAudit('7d', makeOpts());
-    expect(data.dimensions.toolRules.mcp).toBe(1);
+    expect(data.dimensions.apps.blocked).toBe(1);
+    // canon: NOT in toolRules anymore
+    expect(data.dimensions.toolRules.blocked).toBe(0);
+  });
+
+  it('REGROUP: a loop-detected block lands in Detection, never Tool Rules', () => {
+    writeLog([
+      {
+        ts: at('10:03:30'),
+        tool: 'Bash',
+        decision: 'block',
+        checkedBy: 'loop-detected',
+        agent: 'claude',
+      },
+    ]);
+    const { data } = aggregateReportFromAudit('7d', makeOpts());
+    expect(data.dimensions.detection.loops).toBe(1);
+    expect(data.dimensions.toolRules.blocked).toBe(0);
   });
 
   it('surfaces approvals (approved / denied / timed-out) as their own dimension', () => {

--- a/src/__tests__/report-json.unit.test.ts
+++ b/src/__tests__/report-json.unit.test.ts
@@ -52,9 +52,11 @@ function emptyInput(overrides: Partial<BuildReportJsonInput> = {}): BuildReportJ
     dimensions: {
       network: { blocked: 0 },
       data: { blocked: 0, observed: 0 },
+      detection: { loops: 0, pinMismatches: 0, injections: 0 },
       approvals: { approved: 0, denied: 0, timedOut: 0 },
       files: { blocked: 0 },
-      toolRules: { blocked: 0, mcp: 0, loops: 0 },
+      toolRules: { blocked: 0 },
+      apps: { blocked: 0 },
       cost: { totalUSD: 0 },
     },
     generatedAt: FIXED_TIME,

--- a/src/cli/aggregate/report-audit.ts
+++ b/src/cli/aggregate/report-audit.ts
@@ -967,12 +967,19 @@ export async function loadGeminiCostAsync(
 function dimensionOfBlock(
   checkedBy: string,
   ruleName: string
-): 'network' | 'data' | 'files' | 'mcp' | 'toolRules' | 'approvals' | null {
+): 'network' | 'data' | 'detection' | 'files' | 'apps' | 'toolRules' | 'approvals' | null {
   if (checkedBy.includes('egress')) return 'network';
   if (checkedBy.includes('pii') || checkedBy.includes('dlp')) return 'data';
-  if (checkedBy === 'app-permission-block' || ruleName.startsWith('app-permission:')) return 'mcp';
+  // Report v3 canon: loops/pin/injection report under Detection (where the
+  // user configures them), NOT Tool Rules. Mirrors node9Firewall canon-taxonomy.ts.
+  if (
+    checkedBy === 'loop-detected' ||
+    checkedBy === 'mcp-pin-mismatch' ||
+    checkedBy.startsWith('injection')
+  )
+    return 'detection';
+  if (checkedBy === 'app-permission-block' || ruleName.startsWith('app-permission:')) return 'apps';
   if (ruleName.startsWith('shield:project-jail')) return 'files';
-  if (checkedBy === 'loop-detected') return 'toolRules';
   if (checkedBy === 'timeout' || checkedBy === 'local-decision') return 'approvals';
   // Any other block (smart-rule-block, persistent-deny, unknown) → tool rules.
   return 'toolRules';
@@ -1133,7 +1140,10 @@ export function aggregateReportFromAudit(
   let dimDataObserved = 0; // PII/DLP would-block (allowed but flagged)
   let dimFilesBlocked = 0;
   let dimToolRulesBlocked = 0;
-  let dimMcpBlocked = 0;
+  let dimAppsBlocked = 0; // MCP app-permission blocks (canon 'apps')
+  // Detection area (Report v3 canon) — loops/pin/injection.
+  let dimPinMismatch = 0;
+  let dimInjectionBlocked = 0;
 
   for (const e of entries) {
     // Skip intermediate `smart-rule-block-override` rows that were
@@ -1162,9 +1172,14 @@ export function aggregateReportFromAudit(
     }
     if (e.checkedBy === 'loop-detected') loopHits++;
 
-    // Dimension attribution (Report UI v2 · P0). "Observed" data findings
-    // (PII/DLP would-block) are flagged regardless of the final decision.
+    // Detection-area attribution (Report v3 canon) — pin/injection alongside
+    // loops, action-agnostic (a signal counts whether or not it hard-blocked).
     const cb = e.checkedBy ?? '';
+    if (cb === 'mcp-pin-mismatch') dimPinMismatch++;
+    if (cb.startsWith('injection')) dimInjectionBlocked++;
+
+    // "Observed" data findings (PII/DLP would-block) flagged regardless of
+    // the final decision.
     if (cb.includes('would-block') && (cb.includes('pii') || cb.includes('dlp'))) {
       dimDataObserved++;
     }
@@ -1176,14 +1191,14 @@ export function aggregateReportFromAudit(
         case 'files':
           dimFilesBlocked++;
           break;
-        case 'mcp':
-          dimMcpBlocked++;
+        case 'apps':
+          dimAppsBlocked++;
           break;
         case 'toolRules':
           dimToolRulesBlocked++;
           break;
-        // 'data' / 'approvals' / null: covered by dlpBlocked / timedOut /
-        // userDenied — don't double-count here.
+        // 'data' / 'detection' / 'approvals' / null: covered by dlpBlocked /
+        // loopHits+pin+injection / timedOut / userDenied — no double-count.
       }
     }
 
@@ -1279,9 +1294,15 @@ export function aggregateReportFromAudit(
     dimensions: {
       network: { blocked: dimNetworkBlocked },
       data: { blocked: dlpBlocked, observed: dimDataObserved },
+      detection: {
+        loops: loopHits,
+        pinMismatches: dimPinMismatch,
+        injections: dimInjectionBlocked,
+      },
       approvals: { approved: userApproved, denied: userDenied, timedOut },
       files: { blocked: dimFilesBlocked },
-      toolRules: { blocked: dimToolRulesBlocked, mcp: dimMcpBlocked, loops: loopHits },
+      toolRules: { blocked: dimToolRulesBlocked },
+      apps: { blocked: dimAppsBlocked },
       cost: { totalUSD: claudeCost.total + codexCost.total + geminiCost.total },
     },
     generatedAt: now.toISOString(),

--- a/src/cli/commands/report.ts
+++ b/src/cli/commands/report.ts
@@ -339,6 +339,12 @@ function renderTerminalReport(
       `${num(d.data.blocked)} blocked · ${num(d.data.observed)} observed (DLP/PII)`
     );
     dimRow(
+      '🔁',
+      'Detection',
+      d.detection.loops + d.detection.pinMismatches + d.detection.injections > 0,
+      `${num(d.detection.loops)} loops · ${num(d.detection.pinMismatches)} pin · ${num(d.detection.injections)} injection`
+    );
+    dimRow(
       '✋',
       'Approvals',
       d.approvals.approved + d.approvals.denied + d.approvals.timedOut > 0,
@@ -348,9 +354,10 @@ function renderTerminalReport(
     dimRow(
       '🛠',
       'Tool rules',
-      d.toolRules.blocked + d.toolRules.mcp + d.toolRules.loops > 0,
-      `${num(d.toolRules.blocked)} shields/rules · ${num(d.toolRules.mcp)} MCP · ${num(d.toolRules.loops)} loops`
+      d.toolRules.blocked > 0,
+      `${num(d.toolRules.blocked)} shields/rules`
     );
+    dimRow('🧩', 'Apps (MCP)', d.apps.blocked > 0, `${num(d.apps.blocked)} app-permission blocks`);
     dimRow('💰', 'Cost', d.cost.totalUSD > 0, `${fmtCost(d.cost.totalUSD)} this period`);
   }
   console.log('');

--- a/src/cli/render/report-json.ts
+++ b/src/cli/render/report-json.ts
@@ -28,14 +28,19 @@ export interface ReportDimensions {
   /** DLP/PII. `blocked` = hard DLP blocks; `observed` = would-block (DLP or
    *  PII) that was allowed but flagged. */
   data: { blocked: number; observed: number };
+  /** Report v3 canon — the Detection policy area: loop-detection hits, MCP
+   *  pin mismatches, and injection detections. These report HERE (where the
+   *  user configures them), not under Tool Rules. */
+  detection: { loops: number; pinMismatches: number; injections: number };
   /** Human-in-the-loop decisions. Timed-out = auto-denied. */
   approvals: { approved: number; denied: number; timedOut: number };
   /** Credential-jail path reads blocked/reviewed (ruleName shield:project-jail:*). */
   files: { blocked: number };
-  /** Shields / smart rules (`blocked`, excluding jail), MCP app-permission
-   *  governance events (`mcp` — block AND review, since a review is a tool
-   *  rule firing), and loop-detection hits (`loops`). */
-  toolRules: { blocked: number; mcp: number; loops: number };
+  /** Shields / smart rules, excluding jail (files), MCP (apps), and loops
+   *  (detection). */
+  toolRules: { blocked: number };
+  /** MCP app-permission governance events (block AND review). Was `toolRules.mcp`. */
+  apps: { blocked: number };
   /** Period spend across agents (from the cost journals). */
   cost: { totalUSD: number };
 }


### PR DESCRIPTION
## What
Mirrors node9Firewall's new `canon-taxonomy.ts` so `node9 report` (CLI) and the SaaS dashboard agree on which policy area caught what.

- `loop-detected` / `mcp-pin-mismatch` / `injection*` → **Detection** (were Tool Rules)
- `app-permission-block` → **Apps (MCP)** (was `toolRules.mcp`)
- `ReportDimensions` type + CLI report render gain **Detection** and **Apps (MCP)** rows; `toolRules` slims to `{ blocked }`.

## Why
Paired with node9Firewall PR (v3 P1). The classifier is mirrored cross-repo — if only one side regroups, the CLI and dashboard disagree on loop attribution. Ship together.

## Tests
Aggregate regroup proofs (loop→detection, app-permission→apps, both out of toolRules) + updated fixtures. Full suite **3398 green**, typecheck + lint (0 errors) + format clean via pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)