### PR TITLE
fix(ci-check): name the actual granted tools in the CI-2 broad-tools signal

### DIFF
--- a/src/__tests__/ci-check.spec.ts
+++ b/src/__tests__/ci-check.spec.ts
@@ -350,6 +350,175 @@ jobs:
     expect(f.signals.join(' ')).not.toMatch(/broad\/write-capable/i);
   });
 
+  it('T1.1: the broad-tools signal names the ACTUAL granted tool, never a canned curl/git-push exemplar (lobehub migration-support)', () => {
+    // lobehub claude-migration-support.yml: the only broad tool is bare `Write`. The
+    // signal must SAY `Write` and must NOT claim curl / git push (which aren't granted)
+    // — a finding that misdescribes the file is the credibility-killing defect.
+    const wf = `
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  support:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          allowed_non_write_users: "*"
+          prompt: 'reply to github.event.comment.body'
+          claude_args: '--allowedTools "Bash(gh issue:*),Bash(cat docs/*),Bash(echo *),Read,Write"'
+`;
+    const f = analyzeWorkflow('support.yml', wf)!;
+    // Isolate the tool LIST (after "tools:") so the assertion can't trip on the
+    // literal "write-capable" in the signal prefix.
+    const list = (f.signals.find((s) => /broad\/write-capable tools:/i.test(s)) ?? '').replace(
+      /.*tools:/i,
+      ''
+    );
+    expect(list).toMatch(/\bWrite\b/i); // names the real granted tool
+    expect(list).not.toMatch(/curl|git push/i); // never fabricates tools not granted
+  });
+
+  it('T1.1: the broad-tools signal names a dangerous Bash verb when THAT is what fired (not Write)', () => {
+    // Where the broad grant is `Bash(curl ...)`, the signal must name it — proving the
+    // helper reports the real matched grant, not a fixed string.
+    const wf = `
+on:
+  issues:
+    types: [opened]
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          allowed_non_write_users: "*"
+          prompt: 'read github.event.issue.body'
+          claude_args: '--allowedTools "Bash(curl example.com:*),Read"'
+`;
+    const f = analyzeWorkflow('curl.yml', wf)!;
+    const list = (f.signals.find((s) => /broad\/write-capable tools:/i.test(s)) ?? '').replace(
+      /.*tools:/i,
+      ''
+    );
+    expect(list).toMatch(/curl/i); // names the real matched grant
+    expect(list).not.toMatch(/\bWrite\b|git push/i);
+  });
+
+  it('T1.1/F1: a `*`-bearing grant is wrapped in a backtick code span so it cannot inject markdown into the PR comment', () => {
+    const wf = `
+on:
+  issues:
+    types: [opened]
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          allowed_non_write_users: "*"
+          prompt: 'read github.event.issue.body'
+          claude_args: '--allowedTools "Bash(curl a:*),Read"'
+`;
+    const f = analyzeWorkflow('inject.yml', wf)!;
+    const sig = f.signals.find((s) => /broad\/write-capable tools:/i.test(s))!;
+    // The grant (with its `*`) must sit INSIDE a backtick pair — markdown-inert.
+    expect(sig).toMatch(/`[^`]*curl[^`]*\*[^`]*`/);
+  });
+
+  it('T1.1/F2: an unbalanced paren in one grant must NOT swallow the following grants (still names them distinctly)', () => {
+    const wf = `
+on:
+  issues:
+    types: [opened]
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          allowed_non_write_users: "*"
+          prompt: 'read github.event.issue.body'
+          claude_args: '--allowedTools "Bash(echo (:*),Write,Read"'
+`;
+    const f = analyzeWorkflow('unbalanced.yml', wf)!;
+    const list = (f.signals.find((s) => /broad\/write-capable tools:/i.test(s)) ?? '').replace(
+      /.*tools:/i,
+      ''
+    );
+    // `Write` must be named as its own token, not merged into the malformed Bash grant.
+    expect(list).toMatch(/`Write`/);
+  });
+
+  it('T1.1/F3: settings.allowedTools JSON array cruft (brackets/quotes) is stripped from the named tools', () => {
+    const wf = `
+on:
+  issues:
+    types: [opened]
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          allowed_non_write_users: "*"
+          prompt: 'read github.event.issue.body'
+          settings: '{"allowedTools":["Bash","Write"]}'
+`;
+    const f = analyzeWorkflow('settings.yml', wf)!;
+    const list = (f.signals.find((s) => /broad\/write-capable tools:/i.test(s)) ?? '').replace(
+      /.*tools:/i,
+      ''
+    );
+    // Clean `Bash` / `Write`, never `["Bash` / `Write"]`.
+    expect(list).toMatch(/`Bash`/);
+    expect(list).not.toMatch(/[[\]]/); // no stray JSON brackets
+  });
+
+  it('T1.1/F4: two distinct grants sharing a 40-char prefix are both reported, not deduped away', () => {
+    const long1 = 'Bash(curl aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1:*)';
+    const long2 = 'Bash(curl aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2:*)';
+    const wf = `
+on:
+  issues:
+    types: [opened]
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          allowed_non_write_users: "*"
+          prompt: 'read github.event.issue.body'
+          claude_args: '--allowedTools "${long1},${long2},Read"'
+`;
+    const f = analyzeWorkflow('dup.yml', wf)!;
+    const list = (f.signals.find((s) => /broad\/write-capable tools:/i.test(s)) ?? '').replace(
+      /.*tools:/i,
+      ''
+    );
+    // Both distinct grants survive dedup (keyed on the full token) → two code spans.
+    expect((list.match(/`/g) ?? []).length).toBe(4);
+  });
+
   it('F14a: pull_request (labeled) + label-name gate → advisory, and NOT "no actor gate" (metabase)', () => {
     // metabase resolve-backport-conflicts: a maintainer must apply the label
     // (needs write access) — an effective actor gate on `pull_request` (not _target).

--- a/src/ci-check/workflows.ts
+++ b/src/ci-check/workflows.ts
@@ -225,6 +225,53 @@ function collectTools(steps: Step[]): string {
   return s;
 }
 
+/** Split a collected-tools blob into individual grant tokens. Grants are comma/space
+ *  separated; a `Bash(...)` group may itself contain a comma, so we DON'T split inside
+ *  parens — tracked as a boolean toggle (NOT a depth counter) so an unbalanced paren in
+ *  one malformed grant can't swallow every following grant into one token. Each token is
+ *  stripped of the syntax cruft the extractors leave behind (JSON array brackets/quotes
+ *  from `settings.allowedTools`, wrapping quotes from `--allowedTools`) and of any char
+ *  that could break out of the code span the signal renders it in (backtick, newline). */
+function toolTokens(blob: string): string[] {
+  const out: string[] = [];
+  let buf = '';
+  let inParen = false;
+  const flush = () => {
+    const t = buf.replace(/[[\]"'`\r\n]/g, '').trim();
+    if (t) out.push(t);
+    buf = '';
+  };
+  for (const ch of blob) {
+    if (ch === '(') inParen = true;
+    else if (ch === ')') inParen = false;
+    if (!inParen && (ch === ',' || /\s/.test(ch))) {
+      flush();
+      continue;
+    }
+    buf += ch;
+  }
+  flush();
+  return out;
+}
+
+/** The SPECIFIC grant(s) that make a tool-set "broad" (each individually matches
+ *  BROAD_TOOL_RE), deduped + readable. The signal names what actually fired — never a
+ *  canned exemplar that could list tools the workflow doesn't grant (the honesty fix:
+ *  a finding must not misdescribe the file). Dedup keys on the FULL token so two long
+ *  grants that share a 40-char prefix aren't collapsed; truncation is display-only. */
+function matchedBroadTools(blob: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const tok of toolTokens(blob)) {
+    // Wrap in delimiters so BROAD_TOOL_RE's bare-name branch can anchor on a lone token.
+    if (!BROAD_TOOL_RE.test(`,${tok},`)) continue;
+    if (seen.has(tok)) continue;
+    seen.add(tok);
+    out.push(tok.length > 40 ? tok.slice(0, 40) + '…' : tok);
+  }
+  return out;
+}
+
 /** Where (if anywhere) an untrusted PR head is checked out. 'root' = into the
  *  workspace (dangerous under pull_request_target); 'subdir' = isolated path.
  *  Takes a step list so callers can scope it to a single job (CI-4 per-job). */
@@ -684,7 +731,18 @@ export function analyzeWorkflow(path: string, content: string): CiFinding | null
   if (head === 'root') signals.push('checks out the untrusted PR head into the workspace root');
   if (head === 'subdir') signals.push('checks out the untrusted PR head into an isolated subdir');
   if (promptUntrusted) signals.push('feeds untrusted PR/issue text to the agent');
-  if (broadTools) signals.push('agent has broad/write-capable tools (Bash/Write/curl/git push)');
+  if (broadTools) {
+    // Names embed scanned-file text that flows into the Action's PR comment (render.ts).
+    // Wrap each in a backtick code span (the repo convention, cf. agent-config's hook
+    // signal) — combined with toolTokens stripping backticks/newlines, attacker-controlled
+    // grant text cannot inject markdown into the trusted comment.
+    const names = matchedBroadTools(toolsBlob);
+    signals.push(
+      names.length
+        ? `agent has broad/write-capable tools: ${names.map((n) => `\`${n}\``).join(', ')}`
+        : 'agent has broad/write-capable tool grants'
+    );
+  }
   if (bypassActive) signals.push('allowed_non_write_users: "*" — any user can trigger the agent');
   if (elevated) signals.push('elevated permissions (contents/id-token: write)');
   if (pat) signals.push('a static PAT is exposed to the agent (recoverable via injection)');


### PR DESCRIPTION
## What

The CI-2 broad/write-capable-tools signal emitted a **fixed exemplar** string
(`Bash/Write/curl/git push`) regardless of what a scanned workflow actually granted —
so a finding could name tools the file doesn't contain (e.g. lobehub's migration-support
agent, whose only broad grant is bare `Write`, was reported as having curl/git-push). A
security finding that misdescribes the file is the credibility-killing defect.

Now `toolTokens()` + `matchedBroadTools()` enumerate the **specific** grants that matched
`BROAD_TOOL_RE` and name them, backtick-wrapped.

**Signal text only — zero severity/scoring impact.** Verified live: lobehub and hyperdx
both stay `high`; golden 15/15 severity separation intact.

## Adversarial review

A high-effort workflow `/code-review` of the first cut found 4 defects, all fixed here with
fail-without-fix regression tests:

- **Markdown injection** — the signal embeds scanned grant text that flows unescaped into
  the Action's PR comment (`render.ts`). Fix: backtick-wrap names + strip backtick/newline/
  bracket/quote in the tokenizer, so attacker-controlled grant text is markdown-inert.
- **Paren counter** — an unbalanced `(` left the depth counter stuck, merging later grants;
  switched to a boolean `inParen` toggle.
- **JSON cruft** — `settings.allowedTools` array literal (`["Bash","Write"]`) leaked brackets
  into names; now stripped.
- **Dedup drop** — dedup keyed on the truncated label dropped a distinct long grant; now
  keyed on the full token, truncate display-only.

## Verification

- Full suite **3480 passed** (+6 new tests); typecheck / lint / format clean.
- Live re-scan of lobehub confirms the honest signal (`` `Write` ``) end-to-end.
- Tier 1 of `ci-check-calibration-round6`. (T1.2 gh colon-scoped recognition reclassified to
  a later round — it changes severity, not a standalone bugfix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)