### PR TITLE
dev → main: enforcement hardening (B1 / auth strict-floor / config floor), audit convergence, posture CTAs, MCP pin lifecycle

### DIFF
--- a/packages/policy-engine/src/shields/builtin/redis.json
+++ b/packages/policy-engine/src/shields/builtin/redis.json
@@ -2,6 +2,7 @@
   "name": "redis",
   "description": "Protects Redis instances from destructive AI operations",
   "aliases": [],
+  "_scopeNote": "Every rule requires Redis to actually be involved: a client in the command (redis-cli / valkey-cli, in either order — `redis-cli FLUSHALL` and `echo FLUSHALL | redis-cli` are both real), OR the command field holding the bare keyword, which is what the MCP redis_command tool sends ({ command: 'FLUSHALL', args: [] }). Without the client requirement these rules matched the WORD anywhere — including prose in a heredoc writing a file — which produced two observed false positives: a test fixture describing the shield, and a commit message naming the rule. Every other builtin shield already scopes this way (aws s3, docker system prune, kubectl delete, gh repo delete). See redis-scope.spec.ts.",
   "smartRules": [
     {
       "name": "shield:redis:block-flushall",
@@ -10,7 +11,7 @@
         {
           "field": "command",
           "op": "matches",
-          "value": "\\bFLUSHALL\\b",
+          "value": "(redis|valkey)-cli.*\\bFLUSHALL\\b|\\bFLUSHALL\\b.*(redis|valkey)-cli|^ ?FLUSHALL\\b",
           "flags": "i"
         }
       ],
@@ -24,7 +25,7 @@
         {
           "field": "command",
           "op": "matches",
-          "value": "\\bFLUSHDB\\b",
+          "value": "(redis|valkey)-cli.*\\bFLUSHDB\\b|\\bFLUSHDB\\b.*(redis|valkey)-cli|^ ?FLUSHDB\\b",
           "flags": "i"
         }
       ],
@@ -38,7 +39,7 @@
         {
           "field": "command",
           "op": "matches",
-          "value": "\\bCONFIG\\s+RESETSTAT\\b",
+          "value": "(redis|valkey)-cli.*CONFIG RESETSTAT|CONFIG RESETSTAT.*(redis|valkey)-cli|^ ?CONFIG RESETSTAT",
           "flags": "i"
         }
       ],
@@ -52,7 +53,7 @@
         {
           "field": "command",
           "op": "matches",
-          "value": "\\bCONFIG\\s+SET\\b",
+          "value": "(redis|valkey)-cli.*\\bCONFIG SET\\b|\\bCONFIG SET\\b.*(redis|valkey)-cli|^ ?CONFIG SET\\b",
           "flags": "i"
         }
       ],
@@ -66,7 +67,7 @@
         {
           "field": "command",
           "op": "matches",
-          "value": "\\bDEL\\b.*[*?\\[]|redis-cli.*--scan.*\\|.*xargs.*del",
+          "value": "(redis|valkey)-cli.*\\bDEL\\b.*[*?\\[]|^ ?DEL\\b.*[*?\\[]|-cli.*--scan.*xargs.*del",
           "flags": "i"
         }
       ],

--- a/packages/policy-engine/src/shields/builtin/redis.json
+++ b/packages/policy-engine/src/shields/builtin/redis.json
@@ -11,7 +11,7 @@
         {
           "field": "command",
           "op": "matches",
-          "value": "(redis|valkey)-cli.*\\bFLUSHALL\\b|\\bFLUSHALL\\b.*(redis|valkey)-cli|^ ?FLUSHALL\\b",
+          "value": "(redis|valkey)-cli.*\\bFLUSHALL\\b|\\bFLUSHALL\\b.*(redis|valkey)-cli|^ ?FLUSHALL\\b|\\.flushall\\s*\\(",
           "flags": "i"
         }
       ],
@@ -25,7 +25,7 @@
         {
           "field": "command",
           "op": "matches",
-          "value": "(redis|valkey)-cli.*\\bFLUSHDB\\b|\\bFLUSHDB\\b.*(redis|valkey)-cli|^ ?FLUSHDB\\b",
+          "value": "(redis|valkey)-cli.*\\bFLUSHDB\\b|\\bFLUSHDB\\b.*(redis|valkey)-cli|^ ?FLUSHDB\\b|\\.flushdb\\s*\\(",
           "flags": "i"
         }
       ],
@@ -39,7 +39,7 @@
         {
           "field": "command",
           "op": "matches",
-          "value": "(redis|valkey)-cli.*CONFIG RESETSTAT|CONFIG RESETSTAT.*(redis|valkey)-cli|^ ?CONFIG RESETSTAT",
+          "value": "(redis|valkey)-cli.*CONFIG\\s+RESETSTAT|^ ?CONFIG\\s+RESETSTAT",
           "flags": "i"
         }
       ],
@@ -53,7 +53,7 @@
         {
           "field": "command",
           "op": "matches",
-          "value": "(redis|valkey)-cli.*\\bCONFIG SET\\b|\\bCONFIG SET\\b.*(redis|valkey)-cli|^ ?CONFIG SET\\b",
+          "value": "(redis|valkey)-cli.*\\bCONFIG\\s+SET\\b|\\bCONFIG\\s+SET\\b.*(redis|valkey)-cli|^ ?CONFIG\\s+SET\\b",
           "flags": "i"
         }
       ],

--- a/packages/policy-engine/src/shields/redis-scope.spec.ts
+++ b/packages/policy-engine/src/shields/redis-scope.spec.ts
@@ -43,8 +43,20 @@ describe('redis shield — must still catch real Redis operations', () => {
     ['block-flushall', 'echo FLUSHALL | redis-cli'],
     // MCP: the tool sends the bare keyword as the whole command field
     ['block-flushall', 'FLUSHALL'],
+    // Client LIBRARY calls in one-liners. The first cut of this fix dropped
+    // these — a review caught it by running old vs new patterns side by side.
+    // A literal dot+paren is self-limiting (the same property mongodb's rules
+    // rely on: `.dropDatabase(`), so it costs no false positives.
+    ['block-flushall', 'python3 -c "import redis; r = redis.Redis(); r.flushall()"'],
+    ['block-flushall', 'node -e "await client.flushAll()"'],
+    ['block-flushall', 'redis.flushall()'],
     ['block-flushdb', 'redis-cli FLUSHDB'],
     ['block-flushdb', 'FLUSHDB'],
+    ['block-flushdb', 'python3 -c "r.flushdb()"'],
+    // Whitespace: the CLOUD path (BE matchesParamsFilter) tests the raw value
+    // with NO whitespace collapsing, so these rules keep \s+ rather than a
+    // literal space.
+    ['review-config-set', 'redis-cli CONFIG  SET maxmemory 0'],
     ['block-config-resetstat', 'redis-cli CONFIG RESETSTAT'],
     ['block-config-resetstat', 'CONFIG RESETSTAT'],
     ['review-config-set', 'redis-cli CONFIG SET maxmemory 0'],

--- a/packages/policy-engine/src/shields/redis-scope.spec.ts
+++ b/packages/policy-engine/src/shields/redis-scope.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { BUILTIN_SHIELDS } from './index';
+import { evaluateSmartConditions } from '../rules';
+
+/**
+ * The Redis shield matched bare uppercase keywords on the `command` field with
+ * no requirement that Redis be involved at all. Two observed false positives,
+ * both from heredocs writing FILES:
+ *
+ *   • a test fixture: description: "FLUSHALL deletes every key"
+ *   • a commit message naming the rule: shield:redis:block-flushall
+ *
+ * Every other builtin shield already requires the invoking command in its
+ * pattern (`aws s3 …`, `docker system prune`, `kubectl delete …`,
+ * `gh repo delete`, `chmod …`). Redis was the outlier.
+ *
+ * The fix must satisfy BOTH callers, which is the whole difficulty:
+ *   1. shell — `redis-cli FLUSHALL`, where a client names itself
+ *   2. MCP   — the redis_command tool sends { command: "FLUSHALL", args: [] },
+ *              so the field holds the bare keyword and NOTHING else. Requiring
+ *              "redis-cli" alone would create a false negative on the most
+ *              direct route an agent has to the database.
+ */
+
+const rule = (name: string) => {
+  const r = BUILTIN_SHIELDS.redis.smartRules.find((x) => x.name?.endsWith(name));
+  if (!r) throw new Error(`redis rule not found: ${name}`);
+  return r;
+};
+
+const matches = (ruleName: string, command: string) =>
+  evaluateSmartConditions({ command }, rule(ruleName));
+
+describe('redis shield — must still catch real Redis operations', () => {
+  const TRUE_POSITIVES: Array<[string, string]> = [
+    // shell, client names itself
+    ['block-flushall', 'redis-cli FLUSHALL'],
+    ['block-flushall', 'redis-cli -h prod.example.com -p 6379 FLUSHALL'],
+    ['block-flushall', 'valkey-cli FLUSHALL'],
+    ['block-flushall', 'docker exec -it cache redis-cli FLUSHALL'],
+    ['block-flushall', 'redis-cli -u redis://prod/0 flushall'],
+    // client AFTER the keyword — a real invocation shape
+    ['block-flushall', 'echo FLUSHALL | redis-cli'],
+    // MCP: the tool sends the bare keyword as the whole command field
+    ['block-flushall', 'FLUSHALL'],
+    ['block-flushdb', 'redis-cli FLUSHDB'],
+    ['block-flushdb', 'FLUSHDB'],
+    ['block-config-resetstat', 'redis-cli CONFIG RESETSTAT'],
+    ['block-config-resetstat', 'CONFIG RESETSTAT'],
+    ['review-config-set', 'redis-cli CONFIG SET maxmemory 0'],
+    ['review-config-set', 'CONFIG SET appendonly no'],
+  ];
+
+  for (const [ruleName, command] of TRUE_POSITIVES) {
+    it(`${ruleName} still catches: ${command}`, () => {
+      expect(matches(ruleName, command)).toBe(true);
+    });
+  }
+});
+
+describe('redis shield — must NOT fire on text that merely mentions Redis', () => {
+  // The two REAL false positives, verbatim in shape.
+  const FALSE_POSITIVES: Array<[string, string]> = [
+    [
+      'block-flushall',
+      `python3 - <<'PYEOF'\ns = s.replace("x", 'description: "FLUSHALL deletes every key"')\nPYEOF`,
+    ],
+    [
+      'block-flushall',
+      `git commit -F - <<'EOF'\nfix(audit): one decision mapper\n[Blocked] (shield:redis:block-flushall)\nEOF`,
+    ],
+    // Same class, other rules — all four share the bare-keyword shape.
+    ['block-flushdb', `git commit -m "docs: explain block-flushdb"`],
+    ['block-config-resetstat', `cat > notes.md <<'EOF'\nCONFIG RESETSTAT wipes stats\nEOF`],
+    [
+      'review-config-set',
+      `python3 - <<'EOF'\nprint("CONFIG SET changes live server configuration")\nEOF`,
+    ],
+    // Prose about the shield, in ordinary tooling.
+    ['block-flushall', 'grep -rn "FLUSHALL" docs/'],
+    ['block-flushall', 'rg FLUSHALL --type ts'],
+    ['review-config-set', 'echo "CONFIG SET is reviewed by the redis shield"'],
+  ];
+
+  for (const [ruleName, command] of FALSE_POSITIVES) {
+    it(`${ruleName} ignores: ${command.split('\n')[0].slice(0, 52)}…`, () => {
+      expect(matches(ruleName, command)).toBe(false);
+    });
+  }
+});
+
+describe('redis shield — stays cloud-manageable', () => {
+  // cloudEnableable is false when ANY rule needs more than one condition (the
+  // legacy Policy.paramsFilter holds a single {path, regex}). Adding a second
+  // condition here would flip the WHOLE shield to CLI-only — exactly like
+  // docker — and break the cloud toggle the Apps page depends on.
+  it('every redis rule keeps exactly one condition', () => {
+    for (const r of BUILTIN_SHIELDS.redis.smartRules) {
+      expect(r.conditions?.length ?? 0).toBe(1);
+    }
+  });
+});

--- a/src/__tests__/audit-decision.unit.test.ts
+++ b/src/__tests__/audit-decision.unit.test.ts
@@ -124,3 +124,58 @@ describe('robustness', () => {
     expect(counts.unknown).toBeUndefined();
   });
 });
+
+/**
+ * The row form exists because the pair form let each caller pick where the
+ * second argument came from — and five callers made three different choices.
+ * The gate writes `checkedBy`; the PostToolUse hook and the daemon write
+ * `source`. Callers that read only `checkedBy` saw `undefined` on 37,576 rows
+ * of one real log, so a human APPROVING an action rendered "Auto-allowed" and a
+ * human REFUSING one rendered "Blocked".
+ */
+describe('row form — attribution comes from checkedBy OR source', () => {
+  // Shapes taken from the live log, with their real row counts.
+  const LIVE_ROWS: Array<[Record<string, unknown>, string, string]> = [
+    [{ decision: 'allowed', source: 'post-hook' }, 'allow', 'Ran'],
+    [{ decision: 'allow', source: 'daemon' }, 'allow', 'Approved'],
+    [{ decision: 'deny', source: 'daemon' }, 'deny', 'Denied'],
+    [{ decision: 'auto-deny', source: 'daemon' }, 'deny', 'Denied'],
+    [{ decision: 'allowed', source: 'inline-review-approved' }, 'allow', 'Approved'],
+    [{ decision: 'deny', source: 'timeout' }, 'deny', 'Timed out'],
+  ];
+
+  for (const [row, outcome, label] of LIVE_ROWS) {
+    it(`${row.decision}/${row.source} → ${label}`, () => {
+      const v = classifyDecision(row);
+      expect(v.outcome).toBe(outcome);
+      expect(v.label).toBe(label);
+    });
+  }
+
+  it('a source-only row classifies identically to the same row with checkedBy', () => {
+    for (const [row] of LIVE_ROWS) {
+      const viaSource = classifyDecision(row);
+      const viaCheckedBy = classifyDecision({ decision: row.decision, checkedBy: row.source });
+      expect(viaSource).toEqual(viaCheckedBy);
+    }
+  });
+
+  it('prefers checkedBy when a row carries both', () => {
+    expect(
+      classifyDecision({ decision: 'deny', checkedBy: 'timeout', source: 'daemon' }).label
+    ).toBe('Timed out');
+  });
+
+  // A row with neither field must still bucket correctly — the outcome is
+  // driven by `decision`, so attribution only ever costs the nuance.
+  it('classifies a row with no attribution at all', () => {
+    expect(classifyDecision({ decision: 'deny' }).outcome).toBe('deny');
+    expect(classifyDecision({ decision: 'allow' }).outcome).toBe('allow');
+  });
+
+  // A bare string is NOT a row — it must keep taking the legacy path.
+  it('still accepts the legacy (decision, checkedBy) pair', () => {
+    expect(classifyDecision('deny', 'timeout').label).toBe('Timed out');
+    expect(classifyDecision('allow').label).toBe('Auto-allowed');
+  });
+});

--- a/src/__tests__/audit-decision.unit.test.ts
+++ b/src/__tests__/audit-decision.unit.test.ts
@@ -173,6 +173,18 @@ describe('row form — attribution comes from checkedBy OR source', () => {
     expect(classifyDecision({ decision: 'allow' }).outcome).toBe('allow');
   });
 
+  // Regression: the row detector used to sniff for decision/checkedBy/source
+  // keys. An event row has NONE of them, so it fell through to the legacy
+  // branch and the whole object became the decision — the MCP audit reader
+  // printed `? [object Object]`. 2 such rows in a real log, unfiltered.
+  it('treats a keyless event row as a row, not as a decision value', () => {
+    const eventRow = { ts: '2026-05-10T10:00:00Z', event: 'shield-create', shield: 'gmail' };
+    const v = classifyDecision(eventRow);
+    expect(v.raw).toBe('');
+    expect(v.label).not.toContain('[object Object]');
+    expect(v.outcome).toBe('unknown'); // never an allow
+  });
+
   // A bare string is NOT a row — it must keep taking the legacy path.
   it('still accepts the legacy (decision, checkedBy) pair', () => {
     expect(classifyDecision('deny', 'timeout').label).toBe('Timed out');

--- a/src/__tests__/audit-decision.unit.test.ts
+++ b/src/__tests__/audit-decision.unit.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { classifyDecision } from '../audit/decision';
+
+/**
+ * Fixtures are the EXACT (decision, checkedBy) pairs present in a real 101k-row
+ * audit log, with their live counts — not invented shapes. The bug this covers
+ * survived because every reader was self-consistent against synthetic input.
+ */
+const LIVE_PAIRS: Array<[string | null, string, string, string]> = [
+  // decision, checkedBy, expected outcome, expected label
+  ['allowed', 'post-hook', 'allow', 'Ran'], //                     37,312
+  ['allow', 'local-policy', 'allow', 'Auto-allowed'], //           32,986
+  ['allow', 'ignored', 'allow', 'Auto-allowed'], //                 9,948
+  ['allow', 'observe-mode-would-block', 'observe', 'Would block'], //5,424
+  ['deny', 'timeout', 'deny', 'Timed out'], //                      3,643
+  ['deny', 'smart-rule-block', 'deny', 'Blocked'], //               2,885
+  ['allow', 'observe-mode', 'observe', 'Would block'], //           2,712
+  ['deny', 'app-permission-review', 'deny', 'Blocked'], //          2,649
+  ['deny', 'observe-mode-dlp-would-block', 'observe', 'Would block'], // 904
+  ['deny', 'persistent-deny', 'deny', 'Blocked'], //                  903
+  ['deny', 'app-permission-block', 'deny', 'Blocked'], //             718
+  ['deny', 'team-policy', 'deny', 'Blocked'], //                      336
+  ['allow', 'daemon', 'allow', 'Approved'], //                        283
+  ['allow', 'dlp-review-flagged', 'allow', 'Auto-allowed'], //        171
+  ['allow', 'cloud', 'allow', 'Approved'], //                         171
+  ['deny', 'dlp-block', 'deny', 'Blocked'], //                         55
+  ['deny', 'smart-rule-block-override', 'deny', 'Blocked'], //         38
+  ['dlp', 'response-dlp', 'info', 'Finding'], //                       30
+  ['deny', 'daemon', 'deny', 'Denied'], //                             16
+  ['deny', 'local-decision', 'deny', 'Denied'], //                     15
+  ['deny', 'loop-detected', 'deny', 'Blocked'], //                     14
+  ['auto-deny', 'daemon', 'deny', 'Denied'], //                        11
+  ['mcp-discovered', 'daemon', 'info', 'Info'], //                      5
+  ['allowed', 'inline-review-approved', 'allow', 'Approved'], //        1
+];
+
+describe('classifyDecision — every pair in a real log', () => {
+  for (const [decision, checkedBy, outcome, label] of LIVE_PAIRS) {
+    it(`${decision} + ${checkedBy} → ${label}`, () => {
+      const v = classifyDecision(decision, checkedBy);
+      expect(v.outcome).toBe(outcome);
+      expect(v.label).toBe(label);
+      expect(v.raw).toBe(String(decision));
+    });
+  }
+});
+
+describe('the two rules that must not be relaxed', () => {
+  // THE bug: the reader this replaces had a fall-through `else` of `[allow]`,
+  // so anything it didn't recognise reported as permitted — including all
+  // 12,176 `deny` rows.
+  it('never classifies an unrecognised decision as allow', () => {
+    // NB: 'BLOCK' is deliberately absent — it IS a known value (check.ts writes
+    // `block`, and matching is case-insensitive), so it must classify as deny.
+    for (const raw of ['quarantined', 'escalated', '', 'somethingNew', null, undefined, 42, {}]) {
+      const v = classifyDecision(raw, 'whatever');
+      expect(v.outcome).not.toBe('allow');
+      expect(v.outcome).toBe('unknown');
+    }
+  });
+
+  it('keeps the raw value visible so nothing is hidden by the mapping', () => {
+    expect(classifyDecision('escalated', 'x').label).toContain('escalated');
+    expect(classifyDecision('escalated', 'x').raw).toBe('escalated');
+  });
+
+  // 3,643 rows. "A human refused this" and "nobody was watching" need
+  // completely different responses.
+  it('distinguishes a timeout from a human refusal', () => {
+    const timedOut = classifyDecision('deny', 'timeout');
+    const refused = classifyDecision('deny', 'daemon');
+    expect(timedOut.label).toBe('Timed out');
+    expect(refused.label).toBe('Denied');
+    expect(timedOut.label).not.toBe(refused.label);
+    // …but both are still refusals for counting purposes.
+    expect(timedOut.outcome).toBe('deny');
+    expect(refused.outcome).toBe('deny');
+  });
+});
+
+describe('shadow mode is not an allow', () => {
+  // 9,040 rows: node9 WOULD have blocked these but observe mode let them
+  // through. Counting them as plain allows is what made shadow mode invisible.
+  it('classifies observe-mode as its own outcome regardless of stored decision', () => {
+    // one observe path writes `allow`, another writes `deny` — same concept
+    expect(classifyDecision('allow', 'observe-mode-would-block').outcome).toBe('observe');
+    expect(classifyDecision('deny', 'observe-mode-dlp-would-block').outcome).toBe('observe');
+  });
+
+  it('does not count a would-block as allowed', () => {
+    expect(classifyDecision('allow', 'observe-mode').outcome).not.toBe('allow');
+  });
+});
+
+describe('findings are not verdicts', () => {
+  // The CLI used to bucket these as DENY, inventing refusals that never were.
+  it('classifies dlp and mcp-discovered as info, not deny', () => {
+    expect(classifyDecision('dlp', 'response-dlp').outcome).toBe('info');
+    expect(classifyDecision('mcp-discovered', 'daemon').outcome).toBe('info');
+  });
+});
+
+describe('robustness', () => {
+  it('works without a checkedBy at all', () => {
+    expect(classifyDecision('deny').label).toBe('Blocked');
+    expect(classifyDecision('allow').label).toBe('Auto-allowed');
+  });
+
+  it('is case-insensitive on both fields', () => {
+    expect(classifyDecision('DENY', 'TIMEOUT').label).toBe('Timed out');
+    expect(classifyDecision('Allow', 'DAEMON').label).toBe('Approved');
+  });
+
+  // Golden: the distribution over the live pairs. A new producer that invents
+  // an eighth spelling changes these counts and fails here, instead of
+  // silently reporting as an allow in production.
+  it('produces the expected outcome distribution over the live pairs', () => {
+    const counts: Record<string, number> = {};
+    for (const [d, cb] of LIVE_PAIRS) {
+      const o = classifyDecision(d, cb).outcome;
+      counts[o] = (counts[o] ?? 0) + 1;
+    }
+    expect(counts).toEqual({ allow: 7, deny: 12, observe: 3, info: 2 });
+    expect(counts.unknown).toBeUndefined();
+  });
+});

--- a/src/__tests__/autostart-doctor.integration.test.ts
+++ b/src/__tests__/autostart-doctor.integration.test.ts
@@ -1,0 +1,196 @@
+/**
+ * A2 + B1 integration: `node9 doctor` must surface the two states behind the
+ * 6-day silent policy-staleness incident —
+ *   A2: autostart INSTALLED but DISABLED (a unit file on disk that never runs), and
+ *   B1: WHY the daemon is down, from daemon-startup.log.
+ *
+ * Integration, not unit (CLAUDE.md): doctor is a subprocess whose output and exit
+ * code are the contract, and both probes resolve paths through HOME.
+ *
+ * Faking systemd: a stub `systemctl` earlier on PATH. The runner's real systemd is
+ * never touched — `is-enabled` on CI would be nondeterministic, and enabling or
+ * disabling a real unit from a test is not acceptable. This works because the two
+ * probes are independent: isDaemonServiceInstalled() is fs.existsSync(unit file)
+ * (service.ts:190), while isDaemonServiceEnabled() shells out to systemctl.
+ *
+ * Requires `npm run build`.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const CLI = path.resolve(__dirname, '../../dist/cli.js');
+// Linux only, not merely "not Windows": the fixtures below fake systemd
+// specifically (a stub `systemctl` plus a unit file under ~/.config/systemd/user).
+// On darwin the probes go to launchd instead, so the stub is never consulted and
+// these assertions could not hold.
+const itUnix = it.skipIf(process.platform !== 'linux');
+// B1's cause line has nothing to do with systemd — it only needs the daemon-down
+// branch and a seeded log — so it runs anywhere but Windows.
+const itPosix = it.skipIf(process.platform === 'win32');
+
+let home: string;
+let stubBin: string;
+
+beforeAll(() => {
+  expect(fs.existsSync(CLI), `${CLI} missing — run npm run build`).toBe(true);
+});
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-doctor-'));
+  fs.mkdirSync(path.join(home, '.node9'), { recursive: true });
+  stubBin = path.join(home, 'bin');
+  fs.mkdirSync(stubBin, { recursive: true });
+  // Stub by default so NO test consults the developer's real systemd. Tests that
+  // care about autostart state re-stub explicitly; the rest simply must not vary
+  // by machine.
+  stubSystemctlDisabled();
+});
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+/** Report the unit as DISABLED without going near the real systemd. */
+function stubSystemctlDisabled() {
+  const p = path.join(stubBin, 'systemctl');
+  fs.writeFileSync(
+    p,
+    '#!/bin/bash\nif [ "$2" = "is-enabled" ]; then echo disabled; exit 1; fi\nexit 1\n',
+    'utf-8'
+  );
+  fs.chmodSync(p, 0o755);
+}
+
+/** A unit file on disk → isDaemonServiceInstalled() reports installed. */
+function installUnitFile() {
+  const dir = path.join(home, '.config', 'systemd', 'user');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'node9-daemon.service'), '[Unit]\nDescription=node9\n', 'utf-8');
+}
+
+function cloudEnabled(enabled = true) {
+  fs.writeFileSync(
+    path.join(home, '.node9', 'credentials.json'),
+    JSON.stringify({ default: { apiKey: 'fake' } }),
+    'utf-8'
+  );
+  fs.writeFileSync(
+    path.join(home, '.node9', 'config.json'),
+    JSON.stringify({ settings: { approvers: { cloud: enabled } } }),
+    'utf-8'
+  );
+}
+
+/** Seed the machine-readable startup STATE (not the human log — nothing parses that). */
+const seedStartupState = (state: object, msAgo = 60_000) =>
+  fs.writeFileSync(
+    path.join(home, '.node9', 'daemon-startup-state.json'),
+    JSON.stringify({ at: new Date(Date.now() - msAgo).toISOString(), ...state }),
+    'utf-8'
+  );
+
+function runDoctor() {
+  const baseEnv = { ...process.env };
+  delete baseEnv.NODE9_API_KEY;
+  delete baseEnv.NODE9_API_URL;
+  const r = spawnSync(process.execPath, [CLI, 'doctor'], {
+    encoding: 'utf-8',
+    timeout: 60000,
+    cwd: os.tmpdir(),
+    env: {
+      ...baseEnv,
+      HOME: home,
+      USERPROFILE: home,
+      PATH: `${stubBin}${path.delimiter}${process.env.PATH}`,
+      NO_COLOR: '1',
+      NODE9_NO_AUTO_DAEMON: '1',
+      NODE9_TESTING: '1',
+    },
+  });
+  expect(r.error).toBeUndefined();
+  expect(r.status).not.toBeNull();
+  return r;
+}
+
+describe('A2 — doctor surfaces autostart health', () => {
+  itUnix('warns when autostart is INSTALLED but DISABLED', () => {
+    cloudEnabled();
+    installUnitFile();
+    stubSystemctlDisabled();
+    const r = runDoctor();
+    expect(r.stdout).toMatch(/INSTALLED but DISABLED/);
+    expect(r.stdout).toMatch(/will NOT survive a reboot/);
+    // The exit-code contract: this is a LATENT risk on a machine that still
+    // enforces cached policy. Flipping doctor red here would break every CI
+    // health-check that greps its exit code.
+    expect(r.status).toBe(0);
+  });
+
+  itUnix('warns when no autostart unit is installed at all', () => {
+    cloudEnabled();
+    stubSystemctlDisabled();
+    const r = runDoctor();
+    expect(r.stdout).toMatch(/No daemon autostart installed/);
+    expect(r.status).toBe(0);
+  });
+
+  itUnix('says nothing about autostart in privacy mode (cloud disabled)', () => {
+    cloudEnabled(false);
+    installUnitFile();
+    stubSystemctlDisabled();
+    // A privacy-mode user never syncs cloud policy, so autostart health is not
+    // their problem — nagging them would be a false alarm.
+    expect(runDoctor().stdout).not.toMatch(/autostart/i);
+  });
+});
+
+describe('B1 — doctor reports WHY the daemon is down', () => {
+  itPosix('surfaces a recorded startup failure', () => {
+    cloudEnabled();
+    seedStartupState({ outcome: 'failed', kind: 'startup-throw', detail: 'boom' });
+    const r = runDoctor();
+    expect(r.stdout).toMatch(/last start attempt .+ ago: startup-throw — boom/);
+    expect(r.status).toBe(0); // a detail line on an existing warning, not a failure
+  });
+
+  itPosix('says NOTHING once the daemon has started successfully since', () => {
+    cloudEnabled();
+    // The state is overwritten by each attempt, so a success erases the earlier
+    // failure outright — no chance of blaming a crash that was fixed weeks ago.
+    seedStartupState({ outcome: 'ok' });
+    expect(runDoctor().stdout).not.toMatch(/last start attempt/);
+  });
+
+  itPosix('never presents a port conflict as the reason a daemon is not running', () => {
+    cloudEnabled();
+    // "another daemon owns the port" asserts a daemon IS up — printed beneath
+    // "Daemon not running" it contradicts the very warning it explains.
+    seedStartupState({ outcome: 'ok-elsewhere' });
+    expect(runDoctor().stdout).not.toMatch(/last start attempt/);
+  });
+
+  itPosix('reports a spawn that never reported back (the import-time crash)', () => {
+    cloudEnabled();
+    seedStartupState({ outcome: 'starting' }, 10 * 60 * 1000);
+    const r = runDoctor();
+    // A stranded 'starting' keeps the FIRST attempt's timestamp so the grace window
+    // can expire, so it must NOT be labelled as the last attempt — the age printed
+    // would be off by the length of the streak.
+    expect(r.stdout).toMatch(/start attempts failing since .+ ago: did-not-start/);
+    expect(r.stdout).not.toMatch(/last start attempt.*did-not-start/);
+    expect(r.stdout).toMatch(/daemon-startup\.log/); // points at the human artifact
+  });
+
+  itPosix('stays silent about a cause older than the recency window', () => {
+    cloudEnabled();
+    seedStartupState({ outcome: 'failed', kind: 'startup-throw' }, 48 * 60 * 60 * 1000);
+    expect(runDoctor().stdout).not.toMatch(/last start attempt/);
+  });
+
+  itPosix('says nothing when there is no startup state at all', () => {
+    cloudEnabled();
+    expect(runDoctor().stdout).not.toMatch(/last start attempt/);
+  });
+});

--- a/src/__tests__/autostart-skip.integration.test.ts
+++ b/src/__tests__/autostart-skip.integration.test.ts
@@ -1,0 +1,133 @@
+/**
+ * A4a integration: when the enforcement hot path finds the daemon down and does
+ * NOT auto-start it, it must leave a throttled breadcrumb saying WHY. Before this,
+ * "why didn't the daemon come up?" was unanswerable — the root cause of a 6-day
+ * silent policy staleness incident.
+ *
+ * Must be an integration test, not a unit test: the breadcrumb is written by a
+ * spawned `dist/cli.js` to a HOME-derived path, and CLAUDE.md requires integration
+ * coverage for subprocess commands, file writes, and HOME-dependent behavior. A
+ * mocked-fs unit test cannot catch the very bug this file's last case guards.
+ *
+ * NOTE: these tests deliberately do NOT set NODE9_TESTING=1 (the convention in
+ * check.integration.test.ts) — isTestingMode() short-circuits the exact branch
+ * under test, so a test that set it would pass while asserting nothing.
+ *
+ * Requires `npm run build`.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const CLI = path.resolve(__dirname, '../../dist/cli.js');
+const PAYLOAD = JSON.stringify({
+  tool_name: 'Bash',
+  tool_input: { command: 'ls' },
+  cwd: '/tmp',
+});
+
+let home: string;
+
+beforeAll(() => {
+  expect(fs.existsSync(CLI), `${CLI} missing — run npm run build`).toBe(true);
+});
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-skip-'));
+});
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+/** Run `node9 check` against the isolated HOME. NODE9_TESTING is intentionally absent. */
+function runCheck(env: Record<string, string> = {}) {
+  const baseEnv = { ...process.env };
+  delete baseEnv.NODE9_API_KEY;
+  delete baseEnv.NODE9_API_URL;
+  delete baseEnv.NODE9_TESTING; // would short-circuit the branch under test
+  const r = spawnSync(process.execPath, [CLI, 'check', PAYLOAD], {
+    encoding: 'utf-8',
+    timeout: 60000,
+    cwd: os.tmpdir(), // don't pick up the repo's own node9.config.json
+    env: { ...baseEnv, HOME: home, USERPROFILE: home, NO_COLOR: '1', ...env },
+  });
+  expect(r.error).toBeUndefined();
+  expect(r.status).not.toBeNull();
+  return r;
+}
+
+const hookDebug = () => path.join(home, '.node9', 'hook-debug.log');
+const stamp = () => path.join(home, '.node9', '.autostart-skip-stamp');
+
+function breadcrumbs(): string[] {
+  if (!fs.existsSync(hookDebug())) return [];
+  return fs
+    .readFileSync(hookDebug(), 'utf-8')
+    .split('\n')
+    .filter((l) => l.includes('daemon-autostart-skip'));
+}
+
+const withNode9Dir = () => fs.mkdirSync(path.join(home, '.node9'), { recursive: true });
+
+describe('A4a — the hot path records WHY a down daemon was not started', () => {
+  it('records NODE9_NO_AUTO_DAEMON as the reason', () => {
+    withNode9Dir();
+    runCheck({ NODE9_NO_AUTO_DAEMON: '1' });
+    expect(breadcrumbs()[0]).toMatch(/daemon-autostart-skip: NODE9_NO_AUTO_DAEMON/);
+  });
+
+  it('records autoStartDaemon=false as the reason', () => {
+    withNode9Dir();
+    fs.writeFileSync(
+      path.join(home, '.node9', 'config.json'),
+      JSON.stringify({ settings: { autoStartDaemon: false } }),
+      'utf-8'
+    );
+    runCheck();
+    expect(breadcrumbs()[0]).toMatch(/daemon-autostart-skip: autoStartDaemon=false/);
+  });
+
+  it('throttles: a second immediate call does not duplicate the breadcrumb', () => {
+    withNode9Dir();
+    runCheck({ NODE9_NO_AUTO_DAEMON: '1' });
+    runCheck({ NODE9_NO_AUTO_DAEMON: '1' });
+    // This runs on the enforcement hot path — one line per tool call would bury
+    // hook-debug.log.
+    expect(breadcrumbs()).toHaveLength(1);
+    expect(fs.existsSync(stamp())).toBe(true);
+  });
+
+  it('logs again once the throttle window has passed', () => {
+    withNode9Dir();
+    runCheck({ NODE9_NO_AUTO_DAEMON: '1' });
+    const old = new Date(Date.now() - 2 * 60 * 60 * 1000); // window is 1h
+    fs.utimesSync(stamp(), old, old);
+    runCheck({ NODE9_NO_AUTO_DAEMON: '1' });
+    expect(breadcrumbs()).toHaveLength(2);
+  });
+
+  it('arms the throttle even when the breadcrumb cannot be written', () => {
+    // This runs once per tool call on the enforcement hot path, so the throttle
+    // must be armed before anything that can fail. If a persistent append failure
+    // left it unarmed, every subsequent tool call would retry filesystem work
+    // forever. Losing up to an hour of breadcrumbs on a machine that is already
+    // refusing writes is the cheaper failure.
+    withNode9Dir();
+    fs.mkdirSync(hookDebug()); // a directory → appendFileSync throws EISDIR
+    runCheck({ NODE9_NO_AUTO_DAEMON: '1' });
+    expect(fs.existsSync(stamp())).toBe(true);
+  });
+
+  it('records the breadcrumb on a FRESH machine, where ~/.node9 does not exist yet', () => {
+    // Regression guard (C2). The autostart block runs BEFORE the writes that
+    // happen to create ~/.node9, so without an explicit mkdir the append throws
+    // ENOENT into a best-effort `catch {}` and the very first breadcrumb — on the
+    // machine most likely to have a broken daemon — vanishes silently. A silent
+    // diagnostic is the exact failure this whole feature exists to eliminate.
+    expect(fs.existsSync(path.join(home, '.node9'))).toBe(false);
+    runCheck({ NODE9_NO_AUTO_DAEMON: '1' });
+    expect(breadcrumbs()[0]).toMatch(/daemon-autostart-skip: NODE9_NO_AUTO_DAEMON/);
+  });
+});

--- a/src/__tests__/b1-cloud-shield-unweakenable.spec.ts
+++ b/src/__tests__/b1-cloud-shield-unweakenable.spec.ts
@@ -62,9 +62,30 @@ describe('B1 — cloud-mandated shield ignores local overrides', () => {
     _resetConfigCache();
   };
 
-  /** The enforced verdict for RULE, read off the merged policy. */
-  const enforcedVerdict = (): string | undefined =>
-    getConfig().policy.smartRules.find((r) => r.name === RULE)?.verdict;
+  /** A user rule that COLLIDES with the shield's rule name, verdict allow. The
+   *  second B1 hole: this used to suppress the cloud shield's block rule as a
+   *  "duplicate". `where` = 'global' (~/.node9/config.json) or 'project'
+   *  (a repo-checked-in node9.config.json — the supply-chain vector). */
+  const setCollidingUserRule = (where: 'global' | 'project') => {
+    const rule = {
+      name: RULE,
+      tool: '*',
+      conditions: [{ field: 'command', op: 'matches', value: 'FLUSHALL', flags: 'i' }],
+      verdict: 'allow',
+    };
+    const body = JSON.stringify({ policy: { smartRules: [rule] } });
+    const file =
+      where === 'global'
+        ? path.join(tmpHome, '.node9', 'config.json')
+        : path.join(tmpHome, 'node9.config.json');
+    fs.writeFileSync(file, body);
+    _resetConfigCache();
+  };
+
+  /** The enforced verdict for RULE, read off the merged policy. `cwd` is needed
+   *  for the project-config case, whose path is cwd-relative. */
+  const enforcedVerdict = (cwd?: string): string | undefined =>
+    getConfig(cwd).policy.smartRules.find((r) => r.name === RULE)?.verdict;
 
   beforeEach(() => {
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-b1-'));
@@ -129,6 +150,35 @@ describe('B1 — cloud-mandated shield ignores local overrides', () => {
     expect(enforcedVerdict()).toBe('block');
   });
 
+  // ── Part 2: the name-collision hole (found in review of the part-1 commit) ─
+  // User config is merged into the policy BEFORE the shield loop, so a rule
+  // named exactly like a shield rule used to SUPPRESS the shield's version as a
+  // "duplicate". Part 1 (no override) did not close this — the rule never
+  // reached the override path; it pre-empted it.
+  it('a global config.json rule cannot suppress a cloud shield rule', () => {
+    setCloud(['redis']);
+    setCollidingUserRule('global');
+    expect(enforcedVerdict()).toBe('block');
+  });
+
+  // The higher-severity vector: NOT self-inflicted. A cloned repo ships a
+  // node9.config.json naming a fleet-mandated shield rule; running an agent in
+  // that directory would weaken the victim's cloud mandate.
+  it('a repo project node9.config.json cannot suppress a cloud shield rule', () => {
+    setCloud(['redis']);
+    setCollidingUserRule('project');
+    expect(enforcedVerdict(tmpHome)).toBe('block');
+  });
+
+  // A local (non-cloud) shield keeps today's behaviour: the user owns both
+  // their local shield and their config, so a same-named config rule may still
+  // win. The fix must not over-reach into legitimate local composition.
+  it('a config rule still wins over a purely-LOCAL shield rule (no over-reach)', () => {
+    setLocal(['redis']);
+    setCollidingUserRule('global');
+    expect(enforcedVerdict()).toBe('allow');
+  });
+
   // ── At the real gate ──────────────────────────────────────────────────────
   // Reading the merged verdict field is the merge output; this proves the
   // ENGINE acts on it. A FLUSHALL, with the shield cloud-mandated and a local
@@ -146,5 +196,14 @@ describe('B1 — cloud-mandated shield ignores local overrides', () => {
     setLocal(['redis'], { redis: { [RULE]: 'allow' } });
     const r = await evaluatePolicy('Bash', { command: 'redis-cli FLUSHALL' });
     expect(r.decision).not.toBe('block');
+  });
+
+  // The collision hole, at the gate: a global config rule that suppressed the
+  // shield rule must NOT let FLUSHALL through once the shield is cloud-mandated.
+  it('blocks FLUSHALL through the engine despite a colliding config rule', async () => {
+    setCloud(['redis']);
+    setCollidingUserRule('global');
+    const r = await evaluatePolicy('Bash', { command: 'redis-cli FLUSHALL' });
+    expect(r.decision).toBe('block');
   });
 });

--- a/src/__tests__/b1-cloud-shield-unweakenable.spec.ts
+++ b/src/__tests__/b1-cloud-shield-unweakenable.spec.ts
@@ -1,0 +1,150 @@
+// B1 — a cloud-mandated shield must be un-weakenable by a local override.
+//
+// The hole: `node9 shield set redis <rule> allow --force` writes a per-rule
+// override to ~/.node9/shields.json, and config/index.ts applied it to EVERY
+// shield in `local ∪ cloudManagedShields` — so a developer could weaken a
+// shield the dashboard mandated fleet-wide. The comment at config/index.ts:751
+// promised "a developer can add more locally, never weaken these"; this is the
+// test that promise was never backed by.
+//
+// Driven through the REAL merge (getConfig) with the REAL shield catalog. Only
+// the two local-file readers are mocked, because their path
+// (SHIELDS_STATE_FILE, shields.ts:95) is a module-load-time const that a HOME
+// override in beforeEach cannot move — setting HOME would read this machine's
+// real shields.json. The cloud side (rules-cache) IS redirected by HOME,
+// because config/index.ts computes that path per-call.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const activeShields = { current: [] as string[] };
+const shieldOverrides = {
+  current: {} as Record<string, Record<string, string>>,
+};
+
+vi.mock('../shields', async () => {
+  const actual = await vi.importActual<typeof import('../shields')>('../shields');
+  return {
+    ...actual,
+    readActiveShields: () => activeShields.current,
+    readShieldOverrides: () => shieldOverrides.current,
+  };
+});
+
+import { getConfig, _resetConfigCache } from '../config';
+import { evaluatePolicy } from '../core.js';
+
+const RULE = 'shield:redis:block-flushall'; // ships verdict: block
+
+describe('B1 — cloud-mandated shield ignores local overrides', () => {
+  let tmpHome: string;
+  let origHome: string | undefined;
+  let origUserprofile: string | undefined;
+
+  const setCloud = (cloudShields: string[] | null) => {
+    if (cloudShields) {
+      fs.writeFileSync(
+        path.join(tmpHome, '.node9', 'rules-cache.json'),
+        JSON.stringify({
+          fetchedAt: '2026-07-01T00:00:00Z',
+          rules: [],
+          shields: cloudShields,
+        })
+      );
+    }
+    _resetConfigCache();
+  };
+
+  const setLocal = (active: string[], overrides: Record<string, Record<string, string>> = {}) => {
+    activeShields.current = active;
+    shieldOverrides.current = overrides;
+    _resetConfigCache();
+  };
+
+  /** The enforced verdict for RULE, read off the merged policy. */
+  const enforcedVerdict = (): string | undefined =>
+    getConfig().policy.smartRules.find((r) => r.name === RULE)?.verdict;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-b1-'));
+    origHome = process.env.HOME;
+    origUserprofile = process.env.USERPROFILE;
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    fs.mkdirSync(path.join(tmpHome, '.node9'), { recursive: true });
+    activeShields.current = [];
+    shieldOverrides.current = {};
+    _resetConfigCache();
+  });
+
+  afterEach(() => {
+    if (origHome !== undefined) process.env.HOME = origHome;
+    else delete process.env.HOME;
+    if (origUserprofile !== undefined) process.env.USERPROFILE = origUserprofile;
+    else delete process.env.USERPROFILE;
+    _resetConfigCache();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  // ── Row 0: the mocks actually drive the merge (guards against a vacuous
+  //    suite — if the override path is dead, every row below passes for the
+  //    wrong reason, which is exactly what a first cut of this file did) ─────
+  it('a local override DOES apply to a purely-local shield (control)', () => {
+    setLocal(['redis'], { redis: { [RULE]: 'allow' } });
+    expect(enforcedVerdict()).toBe('allow');
+  });
+
+  // ── Row 1: THE security regression. Must fail against pre-fix code. ────────
+  it('does NOT weaken a cloud-mandated shield when a local override says allow', () => {
+    setCloud(['redis']);
+    setLocal([], { redis: { [RULE]: 'allow' } });
+    expect(enforcedVerdict()).toBe('block');
+  });
+
+  // ── Row 2: absolute, not "block weakening only" ───────────────────────────
+  it('ignores a local TIGHTENING override on a cloud shield too', () => {
+    setCloud(['redis']);
+    setLocal([], { redis: { [RULE]: 'review' } });
+    expect(enforcedVerdict()).toBe('block');
+  });
+
+  // ── Row 3: the guard against over-reach ───────────────────────────────────
+  it('still honours a local override on a LOCALLY-enabled shield', () => {
+    setLocal(['redis'], { redis: { [RULE]: 'allow' } });
+    expect(enforcedVerdict()).toBe('allow');
+  });
+
+  // ── Row 4: cloud wins the union ───────────────────────────────────────────
+  it('cloud mandate wins even if the shield was also enabled locally first', () => {
+    setCloud(['redis']);
+    setLocal(['redis'], { redis: { [RULE]: 'allow' } });
+    expect(enforcedVerdict()).toBe('block');
+  });
+
+  // ── Row 6: no regression on the common case ───────────────────────────────
+  it('applies the cloud verdict unchanged when there is no local override', () => {
+    setCloud(['redis']);
+    setLocal([]);
+    expect(enforcedVerdict()).toBe('block');
+  });
+
+  // ── At the real gate ──────────────────────────────────────────────────────
+  // Reading the merged verdict field is the merge output; this proves the
+  // ENGINE acts on it. A FLUSHALL, with the shield cloud-mandated and a local
+  // override set to allow, must still BLOCK — gate-not-cage, un-weakened.
+  it('actually blocks FLUSHALL through the engine despite a local allow override', async () => {
+    setCloud(['redis']);
+    setLocal([], { redis: { [RULE]: 'allow' } });
+    const r = await evaluatePolicy('Bash', { command: 'redis-cli FLUSHALL' });
+    expect(r.decision).toBe('block');
+  });
+
+  // And the legitimate case is not caught by the gate: a purely-local shield's
+  // allow override really does let FLUSHALL through.
+  it('lets FLUSHALL through the engine for a purely-local allow override', async () => {
+    setLocal(['redis'], { redis: { [RULE]: 'allow' } });
+    const r = await evaluatePolicy('Bash', { command: 'redis-cli FLUSHALL' });
+    expect(r.decision).not.toBe('block');
+  });
+});

--- a/src/__tests__/b1-cloud-shield-unweakenable.spec.ts
+++ b/src/__tests__/b1-cloud-shield-unweakenable.spec.ts
@@ -22,6 +22,12 @@ const activeShields = { current: [] as string[] };
 const shieldOverrides = {
   current: {} as Record<string, Record<string, string>>,
 };
+// Lets a test shadow getShield with a WEAK body (as a user ~/.node9/shields/<name>.json
+// would) to prove a MANDATED shield ignores it and resolves from BUILTIN_SHIELDS (#2).
+// Null = pass through to the real catalog (every other test).
+const getShieldImpl = {
+  current: null as null | ((name: string) => unknown),
+};
 
 vi.mock('../shields', async () => {
   const actual = await vi.importActual<typeof import('../shields')>('../shields');
@@ -29,6 +35,8 @@ vi.mock('../shields', async () => {
     ...actual,
     readActiveShields: () => activeShields.current,
     readShieldOverrides: () => shieldOverrides.current,
+    getShield: (name: string) =>
+      getShieldImpl.current ? getShieldImpl.current(name) : actual.getShield(name),
   };
 });
 
@@ -96,10 +104,13 @@ describe('B1 — cloud-mandated shield ignores local overrides', () => {
     fs.mkdirSync(path.join(tmpHome, '.node9'), { recursive: true });
     activeShields.current = [];
     shieldOverrides.current = {};
+    getShieldImpl.current = null;
+    delete process.env.NODE9_MODE;
     _resetConfigCache();
   });
 
   afterEach(() => {
+    delete process.env.NODE9_MODE;
     if (origHome !== undefined) process.env.HOME = origHome;
     else delete process.env.HOME;
     if (origUserprofile !== undefined) process.env.USERPROFILE = origUserprofile;
@@ -205,5 +216,101 @@ describe('B1 — cloud-mandated shield ignores local overrides', () => {
     setCollidingUserRule('global');
     const r = await evaluatePolicy('Bash', { command: 'redis-cli FLUSHALL' });
     expect(r.decision).toBe('block');
+  });
+
+  // ── Remaining bypasses ABOVE the rule-verdict layer (b1-remaining-bypasses) ──
+  // Each was reproduced at the real getConfig gate BEFORE the fix (allow /
+  // observe / Bash-ignored) and must now hold. The earlier B1 review wrongly
+  // marked #1 "refuted"; it is real (first-match-in-array-order, shields
+  // un-pinned), fixed by pinning mandated shield rules.
+
+  const writeGlobalConfig = (obj: unknown) => {
+    fs.writeFileSync(path.join(tmpHome, '.node9', 'config.json'), JSON.stringify(obj));
+    _resetConfigCache();
+  };
+  const setManagedMode = (mode: string, lock: boolean) => {
+    fs.writeFileSync(
+      path.join(tmpHome, '.node9', 'rules-cache.json'),
+      JSON.stringify({
+        fetchedAt: '2026-07-01T00:00:00Z',
+        rules: [],
+        shields: [],
+        managedConfig: { mode, ...(lock ? { locked: ['mode'] } : {}) },
+      })
+    );
+    _resetConfigCache();
+  };
+
+  // #1 — a DIFFERENTLY-named local allow can no longer out-precede a mandate.
+  it('#1 blocks FLUSHALL despite a differently-named local allow rule', async () => {
+    setCloud(['redis']);
+    writeGlobalConfig({
+      policy: {
+        smartRules: [
+          {
+            name: 'my-innocuous-allow',
+            tool: '*',
+            conditions: [{ field: 'command', op: 'matches', value: 'FLUSHALL', flags: 'i' }],
+            verdict: 'allow',
+          },
+        ],
+      },
+    });
+    const r = await evaluatePolicy('Bash', { command: 'redis-cli FLUSHALL' });
+    expect(r.decision).toBe('block');
+  });
+
+  it('#1 pins a mandated shield rule in the merged policy', () => {
+    setCloud(['redis']);
+    expect(getConfig().policy.smartRules.find((r) => r.name === RULE)?.pinned).toBe(true);
+  });
+
+  it('#1 does NOT pin a purely-local shield rule (no over-reach)', () => {
+    setLocal(['redis']);
+    expect(getConfig().policy.smartRules.find((r) => r.name === RULE)?.pinned).toBeUndefined();
+  });
+
+  // #2 — NODE9_MODE (applied last) must respect a cloud-controlled mode.
+  it('#2 NODE9_MODE cannot override a cloud-LOCKED mode', () => {
+    setManagedMode('standard', true);
+    process.env.NODE9_MODE = 'observe';
+    expect(getConfig().settings.mode).toBe('standard');
+  });
+
+  it('#2 NODE9_MODE still applies when the cloud has not set mode (dev convenience)', () => {
+    process.env.NODE9_MODE = 'observe';
+    expect(getConfig().settings.mode).toBe('observe');
+  });
+
+  it('#2 ignores a garbage NODE9_MODE value', () => {
+    process.env.NODE9_MODE = 'wide-open';
+    expect(getConfig().settings.mode).not.toBe('wide-open');
+  });
+
+  // #2b — a mandated shield resolves its BODY from BUILTIN_SHIELDS, not a user
+  // shields/<name>.json shadowing the name with an empty/weak body.
+  it('#2b a mandated shield ignores a shadowing weak user shield body', () => {
+    getShieldImpl.current = (name) => (name === 'redis' ? { name: 'redis', smartRules: [] } : null);
+    setCloud(['redis']);
+    expect(getConfig().policy.smartRules.find((r) => r.name === RULE)?.verdict).toBe('block');
+  });
+
+  // #3 — local ignoredTools/sandboxPaths cannot fast-path past a mandated shield.
+  it('#3 drops local ignoredTools when the fleet mandates shields', () => {
+    setCloud(['redis']);
+    writeGlobalConfig({ policy: { ignoredTools: ['Bash'] } });
+    expect(getConfig().policy.ignoredTools).not.toContain('Bash');
+  });
+
+  it('#3 blocks FLUSHALL despite local ignoredTools:[Bash] under a mandate', async () => {
+    setCloud(['redis']);
+    writeGlobalConfig({ policy: { ignoredTools: ['Bash'] } });
+    const r = await evaluatePolicy('Bash', { command: 'redis-cli FLUSHALL' });
+    expect(r.decision).toBe('block');
+  });
+
+  it('#3 keeps local ignoredTools when NO shield is mandated (no over-reach)', () => {
+    writeGlobalConfig({ policy: { ignoredTools: ['Grep'] } });
+    expect(getConfig().policy.ignoredTools).toContain('Grep');
   });
 });

--- a/src/__tests__/b1-cloud-shield-unweakenable.spec.ts
+++ b/src/__tests__/b1-cloud-shield-unweakenable.spec.ts
@@ -313,4 +313,105 @@ describe('B1 — cloud-mandated shield ignores local overrides', () => {
     writeGlobalConfig({ policy: { ignoredTools: ['Grep'] } });
     expect(getConfig().policy.ignoredTools).toContain('Grep');
   });
+
+  // ── 2nd review: mode floor under a mandate + two hardenings ──────────────────
+  // b1-mode-floor-and-hardening-design.md. observe/audit make the orchestrator
+  // return approved:true (no enforcement), so a LOCAL one disables every mandated
+  // shield. Reproduced at the real getConfig gate before the fix.
+  const writeRulesCache = (obj: Record<string, unknown>) => {
+    fs.writeFileSync(
+      path.join(tmpHome, '.node9', 'rules-cache.json'),
+      JSON.stringify({
+        fetchedAt: '2026-07-01T00:00:00Z',
+        rules: [],
+        shields: [],
+        ...obj,
+      })
+    );
+    _resetConfigCache();
+  };
+
+  // FINDING 1 — floor LOCAL observe/audit to standard under a shield mandate.
+  it('F1 floors NODE9_MODE=observe to standard under a shield mandate', () => {
+    setCloud(['redis']);
+    process.env.NODE9_MODE = 'observe';
+    expect(getConfig().settings.mode).toBe('standard');
+  });
+
+  it('F1 floors NODE9_MODE=audit to standard under a shield mandate', () => {
+    setCloud(['redis']);
+    process.env.NODE9_MODE = 'audit';
+    expect(getConfig().settings.mode).toBe('standard');
+  });
+
+  it('F1 floors a local config.json observe mode to standard under a mandate', () => {
+    setCloud(['redis']);
+    writeGlobalConfig({ settings: { mode: 'observe' } });
+    expect(getConfig().settings.mode).toBe('standard');
+  });
+
+  // The fleet's OWN observe decision is honored — floor is for LOCAL input only.
+  // (A cloud-LOCKED observe: the fleet deliberately forces observe, e.g. a staged
+  // trial. An UNLOCKED managed observe is only a floor the dev's standard already
+  // exceeds, so it correctly resolves to standard — a different case.)
+  it('F1 HONORS a cloud-LOCKED observe mode under a mandate', () => {
+    writeRulesCache({
+      shields: ['redis'],
+      managedConfig: { mode: 'observe', locked: ['mode'] },
+    });
+    expect(getConfig().settings.mode).toBe('observe');
+  });
+
+  it('F1 HONORS a cloud shadowMode staged observe under a mandate', () => {
+    writeRulesCache({ shields: ['redis'], shadowMode: true });
+    expect(getConfig().settings.mode).toBe('observe');
+  });
+
+  it('F1 leaves local observe alone when NO shield is mandated (dev convenience)', () => {
+    process.env.NODE9_MODE = 'observe';
+    expect(getConfig().settings.mode).toBe('observe');
+  });
+
+  // FINDING 2 — a mandated name absent from the builtin catalog fails closed
+  // (dropped), never a shadowable local body.
+  it('F2 drops a non-builtin mandated shield instead of trusting a local body', () => {
+    getShieldImpl.current = (name) =>
+      name === 'corp-secrets'
+        ? {
+            name: 'corp-secrets',
+            smartRules: [
+              {
+                name: 'shield:corp-secrets:leak',
+                tool: '*',
+                conditions: [],
+                verdict: 'allow',
+              },
+            ],
+          }
+        : null;
+    setCloud(['corp-secrets']);
+    expect(
+      getConfig().policy.smartRules.find((r) => r.name === 'shield:corp-secrets:leak')
+    ).toBeUndefined();
+  });
+
+  // FINDING 3 — pinned is stripped from applyLayer rules (local config AND the
+  // locally-writable rules-cache). rules-cache bypasses zod, so this proves the
+  // explicit strip, not zod's incidental drop of the unknown key.
+  it('F3 strips pinned from a locally-writable rules-cache rule', () => {
+    writeRulesCache({
+      rules: [
+        {
+          name: 'attacker-pinned-allow',
+          tool: '*',
+          conditions: [{ field: 'command', op: 'matches', value: 'FLUSHALL', flags: 'i' }],
+          verdict: 'allow',
+          pinned: true,
+        },
+      ],
+    });
+    const rule = getConfig().policy.smartRules.find((r) => r.name === 'attacker-pinned-allow');
+    expect(rule).toBeDefined();
+    expect((rule as { pinned?: boolean }).pinned).toBeUndefined();
+  });
 });

--- a/src/__tests__/daemon-report-blocked.unit.test.ts
+++ b/src/__tests__/daemon-report-blocked.unit.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Regression — GET /report contradicted itself.
+ *
+ * `summary.blocked` was converged onto `classifyDecision`, but
+ * `topBlockedTools` and `byAgent.blocked` kept their own
+ * `!decision.startsWith('allow')` rule twelve lines below, reading the SAME
+ * `entries` array. On a real 101k-row log that made one response disagree with
+ * itself by 950 rows: 11,646 vs 12,596.
+ *
+ * The invariant these tests protect is not a number, it is an agreement:
+ * every blocked count in the body comes from one rule.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildDaemonReport } from '../daemon/server';
+
+const NOW = new Date('2026-05-10T15:00:00Z');
+const TS = '2026-05-10T10:00:00Z';
+
+/** Shapes taken from a real audit log, not invented. */
+const ROWS: Array<Record<string, unknown>> = [
+  { ts: TS, tool: 'Bash', decision: 'allow', checkedBy: 'local-policy', agent: 'Claude Code' },
+  // Real refusals — the only rows any blocked count should include.
+  { ts: TS, tool: 'Bash', decision: 'deny', checkedBy: 'smart-rule-block', agent: 'Claude Code' },
+  { ts: TS, tool: 'Bash', decision: 'deny', checkedBy: 'timeout', agent: 'Claude Code' },
+  // Shadow mode: flagged, but the action RAN. Not a refusal.
+  {
+    ts: TS,
+    tool: 'Bash',
+    decision: 'deny',
+    checkedBy: 'observe-mode-dlp-would-block',
+    agent: 'Claude Code',
+  },
+  {
+    ts: TS,
+    tool: 'Bash',
+    decision: 'allow',
+    checkedBy: 'observe-mode-would-block',
+    agent: 'Claude Code',
+  },
+  // A finding and a discovery event — not verdicts at all.
+  {
+    ts: TS,
+    tool: 'mcp__redis__redis_get',
+    decision: 'mcp-discovered',
+    source: 'daemon',
+    agent: 'Claude Code',
+  },
+];
+
+describe('buildDaemonReport — one rule for every blocked count', () => {
+  it('summary.blocked, topBlockedTools and byAgent.blocked agree', () => {
+    const body = buildDaemonReport(ROWS, '7d', NOW);
+
+    const fromTop = body.topBlockedTools.reduce((n, t) => n + t.value, 0);
+    const fromAgents = body.byAgent.reduce((n, a) => n + a.blocked, 0);
+    const fromDaily = body.daily.reduce((n, d) => n + d.blocked, 0);
+
+    // The agreement IS the invariant — assert it before the value.
+    expect(fromTop).toBe(body.summary.blocked);
+    expect(fromAgents).toBe(body.summary.blocked);
+    expect(fromDaily).toBe(body.summary.blocked);
+
+    // And the value: only the two genuine refusals.
+    expect(body.summary.blocked).toBe(2);
+  });
+
+  it('does not count shadow-mode rows or findings as blocks', () => {
+    const body = buildDaemonReport(ROWS, '7d', NOW);
+    // 6 rows in, 2 refused. The old rule scored 4 (both observe rows minus the
+    // allow-flavoured one, plus the discovery event).
+    expect(body.summary.total).toBe(6);
+    expect(body.summary.blocked).toBe(2);
+    expect(body.byAgent.find((a) => a.agent === 'Claude Code')?.blocked).toBe(2);
+    expect(body.topBlockedTools.find((t) => t.name === 'mcp__redis__redis_get')).toBeUndefined();
+  });
+
+  it('holds for the today/hourly bucketing path too', () => {
+    // 'today' takes a different branch (24 pre-populated hour buckets), which
+    // carried its own copy of the blocked test.
+    const rows = ROWS.map((r) => ({ ...r, ts: NOW.toISOString() }));
+    const body = buildDaemonReport(rows, 'today', NOW);
+    const fromDaily = body.daily.reduce((n, d) => n + d.blocked, 0);
+    expect(fromDaily).toBe(body.summary.blocked);
+    expect(body.daily).toHaveLength(24);
+  });
+
+  it('excludes post-hook and response-dlp rows from every count', () => {
+    const body = buildDaemonReport(
+      [
+        ...ROWS,
+        { ts: TS, tool: 'Bash', decision: 'allowed', source: 'post-hook' },
+        {
+          ts: TS,
+          tool: 'Bash',
+          decision: 'dlp',
+          source: 'response-dlp',
+          checkedBy: 'response-dlp',
+        },
+      ],
+      '7d',
+      NOW
+    );
+    expect(body.summary.total).toBe(6);
+    expect(body.summary.blocked).toBe(2);
+  });
+});

--- a/src/__tests__/daemon-startup-log.integration.test.ts
+++ b/src/__tests__/daemon-startup-log.integration.test.ts
@@ -1,0 +1,373 @@
+/**
+ * A4b + A4c integration: a daemon that dies during startup must leave a trace.
+ *
+ * This is the load-bearing coverage for the 6-day silent-staleness incident. The
+ * auto-start spawn used to be stdio:'ignore', so a daemon that crashed on the way
+ * up vanished without a single byte anywhere. Two mechanisms replaced that:
+ *   A4c — the daemon logs its own benign/fatal exit paths (structured line)
+ *   A4b — the spawner redirects the child's STDERR into daemon-startup.log
+ *
+ * Only an integration test can prove A4b: it is an fd-inheritance property of a
+ * detached spawn. No unit test can observe it (CLAUDE.md: unit tests with mocked
+ * fs cannot catch filesystem or subprocess bugs).
+ *
+ * Requires `npm run build`.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import { spawnSync, spawn } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import net from 'net';
+import http from 'http';
+import { DAEMON_PORT, DAEMON_HOST } from '../auth/daemon';
+
+const CLI = path.resolve(__dirname, '../../dist/cli.js');
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const itUnix = it.skipIf(process.platform === 'win32');
+
+let home: string;
+let blocker: net.Server | null = null;
+// server.close() waits for OPEN CONNECTIONS to end. The daemon's /settings probe
+// leaves one behind, so closing without destroying sockets hangs the afterEach
+// until the runner's hook timeout — which reads as a product failure and is not.
+const openSockets = new Set<net.Socket>();
+
+function trackSockets(server: net.Server): void {
+  server.on('connection', (sock: net.Socket) => {
+    openSockets.add(sock);
+    sock.on('close', () => openSockets.delete(sock));
+  });
+}
+
+beforeAll(() => {
+  expect(fs.existsSync(CLI), `${CLI} missing — run npm run build`).toBe(true);
+});
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-startup-'));
+  fs.mkdirSync(path.join(home, '.node9'), { recursive: true });
+});
+afterEach(async () => {
+  // Reap any daemon this test actually managed to start. Without this, a spawn
+  // that unexpectedly SUCCEEDS (e.g. the crash injection silently failed to take)
+  // leaves a detached daemon squatting the real port, pointed at a HOME that is
+  // about to be deleted — poisoning every later test and the developer's machine.
+  try {
+    const pidFile = path.join(home, '.node9', 'daemon.pid');
+    if (fs.existsSync(pidFile)) {
+      const { pid } = JSON.parse(fs.readFileSync(pidFile, 'utf-8'));
+      // Never signal this process (the deterministic port-in-use case writes our
+      // own pid into that file on purpose).
+      if (typeof pid === 'number' && pid !== process.pid) {
+        try {
+          process.kill(pid, 'SIGTERM');
+        } catch {
+          /* already gone */
+        }
+      }
+    }
+  } catch {
+    /* best-effort cleanup */
+  }
+  if (blocker) {
+    for (const sock of openSockets) sock.destroy();
+    openSockets.clear();
+    await new Promise((r) => blocker!.close(r));
+    blocker = null;
+  }
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+const startupLog = () => path.join(home, '.node9', 'daemon-startup.log');
+const readLog = () => (fs.existsSync(startupLog()) ? fs.readFileSync(startupLog(), 'utf-8') : '');
+
+/**
+ * Make the daemon port unavailable, deterministically. If binding fails the port
+ * is already held by a real daemon on this machine — equally valid for the test,
+ * which only needs "the port is occupied", not "occupied by us".
+ */
+async function occupyDaemonPort(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const s = net.createServer();
+    s.once('error', () => resolve()); // already in use — precondition satisfied
+    s.listen(DAEMON_PORT, DAEMON_HOST, () => {
+      blocker = s;
+      trackSockets(s);
+      resolve();
+    });
+  });
+}
+
+function runDaemon(cli = CLI, extraEnv: Record<string, string> = {}) {
+  const baseEnv = { ...process.env };
+  delete baseEnv.NODE9_API_KEY;
+  delete baseEnv.NODE9_API_URL;
+  delete baseEnv.NODE9_NO_AUTO_DAEMON;
+  delete baseEnv.NODE9_TESTING;
+  return spawnSync(process.execPath, [cli, 'daemon'], {
+    encoding: 'utf-8',
+    timeout: 60000,
+    cwd: os.tmpdir(),
+    env: { ...baseEnv, HOME: home, USERPROFILE: home, NO_COLOR: '1', ...extraEnv },
+  });
+}
+
+/**
+ * ASYNC daemon runner. Required whenever this process hosts a server the child
+ * must talk to: spawnSync blocks the event loop, so an in-process HTTP server can
+ * never answer the child's request (documented in check.integration.test.ts). With
+ * spawnSync the daemon's /settings probe times out, it retries the bind, and loops
+ * until the 60s spawn timeout — a hang, not a result.
+ */
+function runDaemonAsync(
+  extraEnv: Record<string, string> = {},
+  timeoutMs = 20000
+): Promise<{ code: number | null }> {
+  const baseEnv = { ...process.env };
+  delete baseEnv.NODE9_API_KEY;
+  delete baseEnv.NODE9_API_URL;
+  // Never inherit the developer's ambient autostart/testing switches: this repo is
+  // dogfooded, so the shell running the suite may itself have NODE9_NO_AUTO_DAEMON
+  // set — which silently disables the very behaviour under test and makes the run
+  // depend on who is typing.
+  delete baseEnv.NODE9_NO_AUTO_DAEMON;
+  delete baseEnv.NODE9_TESTING;
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI, 'daemon'], {
+      env: { ...baseEnv, HOME: home, USERPROFILE: home, NO_COLOR: '1', ...extraEnv },
+      cwd: os.tmpdir(),
+      stdio: 'ignore',
+    });
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`daemon did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.on('exit', (code) => {
+      clearTimeout(timer);
+      resolve({ code });
+    });
+    child.on('error', reject);
+  });
+}
+
+/** A copy of dist/ whose CLI throws at module load when run as `daemon` — the
+ *  ERR_REQUIRE_ESM incident shape. node_modules is symlinked because the bundle has
+ *  external deps; without it the copy dies with MODULE_NOT_FOUND and any test using
+ *  it passes for entirely the wrong reason. */
+function crashPackage(condition = 'process.argv[2] === "daemon"'): string {
+  const pkg = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-crashpkg-'));
+  fs.cpSync(path.join(REPO_ROOT, 'dist'), path.join(pkg, 'dist'), { recursive: true });
+  fs.copyFileSync(path.join(REPO_ROOT, 'package.json'), path.join(pkg, 'package.json'));
+  fs.symlinkSync(path.join(REPO_ROOT, 'node_modules'), path.join(pkg, 'node_modules'), 'dir');
+  // AFTER the shebang (line 2) — prepending to line 1 breaks it and the binary
+  // fails to parse instead of crashing at import.
+  const cliPath = path.join(pkg, 'dist', 'cli.js');
+  const lines = fs.readFileSync(cliPath, 'utf-8').split('\n');
+  lines.splice(1, 0, `if (${condition}) { throw new Error("SIMULATED import-time crash"); }`);
+  fs.writeFileSync(cliPath, lines.join('\n'), 'utf-8');
+  return pkg;
+}
+
+describe('A4c — the daemon logs its own startup outcome', () => {
+  itUnix('records port-in-use and exits 0 when another daemon owns the port', async () => {
+    await occupyDaemonPort();
+    // A pid file naming a process that is definitely alive (this test runner) puts
+    // the daemon on the "another daemon owns it" branch deterministically, instead
+    // of depending on whatever happens to be running on the machine.
+    fs.writeFileSync(
+      path.join(home, '.node9', 'daemon.pid'),
+      JSON.stringify({ pid: process.pid, port: DAEMON_PORT, internalToken: 'x' }),
+      'utf-8'
+    );
+
+    const r = runDaemon();
+    expect(r.error).toBeUndefined();
+    expect(r.status).toBe(0); // losing a port race is benign, not a failure
+    expect(readLog()).toMatch(/daemon-startup:port-in-use/);
+  });
+});
+
+describe('A4c — an unidentifiable port holder is recorded as a FAILURE, not benign', () => {
+  itUnix('records orphan-unidentified when the pid cannot be recovered', async (ctx) => {
+    // The daemon answers /settings (so it is healthy) but neither `ss` nor `lsof`
+    // can name its pid, so NO pid file is written — and every pid-file-based
+    // command keeps reporting "not running" while each new start exits 0. Recording
+    // that as benign (an earlier design did) hides an unbounded silent loop.
+    await occupyDaemonPort();
+    if (blocker) {
+      // occupyDaemonPort's plain TCP socket cannot answer the daemon's
+      // fetch(/settings) probe, and that probe GATES the branch under test — a raw
+      // net.Server never emits 'request', so the daemon would retry forever. Swap
+      // in a real HTTP server that answers 200.
+      await new Promise<void>((r) => blocker!.close(() => r()));
+      blocker = null;
+    }
+    const healthy = http.createServer((_req, res) => res.writeHead(200).end('{}'));
+    const bound = await new Promise<boolean>((resolve) => {
+      healthy.once('error', () => resolve(false)); // a real daemon owns the port
+      healthy.listen(DAEMON_PORT, DAEMON_HOST, () => resolve(true));
+    });
+    if (!bound) {
+      // SKIP loudly rather than `return`: a bare return reports a green tick for a
+      // test that asserted nothing, which is worse than no test because it looks
+      // like coverage.
+      ctx.skip();
+      return;
+    }
+    blocker = healthy as unknown as net.Server; // afterEach closes it
+    trackSockets(blocker);
+
+    // Hide both pid-recovery tools so identification must fail.
+    const emptyBin = path.join(home, 'nobin');
+    fs.mkdirSync(emptyBin, { recursive: true });
+    const { code } = await runDaemonAsync({ PATH: emptyBin });
+
+    expect(code).toBe(0); // still a clean exit — it is not a crash
+    const state = JSON.parse(
+      fs.readFileSync(path.join(home, '.node9', 'daemon-startup-state.json'), 'utf-8')
+    );
+    expect(state.outcome).toBe('failed');
+    expect(state.kind).toBe('orphan-unidentified');
+    // …and the advice must not tell the user to kill a daemon we just proved healthy.
+    expect(state.detail).toMatch(/healthy daemon/);
+    expect(state.detail).not.toMatch(/stop it/);
+    expect(fs.existsSync(path.join(home, '.node9', 'daemon.pid'))).toBe(false);
+  });
+});
+
+describe('F1 — `node9 daemon --background` is covered by the diagnostic', () => {
+  itUnix('leaves a marker when the backgrounded daemon dies at module load', async () => {
+    // This is the command doctor RECOMMENDS. Without the parent writing 'starting'
+    // first, a child that dies at import records nothing at all — so the user runs
+    // the suggested fix, it fails silently, and doctor still shows the previous
+    // cause. Without F1 there is no state file here and this assertion fails.
+    //
+    // The crash must hit the spawned CHILD (`daemon`) and NOT the parent command
+    // (`daemon --background`): with the default condition the parent dies at import
+    // before it can record anything, and the test measures nothing at all.
+    const pkg = crashPackage(
+      'process.argv[2] === "daemon" && !process.argv.includes("--background")'
+    );
+    try {
+      const r = spawnSync(
+        process.execPath,
+        [path.join(pkg, 'dist', 'cli.js'), 'daemon', '--background'],
+        {
+          encoding: 'utf-8',
+          timeout: 30000,
+          cwd: os.tmpdir(),
+          env: { ...process.env, HOME: home, USERPROFILE: home, NO_COLOR: '1' },
+        }
+      );
+      expect(r.error).toBeUndefined();
+
+      const statePath = path.join(home, '.node9', 'daemon-startup-state.json');
+      expect(fs.existsSync(statePath)).toBe(true);
+      const state = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+      // 'starting' (nothing resolved it — the child never ran our code) or a
+      // conclusive 'failed' if the error listener won the race. Never absent.
+      expect(['starting', 'failed']).toContain(state.outcome);
+    } finally {
+      fs.rmSync(pkg, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('F2 — a port held by a NON-daemon must give up, not spin forever', () => {
+  itUnix('records port-unavailable and exits instead of retrying endlessly', async (ctx) => {
+    // Unbounded, this is a permanent ~1 Hz loop: EADDRINUSE → no pid file → probe
+    // /settings → not a daemon → listen() → EADDRINUSE → … The daemon never serves,
+    // never exits, and records nothing beyond 'starting'.
+    // WITHOUT the fix this test does not fail — it HANGS until the runner's timeout,
+    // which is precisely the defect.
+    await occupyDaemonPort();
+    if (!blocker) {
+      ctx.skip(); // a real daemon owns the port; cannot stand in as a foreign holder
+      return;
+    }
+    // occupyDaemonPort's raw TCP socket is exactly the case under test: it accepts
+    // the connection but never answers HTTP, so the /settings probe cannot succeed.
+
+    const { code } = await runDaemonAsync({}, 30000);
+
+    expect(code).toBe(0); // benign, explained exit — NOT a crash, so systemd won't storm
+    const state = JSON.parse(
+      fs.readFileSync(path.join(home, '.node9', 'daemon-startup-state.json'), 'utf-8')
+    );
+    expect(state.outcome).toBe('failed');
+    expect(state.kind).toBe('port-unavailable');
+    expect(state.detail).toMatch(/not a node9 daemon/);
+  });
+});
+
+describe('A4b — a crash during startup leaves a trace', () => {
+  itUnix('captures an IMPORT-TIME crash from the auto-started child', () => {
+    // The historical trigger was ERR_REQUIRE_ESM: a module-load failure. It happens
+    // before any in-daemon try/catch exists, so the ONLY way it can be captured is
+    // the spawner redirecting the child's stderr. If this test still passes after
+    // reverting that redirect to stdio:'ignore', the test is wrong, not the code.
+    const pkg = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-crashpkg-'));
+    try {
+      fs.cpSync(path.join(REPO_ROOT, 'dist'), path.join(pkg, 'dist'), { recursive: true });
+      fs.copyFileSync(path.join(REPO_ROOT, 'package.json'), path.join(pkg, 'package.json'));
+      // The bundle has external deps; without node_modules the copy dies with
+      // MODULE_NOT_FOUND and this test would pass for entirely the wrong reason.
+      fs.symlinkSync(path.join(REPO_ROOT, 'node_modules'), path.join(pkg, 'node_modules'), 'dir');
+
+      // Inject the crash AFTER the shebang (line 2) — prepending to line 1 breaks
+      // the shebang and the binary fails to parse instead of crashing at import.
+      const cliPath = path.join(pkg, 'dist', 'cli.js');
+      const lines = fs.readFileSync(cliPath, 'utf-8').split('\n');
+      lines.splice(
+        1,
+        0,
+        'if (process.argv[2] === "daemon") { throw new Error("SIMULATED import-time crash"); }'
+      );
+      fs.writeFileSync(cliPath, lines.join('\n'), 'utf-8');
+
+      // `check` auto-starts the daemon. Run it from the COPY so the spawn's
+      // packageDist guard resolves against the copy and permits the spawn.
+      const r = spawnSync(
+        process.execPath,
+        [cliPath, 'check', JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'ls' } })],
+        {
+          encoding: 'utf-8',
+          timeout: 60000,
+          cwd: os.tmpdir(),
+          env: {
+            ...process.env,
+            HOME: home,
+            USERPROFILE: home,
+            NO_COLOR: '1',
+            // this test REQUIRES the auto-start it is measuring
+            NODE9_NO_AUTO_DAEMON: '',
+            NODE9_TESTING: '',
+          },
+        }
+      );
+      expect(r.error).toBeUndefined();
+
+      // The child is detached; give it a moment to die and flush.
+      const deadline = Date.now() + 15000;
+      while (Date.now() < deadline && !/SIMULATED import-time crash/.test(readLog())) {
+        spawnSync(process.execPath, ['-e', 'setTimeout(()=>{},250)']); // ~250ms sync sleep
+      }
+
+      const log = readLog();
+      expect(log).toMatch(/SIMULATED import-time crash/);
+      expect(log).toMatch(/at /); // a real stack, not just a one-line summary
+
+      // …and the machine-readable half: the spawner's marker is still 'starting'
+      // because the child died before it could record anything itself. That
+      // stranded marker plus a down daemon IS the detection — it is what lets
+      // doctor say "did not start" without parsing a line of the stack above.
+      const state = JSON.parse(
+        fs.readFileSync(path.join(home, '.node9', 'daemon-startup-state.json'), 'utf-8')
+      );
+      expect(state.outcome).toBe('starting');
+    } finally {
+      fs.rmSync(pkg, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/__tests__/managed-strict-config-floor.spec.ts
+++ b/src/__tests__/managed-strict-config-floor.spec.ts
@@ -1,0 +1,133 @@
+// src/__tests__/managed-strict-config-floor.spec.ts
+//
+// Task #16 — a CLOUD-managed strict mode must not be silently disabled by
+// local/repo config. Two confirmed bypass vectors, both closed here:
+//
+//   A. environments.requireApproval:false — the engine's strict escape
+//      (policy/index.ts: `if (activeEnvironment?.requireApproval === false)
+//      return { decision: 'allow' }`). A cloned repo's node9.config.json can
+//      define it and neutralise managed strict for that project.
+//   B. local ignoredTools — the engine's ignored-tool fast-path allows a tool
+//      BEFORE policy eval. A repo can add `ignoredTools:['Bash']` to skip strict.
+//
+// The fix applies the existing config-home law (org floor wins; local may only
+// tighten) to both escapes, gated on the mode being cloud-managed. A LOCALLY
+// chosen strict keeps its dev-convenience escapes — verified below so the fix
+// doesn't over-tighten.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { getConfig, getActiveEnvironment, _resetConfigCache } from '../config';
+import { evaluatePolicy } from '../policy';
+
+function writeHome(tmpHome: string, opts: { local: object; cache?: object }): void {
+  fs.writeFileSync(path.join(tmpHome, '.node9', 'config.json'), JSON.stringify(opts.local));
+  if (opts.cache)
+    fs.writeFileSync(path.join(tmpHome, '.node9', 'rules-cache.json'), JSON.stringify(opts.cache));
+}
+
+describe('managed strict floor is not weakened by local/repo config (task #16)', () => {
+  let tmpHome: string;
+  let origHome: string | undefined;
+  let origUserprofile: string | undefined;
+  let origNodeEnv: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-floor-'));
+    origHome = process.env.HOME;
+    origUserprofile = process.env.USERPROFILE;
+    origNodeEnv = process.env.NODE_ENV;
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    // getActiveEnvironment falls back to NODE_ENV; pin it out so the config's
+    // own settings.environment decides which env is active.
+    delete process.env.NODE_ENV;
+    delete process.env.NODE9_MODE;
+    fs.mkdirSync(path.join(tmpHome, '.node9'), { recursive: true });
+    _resetConfigCache();
+  });
+
+  afterEach(() => {
+    if (origHome !== undefined) process.env.HOME = origHome;
+    else delete process.env.HOME;
+    if (origUserprofile !== undefined) process.env.USERPROFILE = origUserprofile;
+    else delete process.env.USERPROFILE;
+    if (origNodeEnv !== undefined) process.env.NODE_ENV = origNodeEnv;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    _resetConfigCache();
+  });
+
+  const STRICT_CACHE = { managedConfig: { mode: 'strict' }, shields: [], rules: [] };
+
+  it('vector A: managed strict strips environments.requireApproval:false (the engine escape)', () => {
+    writeHome(tmpHome, {
+      local: {
+        settings: { environment: 'development' },
+        environments: { development: { requireApproval: false } },
+      },
+      cache: STRICT_CACHE,
+    });
+    const cfg = getConfig();
+    expect(cfg.settings.mode).toBe('strict'); // sanity: managed strict applied
+    // The escape must be gone → the engine can never be handed requireApproval:false.
+    expect(getActiveEnvironment(cfg)?.requireApproval).not.toBe(false);
+  });
+
+  it('vector B: managed strict resets local ignoredTools so a repo cannot fast-path past strict', () => {
+    writeHome(tmpHome, {
+      local: { policy: { ignoredTools: ['Bash'] } },
+      cache: STRICT_CACHE,
+    });
+    const cfg = getConfig();
+    expect(cfg.settings.mode).toBe('strict');
+    expect(cfg.policy.ignoredTools).not.toContain('Bash');
+  });
+
+  it('does NOT over-tighten: a LOCALLY-chosen strict keeps the requireApproval:false escape', () => {
+    writeHome(tmpHome, {
+      // No managed cache → mode is local, dev convenience preserved.
+      local: {
+        settings: { mode: 'strict', environment: 'development' },
+        environments: { development: { requireApproval: false } },
+      },
+    });
+    const cfg = getConfig();
+    expect(cfg.settings.mode).toBe('strict');
+    expect(getActiveEnvironment(cfg)?.requireApproval).toBe(false);
+  });
+
+  it('does NOT over-tighten: a LOCALLY-chosen strict keeps local ignoredTools', () => {
+    writeHome(tmpHome, {
+      local: { settings: { mode: 'strict' }, policy: { ignoredTools: ['Bash'] } },
+    });
+    const cfg = getConfig();
+    expect(cfg.policy.ignoredTools).toContain('Bash');
+  });
+
+  // End-to-end at the REAL gate: the proxy's evaluatePolicy wrapper builds the
+  // engine context from getConfig()+getActiveEnvironment, so these prove the
+  // bypass is closed where verdicts are actually produced, not just in config.
+  it('E2E: managed strict + repo requireApproval:false → an unmatched tool still REVIEWS', async () => {
+    writeHome(tmpHome, {
+      local: {
+        settings: { environment: 'development' },
+        environments: { development: { requireApproval: false } },
+      },
+      cache: STRICT_CACHE,
+    });
+    _resetConfigCache();
+    const v = await evaluatePolicy('TotallyUnknownTool', { note: 'x' });
+    expect(v.decision).toBe('review'); // was 'allow' via the stripped escape
+  });
+
+  it('E2E: managed strict + repo ignoredTools:[Bash] → Bash is NOT fast-path allowed', async () => {
+    writeHome(tmpHome, {
+      local: { policy: { ignoredTools: ['Bash'] } },
+      cache: STRICT_CACHE,
+    });
+    _resetConfigCache();
+    const v = await evaluatePolicy('Bash', { command: 'echo hi' });
+    expect(v.decision).not.toBe('allow'); // strict review, not the fast-path allow
+  });
+});

--- a/src/__tests__/mcp-lifecycle.spec.ts
+++ b/src/__tests__/mcp-lifecycle.spec.ts
@@ -1,0 +1,238 @@
+// MCP lifecycle — orphan detection, lastSeen stamping, stale auto-removal.
+// Tests the reconcileStale() function and the forget CLI guard logic.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+vi.mock('../ui/native', () => ({
+  sendDesktopNotification: vi.fn(),
+  askNativePopup: vi.fn(),
+}));
+
+describe('mcp lifecycle — stale detection & removal', () => {
+  let home: string;
+  let runMcpReconcile: () => void;
+  let getServerKey: typeof import('../mcp-pin').getServerKey;
+  let quoteArg: typeof import('../mcp-cmd').quoteArg;
+
+  const writeConfig = (settings: Record<string, unknown>) =>
+    fs.writeFileSync(
+      path.join(home, '.node9', 'config.json'),
+      JSON.stringify({ settings, policy: {} })
+    );
+  const writeClaude = (servers: Record<string, unknown>) =>
+    fs.writeFileSync(path.join(home, '.claude.json'), JSON.stringify({ mcpServers: servers }));
+  const writePins = (servers: Record<string, unknown>) =>
+    fs.writeFileSync(path.join(home, '.node9', 'mcp-pins.json'), JSON.stringify({ servers }));
+  const readPins = () =>
+    JSON.parse(fs.readFileSync(path.join(home, '.node9', 'mcp-pins.json'), 'utf-8'));
+
+  beforeEach(async () => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-lifecycle-'));
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    vi.spyOn(os, 'homedir').mockReturnValue(home);
+    vi.resetModules();
+    fs.mkdirSync(path.join(home, '.node9'), { recursive: true });
+    const reconciler = await import('../daemon/mcp-reconciler.js');
+    runMcpReconcile = reconciler.runMcpReconcile;
+    const pinMod = await import('../mcp-pin.js');
+    getServerKey = pinMod.getServerKey;
+    quoteArg = (await import('../mcp-cmd.js')).quoteArg;
+  });
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('stamps lastSeen on pins that are still in inventory', () => {
+    writeConfig({ mode: 'standard' });
+    const upstreamCmd = 'npx -y mcp-redis';
+    const sk = getServerKey(upstreamCmd);
+    writePins({
+      [sk]: {
+        label: upstreamCmd,
+        toolsHash: 'abc',
+        toolNames: ['get', 'set'],
+        toolCount: 2,
+        pinnedAt: '2026-01-01T00:00:00.000Z',
+      },
+    });
+    // Server is gatewayed in Claude config (still configured)
+    writeClaude({
+      redis: { command: 'node9', args: ['mcp-gateway', '--upstream', upstreamCmd] },
+    });
+
+    runMcpReconcile();
+    const pins = readPins();
+    expect(pins.servers[sk].lastSeen).toBeDefined();
+    expect(new Date(pins.servers[sk].lastSeen).getTime()).toBeGreaterThan(Date.parse('2026-01-01'));
+  });
+
+  it('does NOT remove orphan pins within the grace period', () => {
+    writeConfig({ mode: 'standard', mcpStaleAfterDays: 7 });
+    const upstreamCmd = 'npx old-server';
+    const sk = getServerKey(upstreamCmd);
+    // Pin exists but server was removed from config recently (lastSeen = 2 days ago)
+    const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000).toISOString();
+    writePins({
+      [sk]: {
+        label: upstreamCmd,
+        toolsHash: 'abc',
+        toolNames: ['tool1'],
+        toolCount: 1,
+        pinnedAt: '2026-01-01T00:00:00.000Z',
+        lastSeen: twoDaysAgo,
+      },
+    });
+    writeClaude({}); // empty — server is gone from config
+
+    runMcpReconcile();
+    const pins = readPins();
+    expect(pins.servers[sk]).toBeDefined(); // still present, within grace period
+  });
+
+  it('auto-removes orphan pins beyond the grace period', () => {
+    writeConfig({ mode: 'standard', mcpStaleAfterDays: 7 });
+    const upstreamCmd = 'npx old-server';
+    const sk = getServerKey(upstreamCmd);
+    // Pin exists, lastSeen = 10 days ago (beyond 7-day threshold)
+    const tenDaysAgo = new Date(Date.now() - 10 * 86_400_000).toISOString();
+    writePins({
+      [sk]: {
+        label: upstreamCmd,
+        toolsHash: 'abc',
+        toolNames: ['tool1'],
+        toolCount: 1,
+        pinnedAt: '2026-01-01T00:00:00.000Z',
+        lastSeen: tenDaysAgo,
+      },
+    });
+    writeClaude({}); // server gone from config
+
+    runMcpReconcile();
+    const pins = readPins();
+    expect(pins.servers[sk]).toBeUndefined(); // removed
+  });
+
+  it('respects mcpStaleAfterDays=0 (never auto-remove)', () => {
+    writeConfig({ mode: 'standard', mcpStaleAfterDays: 0 });
+    const upstreamCmd = 'npx ancient-server';
+    const sk = getServerKey(upstreamCmd);
+    const yearAgo = new Date(Date.now() - 365 * 86_400_000).toISOString();
+    writePins({
+      [sk]: {
+        label: upstreamCmd,
+        toolsHash: 'abc',
+        toolNames: ['tool1'],
+        toolCount: 1,
+        pinnedAt: '2025-01-01T00:00:00.000Z',
+        lastSeen: yearAgo,
+      },
+    });
+    writeClaude({});
+
+    runMcpReconcile();
+    const pins = readPins();
+    expect(pins.servers[sk]).toBeDefined(); // never removed
+  });
+
+  it('backfills lastSeen from pinnedAt when first detecting orphan', () => {
+    // Use mcpStaleAfterDays=0 so backfill is visible without auto-removal
+    writeConfig({ mode: 'standard', mcpStaleAfterDays: 0 });
+    const upstreamCmd = 'npx disappeared';
+    const sk = getServerKey(upstreamCmd);
+    writePins({
+      [sk]: {
+        label: upstreamCmd,
+        toolsHash: 'abc',
+        toolNames: ['tool1'],
+        toolCount: 1,
+        pinnedAt: '2026-06-01T00:00:00.000Z',
+        // no lastSeen field
+      },
+    });
+    writeClaude({}); // not in config
+
+    runMcpReconcile();
+    const pins = readPins();
+    // Should backfill lastSeen = pinnedAt (so the 7-day countdown starts from pinnedAt)
+    expect(pins.servers[sk].lastSeen).toBe('2026-06-01T00:00:00.000Z');
+  });
+
+  // A still-configured but ungoverned server whose arg needs quoting must be
+  // recognized as live — its pin was created by the gateway from the
+  // quoteArg-joined upstream, so inventory must derive the SAME key. A naive
+  // join would diverge (a space forces quoting), make the pin look orphaned,
+  // and auto-remove a server the user is still running. Fails pre-fix.
+  it('keeps a still-configured ungoverned server whose arg needs quoting', () => {
+    writeConfig({ mode: 'standard', mcpStaleAfterDays: 7 });
+    const command = 'npx';
+    const args = ['fs-mcp', '--root', '/my path']; // spaced path → needs quoting
+    const upstream = [command, ...args].map(quoteArg).join(' '); // as the gateway pins it
+    const sk = getServerKey(upstream);
+    const tenDaysAgo = new Date(Date.now() - 10 * 86_400_000).toISOString();
+    writePins({
+      [sk]: {
+        label: upstream,
+        toolsHash: 'abc',
+        toolNames: ['read'],
+        toolCount: 1,
+        pinnedAt: '2026-01-01T00:00:00.000Z',
+        lastSeen: tenDaysAgo, // old enough to be removed IF seen as orphaned
+      },
+    });
+    writeClaude({ fs: { command, args } }); // still configured, ungoverned
+
+    runMcpReconcile();
+    const pins = readPins();
+    // Recognized as live → kept and re-stamped, not auto-removed.
+    expect(pins.servers[sk]).toBeDefined();
+    expect(new Date(pins.servers[sk].lastSeen).getTime()).toBeGreaterThan(Date.parse(tenDaysAgo));
+  });
+
+  it('does not crash when pin file is missing', () => {
+    writeConfig({ mode: 'standard' });
+    writeClaude({ redis: { command: 'npx', args: ['redis-mcp'] } });
+    // No pins file at all
+    expect(() => runMcpReconcile()).not.toThrow();
+  });
+
+  it('handles mixed active and orphan pins correctly', () => {
+    writeConfig({ mode: 'standard', mcpStaleAfterDays: 7 });
+    const activeCmd = 'npx active-server';
+    const staleCmd = 'npx stale-server';
+    const activeSk = getServerKey(activeCmd);
+    const staleSk = getServerKey(staleCmd);
+    const tenDaysAgo = new Date(Date.now() - 10 * 86_400_000).toISOString();
+
+    writePins({
+      [activeSk]: {
+        label: activeCmd,
+        toolsHash: 'abc',
+        toolNames: ['tool1'],
+        toolCount: 1,
+        pinnedAt: '2026-01-01T00:00:00.000Z',
+      },
+      [staleSk]: {
+        label: staleCmd,
+        toolsHash: 'def',
+        toolNames: ['tool2'],
+        toolCount: 1,
+        pinnedAt: '2026-01-01T00:00:00.000Z',
+        lastSeen: tenDaysAgo,
+      },
+    });
+    // Only the active server is still configured
+    writeClaude({
+      active: { command: 'node9', args: ['mcp-gateway', '--upstream', activeCmd] },
+    });
+
+    runMcpReconcile();
+    const pins = readPins();
+    expect(pins.servers[activeSk]).toBeDefined();
+    expect(pins.servers[activeSk].lastSeen).toBeDefined();
+    expect(pins.servers[staleSk]).toBeUndefined(); // removed (stale > 7d)
+  });
+});

--- a/src/__tests__/mcp-lifecycle.spec.ts
+++ b/src/__tests__/mcp-lifecycle.spec.ts
@@ -13,6 +13,7 @@ vi.mock('../ui/native', () => ({
 describe('mcp lifecycle — stale detection & removal', () => {
   let home: string;
   let runMcpReconcile: () => void;
+  let forgetAllStale: () => void;
   let getServerKey: typeof import('../mcp-pin').getServerKey;
   let quoteArg: typeof import('../mcp-cmd').quoteArg;
 
@@ -40,6 +41,7 @@ describe('mcp lifecycle — stale detection & removal', () => {
     const pinMod = await import('../mcp-pin.js');
     getServerKey = pinMod.getServerKey;
     quoteArg = (await import('../mcp-cmd.js')).quoteArg;
+    forgetAllStale = (await import('../cli/commands/mcp-pin.js')).forgetAllStale;
   });
   afterEach(() => {
     fs.rmSync(home, { recursive: true, force: true });
@@ -70,15 +72,16 @@ describe('mcp lifecycle — stale detection & removal', () => {
     expect(new Date(pins.servers[sk].lastSeen).getTime()).toBeGreaterThan(Date.parse('2026-01-01'));
   });
 
-  it('does NOT remove orphan pins within the grace period', () => {
+  // A live server keeps the inventory non-empty, so removal genuinely runs and
+  // this exercises the grace period — not the A1 empty-inventory guard (which
+  // would keep the pin for a different reason).
+  it('does NOT remove an orphan pin within the grace period', () => {
     writeConfig({ mode: 'standard', mcpStaleAfterDays: 7 });
-    const upstreamCmd = 'npx old-server';
-    const sk = getServerKey(upstreamCmd);
-    // Pin exists but server was removed from config recently (lastSeen = 2 days ago)
+    const sk = getServerKey('npx old-server');
     const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000).toISOString();
     writePins({
       [sk]: {
-        label: upstreamCmd,
+        label: 'npx old-server',
         toolsHash: 'abc',
         toolNames: ['tool1'],
         toolCount: 1,
@@ -86,22 +89,19 @@ describe('mcp lifecycle — stale detection & removal', () => {
         lastSeen: twoDaysAgo,
       },
     });
-    writeClaude({}); // empty — server is gone from config
+    writeClaude({ live: { command: 'npx', args: ['live-server'] } });
 
     runMcpReconcile();
-    const pins = readPins();
-    expect(pins.servers[sk]).toBeDefined(); // still present, within grace period
+    expect(readPins().servers[sk]).toBeDefined(); // within grace
   });
 
-  it('auto-removes orphan pins beyond the grace period', () => {
+  it('auto-removes an orphan pin beyond the grace period (live server present)', () => {
     writeConfig({ mode: 'standard', mcpStaleAfterDays: 7 });
-    const upstreamCmd = 'npx old-server';
-    const sk = getServerKey(upstreamCmd);
-    // Pin exists, lastSeen = 10 days ago (beyond 7-day threshold)
+    const sk = getServerKey('npx old-server');
     const tenDaysAgo = new Date(Date.now() - 10 * 86_400_000).toISOString();
     writePins({
       [sk]: {
-        label: upstreamCmd,
+        label: 'npx old-server',
         toolsHash: 'abc',
         toolNames: ['tool1'],
         toolCount: 1,
@@ -109,11 +109,34 @@ describe('mcp lifecycle — stale detection & removal', () => {
         lastSeen: tenDaysAgo,
       },
     });
-    writeClaude({}); // server gone from config
+    writeClaude({ live: { command: 'npx', args: ['live-server'] } });
 
     runMcpReconcile();
-    const pins = readPins();
-    expect(pins.servers[sk]).toBeUndefined(); // removed
+    expect(readPins().servers[sk]).toBeUndefined(); // removed
+  });
+
+  // A1: an EMPTY inventory (no live server detected — a missing/unreadable agent
+  // config is indistinguishable from "no servers configured") must NOT trigger
+  // removal, even beyond the grace period. A wrongly-removed pin re-pins to
+  // whatever the server presents next, silently resetting the rug-pull baseline.
+  it('does NOT auto-remove when the inventory is empty (A1 fail-closed)', () => {
+    writeConfig({ mode: 'standard', mcpStaleAfterDays: 7 });
+    const sk = getServerKey('npx gone-server');
+    const tenDaysAgo = new Date(Date.now() - 10 * 86_400_000).toISOString();
+    writePins({
+      [sk]: {
+        label: 'npx gone-server',
+        toolsHash: 'abc',
+        toolNames: ['tool1'],
+        toolCount: 1,
+        pinnedAt: '2026-01-01T00:00:00.000Z',
+        lastSeen: tenDaysAgo,
+      },
+    });
+    writeClaude({}); // EMPTY inventory — can't confirm the server is gone
+
+    runMcpReconcile();
+    expect(readPins().servers[sk]).toBeDefined(); // kept
   });
 
   it('respects mcpStaleAfterDays=0 (never auto-remove)', () => {
@@ -234,5 +257,65 @@ describe('mcp lifecycle — stale detection & removal', () => {
     expect(pins.servers[activeSk]).toBeDefined();
     expect(pins.servers[activeSk].lastSeen).toBeDefined();
     expect(pins.servers[staleSk]).toBeUndefined(); // removed (stale > 7d)
+  });
+
+  // ── `node9 mcp forget --stale` (forgetAllStale) ─────────────────────────────
+  const pinBody = (label: string) => ({
+    label,
+    toolsHash: 'abc',
+    toolNames: ['tool1'],
+    toolCount: 1,
+    pinnedAt: '2026-01-01T00:00:00.000Z',
+  });
+
+  it('forget --stale removes an orphan when a live server is present', () => {
+    writeConfig({ mode: 'standard' });
+    const orphan = getServerKey('npx old-server');
+    writePins({ [orphan]: pinBody('npx old-server') });
+    writeClaude({ live: { command: 'npx', args: ['live-server'] } });
+
+    forgetAllStale();
+    expect(readPins().servers[orphan]).toBeUndefined();
+  });
+
+  // A1 at the manual path: an empty inventory must NOT wipe every pin — it exits
+  // non-zero and keeps them (a wrongly-forgotten pin resets the rug-pull baseline
+  // on the server's next connection).
+  it('forget --stale refuses to wipe pins when the inventory is empty (A1)', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    writeConfig({ mode: 'standard' });
+    const orphan = getServerKey('npx gone-server');
+    writePins({ [orphan]: pinBody('npx gone-server') });
+    writeClaude({}); // EMPTY inventory
+
+    expect(() => forgetAllStale()).toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(readPins().servers[orphan]).toBeDefined(); // kept, not wiped
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // B1: removing N orphans is one read-modify-write, not N. Functionally, all
+  // orphans go and the live server's pin stays — in a single pass.
+  it('forget --stale removes all orphans and keeps the live one', () => {
+    writeConfig({ mode: 'standard' });
+    const orphanA = getServerKey('npx old-a');
+    const orphanB = getServerKey('npx old-b');
+    const live = getServerKey('npx live-server'); // matches the config below
+    writePins({
+      [orphanA]: pinBody('npx old-a'),
+      [orphanB]: pinBody('npx old-b'),
+      [live]: pinBody('npx live-server'),
+    });
+    writeClaude({ live: { command: 'npx', args: ['live-server'] } });
+
+    forgetAllStale();
+    const servers = readPins().servers;
+    expect(servers[orphanA]).toBeUndefined();
+    expect(servers[orphanB]).toBeUndefined();
+    expect(servers[live]).toBeDefined();
   });
 });

--- a/src/__tests__/report-audit-aggregate.unit.test.ts
+++ b/src/__tests__/report-audit-aggregate.unit.test.ts
@@ -190,11 +190,14 @@ describe('aggregateReportFromAudit', () => {
         source: 'local-policy',
         checkedBy: 'dlp-block',
       },
-      // DLP observe
+      // DLP observe. The producer (orchestrator.ts:453) writes `deny` here and
+      // then returns approved:true — the action RAN. This fixture said `allow`,
+      // a shape that occurs 0 times in a real 101k-row log; the assertion below
+      // was written to match it and so encoded the bug.
       {
         ts: '2026-05-10T10:00:05Z',
         tool: 'Bash',
-        decision: 'allow',
+        decision: 'deny',
         source: 'local-policy',
         checkedBy: 'observe-mode-dlp-would-block',
       },
@@ -213,7 +216,9 @@ describe('aggregateReportFromAudit', () => {
     expect(result.data.timedOut).toBe(1);
     expect(result.data.hardBlocked).toBe(1);
     expect(result.data.dlpBlocked).toBe(1);
-    expect(result.data.observeDlp).toBe(0); // observeDlp is for blocked observe-mode entries; allow path ≠ block path
+    // An observe-DLP row is an observe-DLP row: counted here, and in NO block
+    // bucket, because shadow mode let the action through.
+    expect(result.data.observeDlp).toBe(1);
     expect(result.data.loopHits).toBe(1);
   });
 
@@ -998,5 +1003,94 @@ describe('aggregateReportFromAudit — malformed / event rows', () => {
     // Only the two real tool-call rows counted; the event row dropped.
     expect(result.data.total).toBe(2);
     expect(result.data.dimensions.toolRules.blocked).toBe(1);
+  });
+});
+
+/**
+ * Regression — the fifth hand-rolled decision rule.
+ *
+ * `isAllow = decision.startsWith('allow')` asked one question ("does the word
+ * begin with allow") of rows that need three. Everything else counted as a
+ * BLOCK, so `node9 report` scored shadow-mode rows that RAN and MCP-discovery
+ * events that were never verdicts as refusals. Measured against a real
+ * 101k-row log: 918 phantom blocks (913 observe-DLP + 5 discovery).
+ *
+ * The shapes below are taken from that log, not invented — including the
+ * detail that observe mode writes `allow` on one path and `deny` on another
+ * for the same concept, which is why a straight swap to
+ * `classifyDecision(...).outcome === 'allow'` was NOT the fix: it would have
+ * moved 8,217 observe rows the other way, into the block path.
+ */
+describe('aggregateReportFromAudit — shadow mode and findings are not blocks', () => {
+  const TS = '2026-05-10T10:00:00Z';
+
+  it('does not count observe-mode rows as blocks (they ran)', () => {
+    writeLog([
+      { ts: TS, tool: 'Bash', decision: 'allow' },
+      // Shadow mode, path 1: writes `allow`. The action RAN.
+      { ts: TS, tool: 'Bash', decision: 'allow', checkedBy: 'observe-mode-would-block' },
+      // Shadow mode, path 2: writes `deny` for the same concept. Also RAN.
+      { ts: TS, tool: 'Bash', decision: 'deny', checkedBy: 'observe-mode-dlp-would-block' },
+    ]);
+    const { data } = aggregateReportFromAudit('7d', makeOpts());
+
+    // The observe rows are surfaced by their own counter…
+    expect(data.observeDlp).toBe(1);
+    // …and by NEITHER block counter. Before the fix the deny-flavoured row
+    // landed in toolMap/dailyMap/blockMap as a real refusal.
+    expect(data.hardBlocked).toBe(0);
+    expect(data.dlpBlocked).toBe(0);
+    expect(data.toolMap.get('Bash')?.blocked).toBe(0);
+    expect(data.dailyMap.get('2026-05-10')?.blocked).toBe(0);
+    expect(data.blockMap.size).toBe(0);
+  });
+
+  it('does not count an MCP-discovery event as a user denial', () => {
+    writeLog([
+      // Real shape: decision=mcp-discovered, source=daemon, no checkedBy.
+      // `source === 'daemon'` means "the user interacted", so the old rule
+      // scored this as the user DENYING something they were never shown.
+      { ts: TS, tool: 'mcp__redis__redis_get', decision: 'mcp-discovered', source: 'daemon' },
+      { ts: TS, tool: 'Bash', decision: 'allow', source: 'daemon' },
+    ]);
+    const { data } = aggregateReportFromAudit('7d', makeOpts());
+
+    expect(data.userDenied).toBe(0);
+    expect(data.userApproved).toBe(1);
+    expect(data.toolMap.get('mcp__redis__redis_get')?.blocked).toBe(0);
+  });
+
+  it('still counts real refusals, including an unrecognised decision', () => {
+    writeLog([
+      { ts: TS, tool: 'Bash', decision: 'deny', checkedBy: 'smart-rule-block' },
+      { ts: TS, tool: 'Bash', decision: 'deny', checkedBy: 'timeout' },
+      { ts: TS, tool: 'Bash', decision: 'deny', source: 'daemon' },
+      // An unknown verb must stay VISIBLE as a block rather than silently
+      // becoming an allow — the failure mode this whole thread started with.
+      { ts: TS, tool: 'Bash', decision: 'quarantined', checkedBy: 'future-producer' },
+    ]);
+    const { data } = aggregateReportFromAudit('7d', makeOpts());
+
+    expect(data.timedOut).toBe(1);
+    expect(data.userDenied).toBe(1);
+    expect(data.hardBlocked).toBe(2); // smart-rule-block + quarantined
+    expect(data.toolMap.get('Bash')?.blocked).toBe(4);
+  });
+
+  it('scores the prior period on the same population as the current one', () => {
+    // priorEntries previously kept response-dlp and event rows that the
+    // current-period filter dropped, so the trend arrow compared two
+    // different denominators. 7d window → prior window is the 7 days before.
+    writeLog([
+      { ts: '2026-04-28T10:00:00Z', tool: 'Bash', decision: 'allow' },
+      { ts: '2026-04-28T10:01:00Z', tool: 'Bash', decision: 'deny', checkedBy: 'smart-rule-block' },
+      // Neither of these belongs in a block rate: a finding, and an event row.
+      { ts: '2026-04-28T10:02:00Z', tool: 'Bash', decision: 'dlp', source: 'response-dlp' },
+      { ts: '2026-05-10T10:00:00Z', tool: 'Bash', decision: 'allow' },
+    ]);
+    const { data } = aggregateReportFromAudit('7d', makeOpts());
+
+    // 1 block of 2 comparable prior rows — not 1 of 3, and not 2 of 3.
+    expect(data.priorBlockRate).toBe(0.5);
   });
 });

--- a/src/__tests__/rules-cache-atomic.spec.ts
+++ b/src/__tests__/rules-cache-atomic.spec.ts
@@ -147,4 +147,54 @@ describe('readRulesCacheResilient — no silent fail-open on a torn/corrupt read
     );
     expect(loggedUnreadable).toBe(true); // ...but never silently
   });
+
+  it('falls back to the last-known-good copy when the primary is corrupt (no fail-open)', async () => {
+    // Primary corrupt, but the daemon's last-good sibling holds the real policy.
+    fs.writeFileSync(cacheOf(), '{ truncated');
+    fs.writeFileSync(
+      path.join(tmpHome, '.node9', 'rules-cache.last-good.json'),
+      JSON.stringify({ shields: ['aws'], rules: [] })
+    );
+    const raw = readRulesCacheResilient(cacheOf());
+    // The whole point: enforcement is PRESERVED from the last-good copy, not
+    // silently dropped to {} (fail-open). (The one-per-process fallback log is
+    // best-effort and covered by the corrupt-log test above.)
+    expect(raw.shields).toEqual(['aws']);
+  });
+});
+
+describe('writeCache maintains a last-known-good backup', () => {
+  let tmpHome: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-lastgood-'));
+    origHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    fs.mkdirSync(path.join(tmpHome, '.node9'), { recursive: true });
+  });
+  afterEach(() => {
+    if (origHome !== undefined) process.env.HOME = origHome;
+    else delete process.env.HOME;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('writes both the primary and rules-cache.last-good.json with the same content', () => {
+    __writeCacheForTest({
+      fetchedAt: '2026-07-01T00:00:00Z',
+      rules: [],
+      shields: ['aws'],
+      workspaceId: 'ws-1',
+    } as unknown as Parameters<typeof __writeCacheForTest>[0]);
+    const primary = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, '.node9', 'rules-cache.json'), 'utf-8')
+    );
+    const backup = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, '.node9', 'rules-cache.last-good.json'), 'utf-8')
+    );
+    expect(backup).toEqual(primary);
+    expect(backup.shields).toEqual(['aws']);
+  });
 });

--- a/src/__tests__/rules-cache-atomic.spec.ts
+++ b/src/__tests__/rules-cache-atomic.spec.ts
@@ -1,0 +1,150 @@
+// src/__tests__/rules-cache-atomic.spec.ts
+//
+// Regression for the non-deterministic shield/policy fail-open (task #17).
+//
+// Root cause: the daemon rewrote ~/.node9/rules-cache.json with a plain,
+// non-atomic fs.writeFileSync, while a hook's getConfig() read it with a
+// JSON.parse inside a fail-OPEN catch. A read overlapping a write got a
+// partial file → parse threw → ALL cloud enforcement (shields, managed mode)
+// was silently dropped for that call → a shield-blocked command was allowed.
+// Non-deterministic (overlap-dependent) and fail-open.
+//
+// Two fixes, both covered here:
+//   1. writeCache writes atomically (temp + rename) — no partial file is ever
+//      visible to a concurrent reader.
+//   2. the reader retries a torn read and, on a present-but-corrupt cache,
+//      logs instead of silently dropping enforcement.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { __writeCacheForTest } from '../daemon/sync';
+import { readRulesCacheResilient } from '../config';
+
+describe('writeCache — atomic write (no partial file visible)', () => {
+  let tmpHome: string;
+  let origHome: string | undefined;
+  let origUserprofile: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-atomic-'));
+    origHome = process.env.HOME;
+    origUserprofile = process.env.USERPROFILE;
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    fs.mkdirSync(path.join(tmpHome, '.node9'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (origHome !== undefined) process.env.HOME = origHome;
+    else delete process.env.HOME;
+    if (origUserprofile !== undefined) process.env.USERPROFILE = origUserprofile;
+    else delete process.env.USERPROFILE;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('renames a temp file onto rules-cache.json instead of truncating it in place', async () => {
+    const target = path.join(tmpHome, '.node9', 'rules-cache.json');
+
+    const renameSpy = vi.spyOn(fs, 'renameSync');
+    const writeSpy = vi.spyOn(fs, 'writeFileSync');
+
+    __writeCacheForTest({
+      fetchedAt: '2026-07-01T00:00:00Z',
+      rules: [],
+      shields: ['aws'],
+      workspaceId: 'ws-1',
+    } as unknown as Parameters<typeof __writeCacheForTest>[0]);
+
+    // The final path must be produced by an atomic rename...
+    const renamedToTarget = renameSpy.mock.calls.some(([, dst]) => dst === target);
+    expect(renamedToTarget).toBe(true);
+    // ...never by a direct in-place write to the target (the old truncating bug).
+    const directTargetWrite = writeSpy.mock.calls.some(([p]) => p === target);
+    expect(directTargetWrite).toBe(false);
+
+    // And the resulting file is complete, valid JSON carrying the payload.
+    const parsed = JSON.parse(fs.readFileSync(target, 'utf-8'));
+    expect(parsed.shields).toEqual(['aws']);
+  });
+
+  it('leaves no .tmp residue after a successful write', async () => {
+    __writeCacheForTest({
+      fetchedAt: '2026-07-01T00:00:00Z',
+      rules: [],
+      shields: [],
+      workspaceId: 'ws-1',
+    } as unknown as Parameters<typeof __writeCacheForTest>[0]);
+    const leftovers = fs
+      .readdirSync(path.join(tmpHome, '.node9'))
+      .filter((f) => f.includes('.tmp'));
+    expect(leftovers).toEqual([]);
+  });
+});
+
+describe('readRulesCacheResilient — no silent fail-open on a torn/corrupt read', () => {
+  let tmpHome: string;
+  let origHome: string | undefined;
+  const cacheOf = () => path.join(tmpHome, '.node9', 'rules-cache.json');
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-read-'));
+    origHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    fs.mkdirSync(path.join(tmpHome, '.node9'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (origHome !== undefined) process.env.HOME = origHome;
+    else delete process.env.HOME;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('parses a whole file', async () => {
+    fs.writeFileSync(cacheOf(), JSON.stringify({ shields: ['aws'], rules: [] }));
+    const raw = readRulesCacheResilient(cacheOf());
+    expect(raw.shields).toEqual(['aws']);
+  });
+
+  it('returns {} for an ABSENT cache without logging (no cloud policy is normal)', async () => {
+    const appendSpy = vi.spyOn(fs, 'appendFileSync');
+    const raw = readRulesCacheResilient(cacheOf()); // file does not exist
+    expect(raw).toEqual({});
+    const loggedUnreadable = appendSpy.mock.calls.some(([, data]) =>
+      String(data).includes('RULES_CACHE_UNREADABLE')
+    );
+    expect(loggedUnreadable).toBe(false);
+  });
+
+  it('recovers a torn read on retry instead of dropping enforcement', async () => {
+    const good = JSON.stringify({ shields: ['aws'], rules: [] });
+    const realRead = fs.readFileSync;
+    let n = 0;
+    vi.spyOn(fs, 'readFileSync').mockImplementation(((p: fs.PathOrFileDescriptor, o?: unknown) => {
+      if (typeof p === 'string' && p.endsWith('rules-cache.json')) {
+        n += 1;
+        if (n === 1) return good.slice(0, Math.floor(good.length * 0.5)); // partial/torn
+        return good; // retry sees the complete (atomically renamed) file
+      }
+      return (realRead as (a: unknown, b: unknown) => unknown)(p, o);
+    }) as typeof fs.readFileSync);
+
+    const raw = readRulesCacheResilient(cacheOf());
+    expect(raw.shields).toEqual(['aws']); // recovered, NOT dropped
+    expect(n).toBeGreaterThanOrEqual(2); // proves a retry happened
+  });
+
+  it('logs (does NOT silently drop) when a present cache is corrupt past retries', async () => {
+    fs.writeFileSync(cacheOf(), '{ this is not valid json ');
+    const appendSpy = vi.spyOn(fs, 'appendFileSync');
+    const raw = readRulesCacheResilient(cacheOf());
+    expect(raw).toEqual({}); // still falls back (no hard-brick)...
+    const loggedUnreadable = appendSpy.mock.calls.some(([, data]) =>
+      String(data).includes('RULES_CACHE_UNREADABLE')
+    );
+    expect(loggedUnreadable).toBe(true); // ...but never silently
+  });
+});

--- a/src/__tests__/shield-block-failclosed.spec.ts
+++ b/src/__tests__/shield-block-failclosed.spec.ts
@@ -1,0 +1,116 @@
+// src/__tests__/shield-block-failclosed.spec.ts
+//
+// Fail-closed gate for the block→review downgrade (task #17).
+//
+// When the daemon is running, a smart-rule/shield hard-block is downgraded to a
+// review ("a human is at the keyboard"). In a NON-INTERACTIVE context (headless
+// server, a piped agent with no GUI and no `node9 tail` connected) that
+// assumption is false — and the approver race could then resolve the review to
+// ALLOW via a cloud immediate-allow of a client-side shield the SaaS has no rule
+// for. That is a fail-open on a HARD BLOCK (confirmed live: a coin-flip between
+// allow and block on identical inputs).
+//
+// The downgrade is now gated on `hasReachableHumanApprover`: a real human must
+// be reachable (a GUI display for the native popup, or a connected input-capable
+// tail) or the block STAYS hard. This unit-tests that gate directly — the full
+// authorizeHeadless path can't, because vitest sets VITEST=1 → isTestEnv short-
+// circuits every block to hard (the CI path is already fail-closed).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { mockHasInteractiveApprover } = vi.hoisted(() => ({
+  mockHasInteractiveApprover: vi.fn<() => Promise<boolean>>(),
+}));
+
+vi.mock('../auth/daemon.js', () => ({
+  DAEMON_PORT: 7391,
+  DAEMON_HOST: '127.0.0.1',
+  daemonHasInteractiveApprover: () => mockHasInteractiveApprover(),
+  // The rest of the module is unused by hasReachableHumanApprover but must exist
+  // so the import resolves.
+  isDaemonRunning: vi.fn().mockReturnValue(false),
+  notifyActivitySocket: vi.fn(),
+  checkStatePredicates: vi.fn(),
+  registerDaemonEntry: vi.fn(),
+  waitForDaemonDecision: vi.fn(),
+  notifyDaemonViewer: vi.fn(),
+  resolveViaDaemon: vi.fn(),
+  notifyTaint: vi.fn(),
+  checkTaint: vi.fn(),
+  checkSessionTaint: vi.fn(),
+  getInternalToken: vi.fn(),
+}));
+
+import { hasReachableHumanApprover } from '../auth/orchestrator';
+
+const ALL_ON = { native: true, terminal: true };
+
+describe('hasReachableHumanApprover — fail-closed gate (task #17)', () => {
+  let origDisplay: string | undefined;
+  let origWayland: string | undefined;
+
+  beforeEach(() => {
+    origDisplay = process.env.DISPLAY;
+    origWayland = process.env.WAYLAND_DISPLAY;
+    delete process.env.DISPLAY;
+    delete process.env.WAYLAND_DISPLAY;
+    mockHasInteractiveApprover.mockResolvedValue(false);
+  });
+  afterEach(() => {
+    if (origDisplay !== undefined) process.env.DISPLAY = origDisplay;
+    else delete process.env.DISPLAY;
+    if (origWayland !== undefined) process.env.WAYLAND_DISPLAY = origWayland;
+    else delete process.env.WAYLAND_DISPLAY;
+    vi.clearAllMocks();
+  });
+
+  it('NO display + NO tail → not reachable (the fail-open case → block stays hard)', async () => {
+    expect(await hasReachableHumanApprover({ approvers: ALL_ON })).toBe(false);
+  });
+
+  it('a GUI display present → reachable (native popup can ask a human)', async () => {
+    process.env.DISPLAY = ':0';
+    expect(await hasReachableHumanApprover({ approvers: ALL_ON })).toBe(true);
+    // Native was enough — never needed the daemon round-trip.
+    expect(mockHasInteractiveApprover).not.toHaveBeenCalled();
+  });
+
+  it('a connected tail → reachable even with no display', async () => {
+    mockHasInteractiveApprover.mockResolvedValue(true);
+    expect(await hasReachableHumanApprover({ approvers: ALL_ON })).toBe(true);
+  });
+
+  it('display present but calledFromDaemon → NOT reachable via native (daemon shows no popup)', async () => {
+    process.env.DISPLAY = ':0';
+    // Only a tail can reach a human from the daemon's own pass; none here.
+    expect(await hasReachableHumanApprover({ approvers: ALL_ON, calledFromDaemon: true })).toBe(
+      false
+    );
+  });
+
+  it('calledFromDaemon still reachable when a tail is connected', async () => {
+    process.env.DISPLAY = ':0';
+    mockHasInteractiveApprover.mockResolvedValue(true);
+    expect(await hasReachableHumanApprover({ approvers: ALL_ON, calledFromDaemon: true })).toBe(
+      true
+    );
+  });
+
+  it('native approver disabled + no tail → not reachable even with a display', async () => {
+    process.env.DISPLAY = ':0';
+    expect(await hasReachableHumanApprover({ approvers: { native: false, terminal: true } })).toBe(
+      false
+    );
+  });
+
+  it('terminal approver disabled → a connected tail does not count', async () => {
+    mockHasInteractiveApprover.mockResolvedValue(true);
+    expect(await hasReachableHumanApprover({ approvers: { native: true, terminal: false } })).toBe(
+      false
+    );
+  });
+
+  it('fails closed when the daemon reachability check returns false', async () => {
+    mockHasInteractiveApprover.mockResolvedValue(false);
+    expect(await hasReachableHumanApprover({ approvers: ALL_ON })).toBe(false);
+  });
+});

--- a/src/__tests__/spawn-error-state.unit.test.ts
+++ b/src/__tests__/spawn-error-state.unit.test.ts
@@ -1,0 +1,145 @@
+/**
+ * R0: a spawn that fails to EXEC must be recorded as a failed start.
+ *
+ * This exists because the first attempt at that was unreachable code. It recorded
+ * `spawn-failed` from a try/catch around spawn() — but spawn() does not throw for
+ * exec failures; it reports them asynchronously on the child's 'error' event:
+ *
+ *   spawn('/definitely/not/a/real/binary') → NO THROW; async 'error' event: ENOENT
+ *   spawn('<non-executable file>')          → NO THROW; async 'error' event: EACCES
+ *
+ * So the catch only ever fired for a synchronous TypeError from bad arguments, and
+ * the stranded-'starting' bug it was written to fix survived four review rounds and
+ * a /review-pr — green the whole way, because nothing exercised it.
+ *
+ * The test therefore drives the REAL 'error' event. A mocked throw would pass
+ * against the old unreachable catch and recreate the same false witness. It also
+ * proves the listener is attached at all: emitting 'error' on an EventEmitter with
+ * no listener throws, so a regression here fails loudly rather than silently.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'events';
+import { spawn } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { autoStartDaemonAndWait } from '../cli/daemon-starter';
+import { readStartupState, recordStartupState } from '../daemon/startup-log';
+
+// ESM exports are not configurable, so spawn cannot be spied — mock the module
+// (the convention already used in observe-mode.spec.ts / core.test.ts).
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return { ...actual, spawn: vi.fn() };
+});
+const mockSpawn = vi.mocked(spawn);
+
+// The poll loop calls these; R1 needs isDaemonReachable to throw mid-poll.
+const { mockIsRunning, mockIsReachable } = vi.hoisted(() => ({
+  mockIsRunning: vi.fn(() => false),
+  mockIsReachable: vi.fn(async () => false),
+}));
+vi.mock('../auth/daemon', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../auth/daemon')>();
+  return { ...actual, isDaemonRunning: mockIsRunning, isDaemonReachable: mockIsReachable };
+});
+
+let tmp: string;
+let homeSpy: ReturnType<typeof vi.spyOn>;
+let origArgv1: string;
+let origTesting: string | undefined;
+
+beforeEach(() => {
+  mockIsRunning.mockReturnValue(false);
+  mockIsReachable.mockResolvedValue(false);
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-spawnerr-'));
+  fs.mkdirSync(path.join(tmp, '.node9'), { recursive: true });
+  homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(tmp);
+  // autoStartDaemonAndWait bails unless argv[1] is an absolute, real .js file, and
+  // returns early in testing mode — neither is about the behaviour under test.
+  origArgv1 = process.argv[1];
+  process.argv[1] = path.resolve(__dirname, '../../dist/cli.js');
+  origTesting = process.env.NODE9_TESTING;
+  delete process.env.NODE9_TESTING;
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  homeSpy.mockRestore();
+  process.argv[1] = origArgv1;
+  if (origTesting !== undefined) process.env.NODE9_TESTING = origTesting;
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/** A stand-in child that reports an exec failure the way Node really does. */
+function fakeChildEmittingError(code: string) {
+  const child = new EventEmitter() as EventEmitter & { unref: () => void };
+  child.unref = () => {};
+  mockSpawn.mockImplementation(() => {
+    // Node surfaces exec failures on a later tick, never synchronously.
+    setTimeout(
+      () => child.emit('error', Object.assign(new Error(`${code}: spawn failed`), { code })),
+      0
+    );
+    return child as unknown as ReturnType<typeof spawn>;
+  });
+  return child;
+}
+
+describe('R0 — an exec failure is recorded, not swallowed', () => {
+  it('records spawn-failed when the child emits ENOENT', async () => {
+    fakeChildEmittingError('ENOENT');
+    const started = await autoStartDaemonAndWait();
+
+    expect(started).toBe(false);
+    const state = readStartupState();
+    expect(state?.outcome).toBe('failed');
+    expect(state?.kind).toBe('spawn-failed');
+    expect(state?.detail).toMatch(/ENOENT/);
+  });
+
+  it('records spawn-failed when the child emits EMFILE (the realistic case here)', async () => {
+    // The spawn target is process.execPath — the running node binary — so ENOENT
+    // and EACCES are near-impossible at this call site. Resource exhaustion is the
+    // failure that actually reaches it on a loaded machine.
+    fakeChildEmittingError('EMFILE');
+    await autoStartDaemonAndWait();
+    expect(readStartupState()?.kind).toBe('spawn-failed');
+    expect(readStartupState()?.detail).toMatch(/EMFILE/);
+  });
+
+  it('leaves the marker at "starting" when the child spawns cleanly', async () => {
+    // No 'error' event: the child now owns the outcome and will record 'ok' or
+    // 'failed' itself. The spawner must not pre-empt that.
+    const child = new EventEmitter() as EventEmitter & { unref: () => void };
+    child.unref = () => {};
+    mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+    await autoStartDaemonAndWait();
+    expect(readStartupState()?.outcome).toBe('starting');
+  });
+});
+
+describe('R1 — only a spawn that produced no child may blame the attempt', () => {
+  it('does not overwrite the daemon\'s own "ok" when the POLL throws', async () => {
+    // The catch wraps the poll loop as well as the spawn. A throw from polling is
+    // not a spawn failure, and by then the child is authoritative — it has already
+    // recorded its own outcome. Overwriting that leaves the state claiming failure
+    // for a daemon that is up.
+    const child = new EventEmitter() as EventEmitter & { unref: () => void };
+    child.unref = () => {};
+    mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+    // Model the real ordering: the spawner marks 'starting', then the CHILD comes
+    // up and records its own 'ok' while we are polling — and only then does the
+    // probe throw. (Seeding 'ok' before the call would be wrong: the spawner's own
+    // 'starting' legitimately overwrites anything older.)
+    mockIsRunning.mockImplementation(() => {
+      recordStartupState('ok'); // the child, mid-poll
+      return true;
+    });
+    mockIsReachable.mockRejectedValue(new Error('ECONNRESET while probing'));
+
+    await autoStartDaemonAndWait();
+
+    expect(readStartupState()?.outcome).toBe('ok');
+    expect(readStartupState()?.kind).toBeUndefined();
+  });
+});

--- a/src/__tests__/startup-cause.unit.test.ts
+++ b/src/__tests__/startup-cause.unit.test.ts
@@ -1,0 +1,287 @@
+/**
+ * B1: the daemon startup STATE — what doctor prints beneath "Daemon not running".
+ *
+ * An earlier design parsed daemon-startup.log (the raw stderr sink) to work this
+ * out. Two review rounds found five separate ways the text lied: a crash dump's
+ * last line is Node's version banner; `Error [ERR_REQUIRE_ESM]:` does not match
+ * `Error:`; a SUCCESSFUL start looks like nothing at all, so an old crash was
+ * reported forever; a multi-line err.message forges a second entry; and an
+ * unrelated append refreshes the mtime that recency was judged on.
+ *
+ * All five were one root cause — a single file serving both a machine and a human
+ * — so the machine signal moved to its own atomically-written JSON object. What
+ * follows is what is left to get wrong.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  logDaemonStartup,
+  readStartupCause,
+  readStartupState,
+  recordStartupState,
+  DAEMON_STARTUP_STATE,
+} from '../daemon/startup-log';
+
+let tmp: string;
+let homeSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-cause-'));
+  homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(tmp);
+});
+afterEach(() => {
+  homeSpy.mockRestore();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/** Seed a state whose age we control — recency is judged per state object. */
+const seed = (state: object, msAgo = 60_000) => {
+  fs.mkdirSync(path.join(tmp, '.node9'), { recursive: true });
+  fs.writeFileSync(
+    DAEMON_STARTUP_STATE(),
+    JSON.stringify({ at: new Date(Date.now() - msAgo).toISOString(), ...state }),
+    'utf-8'
+  );
+};
+
+describe('recordStartupState', () => {
+  it('creates .node9 if absent and round-trips through readStartupState', () => {
+    recordStartupState('failed', 'bind-failed', 'EACCES');
+    const s = readStartupState();
+    expect(s?.outcome).toBe('failed');
+    expect(s?.kind).toBe('bind-failed');
+    expect(s?.detail).toBe('EACCES');
+  });
+
+  it('overwrites rather than appends — only the latest attempt matters', () => {
+    recordStartupState('failed', 'startup-throw', 'boom');
+    recordStartupState('ok');
+    expect(readStartupState()?.outcome).toBe('ok');
+    expect(readStartupState()?.kind).toBeUndefined(); // no residue from the failure
+  });
+
+  it('survives a multi-line detail without forging a second entry', () => {
+    // The line-oriented format this replaced could not: a detail containing
+    // "\nError: connect ECONNREFUSED" was read back as a DIFFERENT, nested error,
+    // losing both the real classification and its timestamp.
+    recordStartupState(
+      'failed',
+      'startup-throw',
+      'Cannot find module X\nRequire stack:\n- /a/cli.js\nError: connect ECONNREFUSED'
+    );
+    const cause = readStartupCause();
+    expect(cause?.kind).toBe('startup-throw'); // not "Error"
+    expect(cause?.detail).toMatch(/Cannot find module X/);
+  });
+
+  it('truncates a pathologically long detail', () => {
+    recordStartupState('failed', 'startup-throw', 'y'.repeat(5000));
+    expect(readStartupState()!.detail!.length).toBeLessThanOrEqual(200);
+  });
+
+  it('never throws when the state path is unwritable', () => {
+    fs.mkdirSync(path.join(tmp, '.node9'), { recursive: true });
+    fs.mkdirSync(DAEMON_STARTUP_STATE()); // a directory where the file should be
+    expect(() => recordStartupState('ok')).not.toThrow();
+    expect(readStartupState()).toBeNull();
+  });
+});
+
+describe('readStartupCause — a successful start means there is nothing to explain', () => {
+  it('says nothing after a clean start', () => {
+    seed({ outcome: 'ok' });
+    expect(readStartupCause()).toBeNull();
+  });
+
+  it('says nothing when the start stood down for a healthy daemon', () => {
+    // "another daemon owns the port" printed beneath "Daemon not running" would
+    // assert the opposite of the warning it is meant to explain.
+    seed({ outcome: 'ok-elsewhere' });
+    expect(readStartupCause()).toBeNull();
+  });
+
+  it('a success ERASES an earlier failure — no resurrection', () => {
+    // The bug that survived an entire review round: on an append-only log an old
+    // crash stayed the newest recognisable entry forever, so doctor blamed an
+    // ERR_REQUIRE_ESM that had not happened in weeks.
+    recordStartupState('failed', 'startup-throw', 'ancient boom');
+    recordStartupState('ok');
+    expect(readStartupCause()).toBeNull();
+  });
+});
+
+describe('readStartupCause — a real failure is reported', () => {
+  it('reports a recorded failure with its kind and detail', () => {
+    seed({ outcome: 'failed', kind: 'bind-failed', detail: 'EACCES' });
+    const cause = readStartupCause();
+    expect(cause?.kind).toBe('bind-failed');
+    expect(cause?.detail).toBe('EACCES');
+  });
+
+  it('reports an unidentified port squatter — the silent-loop case', () => {
+    // Something holds the port but no pid file names it, so every CLI reports
+    // "not running" while each new start exits 0 and says nothing. Recording this
+    // as benign (an earlier design did) hides an unbounded loop.
+    seed({
+      outcome: 'failed',
+      kind: 'orphan-unidentified',
+      detail: 'another process holds :7391 but could not be identified',
+    });
+    expect(readStartupCause()?.kind).toBe('orphan-unidentified');
+  });
+
+  it('stays quiet while a start is still in progress', () => {
+    // A daemon needs a moment to bind. Accusing "did not start" inside that window
+    // would be a false alarm on a perfectly healthy start.
+    seed({ outcome: 'starting' }, 2_000);
+    expect(readStartupCause()).toBeNull();
+  });
+
+  it('reports a spawn that never reported back — the import-time crash', () => {
+    // THE incident: the child dies at module load, before it runs a line of our
+    // code, so it cannot record anything itself. The marker written before the
+    // spawn is the only evidence the attempt ever happened. Aged past the
+    // still-booting grace so it counts as died, not slow.
+    seed({ outcome: 'starting' }, 10 * 60 * 1000);
+    const cause = readStartupCause();
+    expect(cause?.kind).toBe('did-not-start');
+    expect(cause?.detail).toMatch(/daemon-startup\.log/); // points at the human artifact
+  });
+
+  it('does not claim the daemon EXITED — it may never have started at all', () => {
+    // A stranded 'starting' has two causes: the child crashed at module load, or no
+    // child was ever created (an exec failure on the check path, which deliberately
+    // records nothing — see daemon-starter/check R0). "exited during startup" is
+    // true only for the first, and points at a log that is empty for the second.
+    seed({ outcome: 'starting' }, 10 * 60 * 1000);
+    const detail = readStartupCause()!.detail;
+    expect(detail).not.toMatch(/exited/);
+    expect(detail).toMatch(/hook-debug\.log/); // names the other place evidence can be
+  });
+});
+
+describe('readStartupCause — says nothing rather than something wrong', () => {
+  it('ignores a state older than the recency window', () => {
+    seed({ outcome: 'failed', kind: 'startup-throw' }, 48 * 60 * 60 * 1000);
+    expect(readStartupCause()).toBeNull();
+  });
+
+  it('honours a caller-supplied window', () => {
+    seed({ outcome: 'failed', kind: 'startup-throw' }, 2 * 60 * 60 * 1000);
+    expect(readStartupCause(60 * 60 * 1000)).toBeNull();
+    expect(readStartupCause(4 * 60 * 60 * 1000)?.kind).toBe('startup-throw');
+  });
+
+  it('recency uses the state timestamp, NOT the file mtime', () => {
+    // The distinction that broke the log-based design: touching the file must not
+    // make an old failure look current.
+    seed({ outcome: 'failed', kind: 'startup-throw' }, 48 * 60 * 60 * 1000);
+    const now = new Date();
+    fs.utimesSync(DAEMON_STARTUP_STATE(), now, now); // fresh mtime, stale content
+    expect(readStartupCause()).toBeNull();
+  });
+
+  it('returns null for missing, corrupt, empty or malformed state', () => {
+    expect(readStartupCause()).toBeNull(); // absent
+    fs.mkdirSync(path.join(tmp, '.node9'), { recursive: true });
+    fs.writeFileSync(DAEMON_STARTUP_STATE(), 'not json{', 'utf-8');
+    expect(readStartupCause()).toBeNull();
+    fs.writeFileSync(DAEMON_STARTUP_STATE(), '', 'utf-8');
+    expect(readStartupCause()).toBeNull();
+    fs.writeFileSync(DAEMON_STARTUP_STATE(), JSON.stringify({ outcome: 'ok' }), 'utf-8'); // no `at`
+    expect(readStartupCause()).toBeNull();
+  });
+
+  it('returns null for an unknown outcome from a newer version', () => {
+    seed({ outcome: 'some-future-thing' });
+    expect(readStartupCause()).toBeNull();
+  });
+
+  it('returns null for a non-ISO timestamp', () => {
+    fs.mkdirSync(path.join(tmp, '.node9'), { recursive: true });
+    fs.writeFileSync(
+      DAEMON_STARTUP_STATE(),
+      JSON.stringify({ outcome: 'failed', kind: 'x', at: 'yesterday-ish' }),
+      'utf-8'
+    );
+    expect(readStartupCause()).toBeNull();
+  });
+});
+
+describe('recordStartupState — a failing streak keeps its FIRST timestamp', () => {
+  it('does not reset the clock when re-marked during a crash loop', () => {
+    // The hook fires on every tool call, so a crash-looping daemon is re-marked
+    // every few seconds. If each mark reset the timestamp, the grace window would
+    // never expire and doctor would stay silent for as long as the user kept
+    // working — hiding the loop most reliably exactly when it hurts most.
+    seed({ outcome: 'starting' }, 10 * 60 * 1000);
+    // Read the seeded value back rather than recomputing it: two Date.now() calls
+    // can straddle a millisecond boundary, which made this assertion flaky.
+    const first = readStartupState()!.at;
+    recordStartupState('starting'); // a later hook invocation
+    expect(readStartupState()?.at).toBe(first);
+    expect(readStartupCause()?.kind).toBe('did-not-start'); // still reported
+  });
+
+  it('starts a fresh streak after a conclusive outcome', () => {
+    recordStartupState('starting');
+    recordStartupState('ok'); // streak resolved
+    recordStartupState('starting'); // a genuinely new attempt
+    expect(readStartupState()?.outcome).toBe('starting');
+    expect(Date.now() - new Date(readStartupState()!.at).getTime()).toBeLessThan(5_000);
+  });
+
+  it('re-marks when the previous streak has aged out of the window', () => {
+    // Otherwise an ancient 'starting' would silence us for the opposite reason.
+    seed({ outcome: 'starting' }, 48 * 60 * 60 * 1000);
+    recordStartupState('starting');
+    expect(Date.now() - new Date(readStartupState()!.at).getTime()).toBeLessThan(5_000);
+  });
+
+  it('records a spawn that threw as a conclusive failure, not a stranded marker', () => {
+    // No child ever existed, so nothing else will resolve 'starting'. Left alone it
+    // reads as "the daemon exited during startup — see daemon-startup.log", which
+    // points at a file holding no trace of a process that was never created.
+    recordStartupState('starting');
+    recordStartupState('failed', 'spawn-failed', 'EACCES');
+    const cause = readStartupCause();
+    expect(cause?.kind).toBe('spawn-failed');
+    expect(cause?.detail).toBe('EACCES');
+  });
+});
+
+describe('round 5 — regressions found by the fifth review', () => {
+  it('does not truncate the human log when recording a breadcrumb (evidence survives)', () => {
+    // The crashing daemon writes its stack to stderr, which the spawner redirects
+    // into this file, and THEN calls logDaemonStartup. Capping there wiped the
+    // stack milliseconds after it landed, leaving doctor pointing at an empty log.
+    fs.mkdirSync(path.join(tmp, '.node9'), { recursive: true });
+    const log = path.join(tmp, '.node9', 'daemon-startup.log');
+    fs.writeFileSync(log, 'x'.repeat(300 * 1024) + '\nError: the stack that matters\n');
+    logDaemonStartup('startup-throw', 'boom');
+    const after = fs.readFileSync(log, 'utf-8');
+    expect(after).toMatch(/the stack that matters/);
+    expect(after).toMatch(/daemon-startup:startup-throw/);
+  });
+
+  it('is not pinned forever by a FUTURE-dated streak timestamp', () => {
+    // `Date.now() - prevAt < 24h` is also true when prevAt is in the future (clock
+    // skew, a corrected clock), which pinned the marker permanently and silenced
+    // every later attempt.
+    seed({ outcome: 'starting' }, -48 * 60 * 60 * 1000); // 48h in the FUTURE
+    recordStartupState('starting');
+    const at = new Date(readStartupState()!.at).getTime();
+    expect(Math.abs(Date.now() - at)).toBeLessThan(5_000); // re-stamped to now
+  });
+
+  it('labels a failing streak by when it STARTED, not as the last attempt', () => {
+    // The timestamp is deliberately the first attempt of the streak, so calling it
+    // "last start attempt" misreports the age by the length of the streak.
+    seed({ outcome: 'starting' }, 10 * 60 * 1000);
+    expect(readStartupCause()?.label).toBe('start attempts failing since');
+    seed({ outcome: 'failed', kind: 'bind-failed' });
+    expect(readStartupCause()?.label).toBe('last start attempt');
+  });
+});

--- a/src/__tests__/strict-cloud-allow-bypass.spec.ts
+++ b/src/__tests__/strict-cloud-allow-bypass.spec.ts
@@ -1,0 +1,173 @@
+// src/__tests__/strict-cloud-allow-bypass.spec.ts
+// B1 (#6) — a cloud-managed strict mode must not be bypassed by the SaaS
+// gate's immediate-allow.
+//
+// The bug (live repro 2026-07-23): tier-7 strict fallback produces a review
+// verdict with NO ruleName — it is a mode, not a rule. The orchestrator's
+// cloud-bypass guard (`localSmartRuleMatched`) was keyed on ruleName, so the
+// SaaS checkRule answer for an unmatched tool — AUTO_ALLOWED, meaning "no org
+// rule matched", not "the org approved" — resolved the call as approved.
+// The strictest posture an admin can set did nothing on the exact path it
+// exists for.
+//
+// Harness mirrors app-permissions.spec.ts: tmp HOME, managedConfig via
+// rules-cache.json (the REAL input the daemon sync writes), cloud mocked at
+// the initNode9SaaS boundary answering exactly what today's BE answers for an
+// unmatched tool: { pending: false, approved: true }.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { _resetConfigCache } from '../config';
+import { authorizeHeadless, _resetConfigCache as _resetCore } from '../core.js';
+
+const { mockTrustSession, mockInitSaaS, mockPollSaaS } = vi.hoisted(() => ({
+  mockTrustSession: vi.fn((..._a: unknown[]): unknown => null),
+  mockInitSaaS: vi.fn(
+    async (..._a: unknown[]): Promise<unknown> => ({ pending: false, approved: true })
+  ),
+  mockPollSaaS: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ approved: false })),
+}));
+vi.mock('../auth/state', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../auth/state')>()),
+  getActiveTrustSession: (...a: unknown[]) => mockTrustSession(...a),
+}));
+vi.mock('../auth/cloud', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../auth/cloud')>()),
+  initNode9SaaS: (...a: unknown[]) => mockInitSaaS(...a),
+  pollNode9SaaS: (...a: unknown[]) => mockPollSaaS(...a),
+  resolveNode9SaaS: vi.fn(async () => undefined),
+}));
+
+/** Base local config: standard mode, cloud is the ONLY approver surface.
+ *  Native/browser/terminal stay off so a guarded fall-through resolves
+ *  deterministically as no-approval-mechanism instead of opening UI. */
+function writeLocalConfig(tmpHome: string): void {
+  fs.writeFileSync(
+    path.join(tmpHome, '.node9', 'config.json'),
+    JSON.stringify({
+      settings: {
+        mode: 'standard',
+        approvalTimeoutMs: 0,
+        approvers: { native: false, browser: false, cloud: true, terminal: false },
+      },
+      policy: {},
+    })
+  );
+}
+
+function writeRulesCache(
+  tmpHome: string,
+  opts: { managedMode?: string; rules?: unknown[] } = {}
+): void {
+  fs.writeFileSync(
+    path.join(tmpHome, '.node9', 'rules-cache.json'),
+    JSON.stringify({
+      fetchedAt: '2026-07-01T00:00:00Z',
+      rules: opts.rules ?? [],
+      ...(opts.managedMode ? { managedConfig: { mode: opts.managedMode, locked: [] } } : {}),
+    })
+  );
+}
+
+describe('cloud immediate-allow vs managed strict (B1 #6)', () => {
+  let tmpHome: string;
+  let origHome: string | undefined;
+  let origUserprofile: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-strictbypass-'));
+    origHome = process.env.HOME;
+    origUserprofile = process.env.USERPROFILE;
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    delete process.env.NODE9_API_KEY;
+    delete process.env.NODE9_MODE;
+    fs.mkdirSync(path.join(tmpHome, '.node9'), { recursive: true });
+    writeLocalConfig(tmpHome);
+    // cloudEnforced requires a real credential on disk (approvers.cloud && apiKey).
+    fs.writeFileSync(
+      path.join(tmpHome, '.node9', 'credentials.json'),
+      JSON.stringify({
+        default: { apiKey: 'nk_test_0000', apiUrl: 'https://example.invalid/api/v1/intercept' },
+      })
+    );
+    _resetConfigCache();
+    _resetCore();
+    mockTrustSession.mockReturnValue(null);
+    // Today's BE answer for an unmatched tool: resolved, allowed, no pending entry.
+    mockInitSaaS.mockClear();
+    mockInitSaaS.mockResolvedValue({ pending: false, approved: true });
+    mockPollSaaS.mockResolvedValue({ approved: false });
+  });
+
+  afterEach(() => {
+    if (origHome !== undefined) process.env.HOME = origHome;
+    else delete process.env.HOME;
+    if (origUserprofile !== undefined) process.env.USERPROFILE = origUserprofile;
+    else delete process.env.USERPROFILE;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    _resetConfigCache();
+    _resetCore();
+  });
+
+  it('managed strict: cloud "no rule matched" allow must NOT resolve the call', async () => {
+    writeRulesCache(tmpHome, { managedMode: 'strict' });
+
+    const result = await authorizeHeadless('TotallyUnknownTool', { note: 'probe' });
+
+    // The bug resolved this as { approved: true, checkedBy: 'cloud' }. A tier-7
+    // strict review must fall through to the race; with every local surface off
+    // and no cloud PENDING entry, that is a deterministic deny.
+    expect(result.approved).toBe(false);
+    expect(result.checkedBy).not.toBe('cloud');
+    expect(result.blockedBy).toBe('no-approval-mechanism');
+    // Label convention: once cloud is enforced, the orchestrator stamps
+    // 'Organization Policy (SaaS)' over the local label (orchestrator.ts —
+    // same for smart-rule reviews today). The managed strict floor IS org
+    // policy, so either attribution is honest; assert only that a label exists.
+    expect(result.blockedByLabel).toMatch(/strict|organization policy/i);
+  });
+
+  it('managed strict: the SaaS is told forceReview so it creates a genuine PENDING', async () => {
+    writeRulesCache(tmpHome, { managedMode: 'strict' });
+
+    await authorizeHeadless('TotallyUnknownTool', { note: 'probe' });
+
+    expect(mockInitSaaS).toHaveBeenCalled();
+    // initNode9SaaS(toolName, args, creds, meta, riskMetadata, agentPolicy, forceReview)
+    const forceReview = mockInitSaaS.mock.calls[0][6];
+    expect(forceReview).toBe(true);
+  });
+
+  it('standard mode: unmatched tools stay on the local fast path — no cloud round-trip (pinned)', async () => {
+    writeRulesCache(tmpHome, {});
+
+    const result = await authorizeHeadless('TotallyUnknownTool', { note: 'probe' });
+
+    // Standard-mode unmatched → local allow at the fast path. The fix must not
+    // drag every allowed call through initNode9SaaS (the hot-path cost the
+    // outbox shipper exists to avoid).
+    expect(result.approved).toBe(true);
+    expect(result.checkedBy).toBe('local-policy');
+    expect(mockInitSaaS).not.toHaveBeenCalled();
+  });
+
+  it('smart-rule review: still falls to the race, never resolved by cloud allow (pinned)', async () => {
+    writeRulesCache(tmpHome, {
+      rules: [
+        {
+          name: 'review-unknown',
+          tool: 'TotallyUnknownTool',
+          verdict: 'review',
+          conditions: [],
+        },
+      ],
+    });
+
+    const result = await authorizeHeadless('TotallyUnknownTool', { note: 'probe' });
+
+    expect(result.approved).toBe(false);
+    expect(result.checkedBy).not.toBe('cloud');
+  });
+});

--- a/src/__tests__/strict-cloud-allow-bypass.spec.ts
+++ b/src/__tests__/strict-cloud-allow-bypass.spec.ts
@@ -153,6 +153,40 @@ describe('cloud immediate-allow vs managed strict (B1 #6)', () => {
     expect(mockInitSaaS).not.toHaveBeenCalled();
   });
 
+  it('managed strict: a prior "Always Allow" must not pre-satisfy the review', async () => {
+    // Same defect shape as the cloud guard: the persistent consult was keyed on
+    // ruleName, so a tier-7 review fell through to decisions.json. One click
+    // granted BEFORE the org mandated strict would permanently exempt the tool
+    // — and the call never reaches the cloud, so the BE floor can't catch it.
+    writeRulesCache(tmpHome, { managedMode: 'strict' });
+    fs.writeFileSync(
+      path.join(tmpHome, '.node9', 'decisions.json'),
+      JSON.stringify({ TotallyUnknownTool: 'allow' })
+    );
+
+    const result = await authorizeHeadless('TotallyUnknownTool', { note: 'probe' });
+
+    expect(result.approved).toBe(false);
+    expect(result.checkedBy).not.toBe('persistent');
+  });
+
+  it('standard mode: a prior "Always Allow" still works for reviewed tools (pinned)', async () => {
+    // No managed mode; make the tool reach the persistent consult by turning
+    // cloud off (otherwise a standard-mode unmatched tool is allowed earlier).
+    writeRulesCache(tmpHome, {});
+    fs.writeFileSync(
+      path.join(tmpHome, '.node9', 'decisions.json'),
+      JSON.stringify({ mkfs_data: 'allow' })
+    );
+
+    // mkfs_data trips the dangerous-word review (no ruleName, tier < 7) — the
+    // exact shape that must STAY persistent-resolvable.
+    const result = await authorizeHeadless('mkfs_data', { note: 'probe' });
+
+    expect(result.approved).toBe(true);
+    expect(result.checkedBy).toBe('persistent');
+  });
+
   it('smart-rule review: still falls to the race, never resolved by cloud allow (pinned)', async () => {
     writeRulesCache(tmpHome, {
       rules: [

--- a/src/audit/decision.ts
+++ b/src/audit/decision.ts
@@ -49,16 +49,43 @@ const TIMEOUT_SOURCES = new Set(['timeout']);
 
 const has = (s: string, needle: string) => s.includes(needle);
 
+/** The subset of an audit row this needs. Anything row-shaped satisfies it. */
+export interface AuditRowLike {
+  decision?: unknown;
+  checkedBy?: unknown;
+  /** The gate writes `checkedBy`; the PostToolUse hook writes `source`. */
+  source?: unknown;
+}
+
 /**
- * Classify one audit row.
+ * Classify one audit row. PASS THE ROW.
  *
- * `checkedBy` carries the nuance the dashboard shows — whether an allow was
- * automatic or human-approved, whether a refusal was a rule, a person, or a
- * timeout — so both fields are needed to produce an honest label.
+ * The attribution field is NOT uniform: the gate writes `checkedBy`, while the
+ * PostToolUse hook and the daemon write `source`. In one real log that is
+ * 37,576 rows with `source` and no `checkedBy`.
+ *
+ * An earlier signature took `(decision, checkedBy)` and left each caller to
+ * decide where the second argument came from — five callers made three
+ * different choices, so a human approving an action displayed as "Auto-allowed"
+ * and a human REFUSING one displayed as "Blocked". That is the same
+ * reader-drift this module exists to prevent, just moved one level up into the
+ * call sites. Taking the row removes the choice.
+ *
+ * The two-argument form is kept for callers that genuinely hold only the pair
+ * (and for tests), but prefer the row form.
  */
-export function classifyDecision(decision: unknown, checkedBy?: unknown): DecisionView {
+export function classifyDecision(row: AuditRowLike): DecisionView;
+export function classifyDecision(decision: unknown, checkedBy?: unknown): DecisionView;
+export function classifyDecision(a: unknown, b?: unknown): DecisionView {
+  // A row-shaped first argument carries its own attribution field; anything
+  // else is the legacy (decision, checkedBy) pair.
+  const isRow =
+    !!a && typeof a === 'object' && ('decision' in a || 'checkedBy' in a || 'source' in a);
+  const decision = isRow ? (a as AuditRowLike).decision : a;
+  const attribution = isRow ? ((a as AuditRowLike).checkedBy ?? (a as AuditRowLike).source) : b;
+
   const raw = typeof decision === 'string' ? decision : String(decision ?? '');
-  const src = typeof checkedBy === 'string' ? checkedBy.toLowerCase() : '';
+  const src = typeof attribution === 'string' ? attribution.toLowerCase() : '';
   const d = raw.toLowerCase();
 
   // Shadow mode first: the row's own decision is unreliable here (one observe

--- a/src/audit/decision.ts
+++ b/src/audit/decision.ts
@@ -1,0 +1,108 @@
+/**
+ * The ONE place that turns a raw audit row into a human-readable outcome.
+ *
+ * WHY THIS EXISTS
+ *
+ * The audit log carries six spellings of three outcomes, written by seven
+ * producers: the gate writes `allow`/`deny`, the PostToolUse hook writes
+ * `allowed`, the daemon writes `auto-deny` and `mcp-discovered`, the DLP
+ * scanner writes `dlp`, and two call sites write `block`. Every reader used to
+ * hand-roll its own rule for collapsing that, and they disagreed:
+ *
+ *   • the MCP audit tool rendered everything that wasn't literally `block` or
+ *     `review` as `[allow]` — so all 12,176 `deny` rows reported as ALLOWED
+ *   • `node9 audit` used `startsWith('allow')`, correct for the main cases but
+ *     showing `dlp` and `mcp-discovered` (findings, not verdicts) as DENY
+ *   • `node9 sessions` had a third copy
+ *
+ * Two readers failing in OPPOSITE directions on the same file is what this
+ * module removes. Vocabulary matches the dashboard's RequestStatus labels so
+ * the CLI, the MCP tools and the web UI describe an event the same way.
+ *
+ * TWO RULES THAT MUST NOT BE RELAXED
+ *
+ * 1. An unrecognised decision NEVER classifies as `allow`. That is exactly the
+ *    bug this replaces — a fall-through `else` that reported anything unknown
+ *    as permitted. Reporting fails loud: unknown surfaces as `unknown` with the
+ *    raw value preserved, so a new producer inventing an eighth spelling shows
+ *    up in a test rather than silently as an allow in production.
+ * 2. "Timed out" is not "Denied". 3,643 rows in one real log are refusals
+ *    because nobody answered, not because a human refused. Those demand very
+ *    different responses, and merging them hides approval fatigue.
+ */
+
+/** Coarse bucket — filtering and counting. `label` is presentation. */
+export type AuditOutcome = 'allow' | 'deny' | 'observe' | 'info' | 'unknown';
+
+export interface DecisionView {
+  outcome: AuditOutcome;
+  /** Dashboard vocabulary: Auto-allowed · Approved · Blocked · Denied · … */
+  label: string;
+  /** Exactly what the row stored, so nothing is hidden by the mapping. */
+  raw: string;
+}
+
+/** checkedBy values meaning a HUMAN made the call (vs a rule firing). */
+const HUMAN_SOURCES = new Set(['daemon', 'cloud', 'local-decision', 'inline-review-approved']);
+
+const TIMEOUT_SOURCES = new Set(['timeout']);
+
+const has = (s: string, needle: string) => s.includes(needle);
+
+/**
+ * Classify one audit row.
+ *
+ * `checkedBy` carries the nuance the dashboard shows — whether an allow was
+ * automatic or human-approved, whether a refusal was a rule, a person, or a
+ * timeout — so both fields are needed to produce an honest label.
+ */
+export function classifyDecision(decision: unknown, checkedBy?: unknown): DecisionView {
+  const raw = typeof decision === 'string' ? decision : String(decision ?? '');
+  const src = typeof checkedBy === 'string' ? checkedBy.toLowerCase() : '';
+  const d = raw.toLowerCase();
+
+  // Shadow mode first: the row's own decision is unreliable here (one observe
+  // path writes `allow`, another writes `deny` for the same concept), and
+  // either way the action was NOT stopped — but node9 would have stopped it.
+  // Counting these as plain allows is what makes shadow mode invisible.
+  if (src && has(src, 'observe-mode')) {
+    return { outcome: 'observe', label: 'Would block', raw };
+  }
+
+  // Not decisions at all — a detection finding and an inventory event. Bucketing
+  // them as refusals (the CLI's old behaviour) invents denials that never were.
+  if (d === 'dlp') return { outcome: 'info', label: 'Finding', raw };
+  if (d === 'mcp-discovered') return { outcome: 'info', label: 'Info', raw };
+
+  if (d === 'allow' || d === 'allowed') {
+    // The PostToolUse hook records that a tool RAN. It isn't a verdict — the
+    // gate already decided, earlier, in its own row.
+    if (src === 'post-hook') return { outcome: 'allow', label: 'Ran', raw };
+    if (HUMAN_SOURCES.has(src)) {
+      return { outcome: 'allow', label: 'Approved', raw };
+    }
+    return { outcome: 'allow', label: 'Auto-allowed', raw };
+  }
+
+  if (d === 'deny' || d === 'auto-deny' || d === 'block') {
+    if (TIMEOUT_SOURCES.has(src)) {
+      return { outcome: 'deny', label: 'Timed out', raw };
+    }
+    if (HUMAN_SOURCES.has(src)) {
+      return { outcome: 'deny', label: 'Denied', raw };
+    }
+    return { outcome: 'deny', label: 'Blocked', raw };
+  }
+
+  if (d === 'review' || d === 'pending') {
+    return { outcome: 'info', label: 'Pending', raw };
+  }
+
+  // Never `allow`. See rule 1 in the header.
+  return { outcome: 'unknown', label: raw ? `? ${raw}` : '? (none)', raw };
+}
+
+/** Fixed-width tag for aligned CLI / MCP output. */
+export function decisionTag(view: DecisionView): string {
+  return `[${view.label}]`.padEnd(14);
+}

--- a/src/audit/decision.ts
+++ b/src/audit/decision.ts
@@ -77,10 +77,13 @@ export interface AuditRowLike {
 export function classifyDecision(row: AuditRowLike): DecisionView;
 export function classifyDecision(decision: unknown, checkedBy?: unknown): DecisionView;
 export function classifyDecision(a: unknown, b?: unknown): DecisionView {
-  // A row-shaped first argument carries its own attribution field; anything
-  // else is the legacy (decision, checkedBy) pair.
-  const isRow =
-    !!a && typeof a === 'object' && ('decision' in a || 'checkedBy' in a || 'source' in a);
+  // Any object is a row; anything else is the legacy (decision, checkedBy)
+  // pair. Do NOT sniff for specific keys — an event row
+  // (`{"event":"shield-create"}`) carries none of them, fell through to the
+  // legacy branch, and got stringified into the decision itself, so the MCP
+  // audit reader printed `? [object Object]`. A decision is never an object,
+  // which makes the type alone a sufficient test.
+  const isRow = !!a && typeof a === 'object';
   const decision = isRow ? (a as AuditRowLike).decision : a;
   const attribution = isRow ? ((a as AuditRowLike).checkedBy ?? (a as AuditRowLike).source) : b;
 

--- a/src/auth/daemon.ts
+++ b/src/auth/daemon.ts
@@ -168,6 +168,27 @@ export async function isDaemonReachable(timeoutMs = 500): Promise<boolean> {
 }
 
 /**
+ * Is a genuine human approver reachable right now — i.e. is an input-capable
+ * client (`node9 tail`) connected to the daemon? Used by the orchestrator to
+ * decide whether a shield hard-block may be downgraded to a review. Fails
+ * CLOSED (returns false) on any error/timeout: if we can't confirm a human is
+ * watching, a hard block must stay hard rather than become an auto-allowable
+ * review in a non-interactive context.
+ */
+export async function daemonHasInteractiveApprover(timeoutMs = 400): Promise<boolean> {
+  try {
+    const res = await fetch(`http://${DAEMON_HOST}:${DAEMON_PORT}/approver`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) return false;
+    const body = (await res.json()) as { interactive?: unknown };
+    return body.interactive === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Register a new approval entry with the daemon and return its ID.
  * Both the browser racer (GET /wait) and the terminal racer (POST /decision)
  * share this entry — it must be created before the race starts.

--- a/src/auth/orchestrator.ts
+++ b/src/auth/orchestrator.ts
@@ -862,7 +862,14 @@ async function _authorizeHeadlessCore(
     // commands not covered by a smart rule. Future work: key by command-level
     // pattern (e.g. first command token) so approvals are narrowly scoped.
     // See: doc/roadmap.md "Command-Scoped Persistent Approvals".
-    const persistent = policyResult.ruleName ? null : getPersistentDecision(toolName);
+    //
+    // B1 (#6): tier-7 strict reviews skip the consult too — same key-on-
+    // ruleName defect as the cloud guard above. An "Always Allow" clicked
+    // BEFORE the org mandated strict would permanently exempt that tool, and
+    // the call never reaches the cloud, so the BE floor can't compensate.
+    // Rule-less sub-tier-7 reviews (dangerous-word) stay persistent-resolvable.
+    const persistent =
+      policyResult.ruleName || policyResult.tier === 7 ? null : getPersistentDecision(toolName);
     // `!appPermReview`: a prior "Always Allow" must not bypass an org-set review
     // (fix #3). A persistent DENY still short-circuits (tightening is fine).
     if (persistent === 'allow' && !appPermReview) {

--- a/src/auth/orchestrator.ts
+++ b/src/auth/orchestrator.ts
@@ -16,6 +16,7 @@ import {
 } from './state';
 import {
   isDaemonRunning,
+  daemonHasInteractiveApprover,
   getInternalToken,
   registerDaemonEntry,
   waitForDaemonDecision,
@@ -159,6 +160,31 @@ function notifyActivity(data: {
   sessionId?: string;
 }): Promise<boolean> {
   return notifyActivitySocket(data);
+}
+
+/**
+ * Is a genuine HUMAN approver reachable right now, for the purpose of softening
+ * a hard block into a review? (task #17, fail-closed gate.)
+ *
+ *  - native GUI popup: reachable iff a display is present AND this is the HOOK
+ *    process (the daemon's own background pass never opens a dialog, so a
+ *    display does not help there).
+ *  - terminal (`node9 tail`): reachable iff an input-capable client is connected
+ *    to the daemon (asked over HTTP; that call fails closed on error/timeout).
+ *
+ * Cloud is deliberately NOT a "human" here — it can auto-resolve a client-side
+ * shield the SaaS has no rule for. Returns false on any uncertainty so a hard
+ * block stays hard rather than becoming an auto-allowable review.
+ */
+export async function hasReachableHumanApprover(opts: {
+  approvers: { native?: boolean; terminal?: boolean };
+  calledFromDaemon?: boolean;
+}): Promise<boolean> {
+  const hasDisplay = !!(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+  const nativeReachable = !opts.calledFromDaemon && opts.approvers.native !== false && hasDisplay;
+  // Short-circuit: only pay the daemon round-trip when native can't reach a human.
+  if (nativeReachable) return true;
+  return opts.approvers.terminal !== false && (await daemonHasInteractiveApprover());
 }
 
 export async function authorizeHeadless(
@@ -717,6 +743,22 @@ async function _authorizeHeadlessCore(
 
     // Hard block from smart rules — skip the race engine entirely
     if (policyResult.decision === 'block') {
+      // Fail-closed gate for the block→review downgrade below. A hard block may
+      // only soften to a review when a genuine HUMAN approver is actually
+      // reachable — a GUI popup can be shown, or a `node9 tail` is connected.
+      // With NO reachable human (CI, headless, a piped non-interactive agent)
+      // the block STAYS a block, so the approver race can never resolve it to
+      // allow (e.g. a cloud immediate-allow of a client-side shield the SaaS
+      // has no rule for). Cloud is deliberately NOT a "human" here — it can
+      // auto-resolve. Fails closed: any uncertainty keeps the hard block.
+      const daemonUp = isDaemonRunning();
+      let humanApproverReachable = false;
+      if (!policyResult.dependsOnStatePredicates?.length && daemonUp && !isTestEnv) {
+        humanApproverReachable = await hasReachableHumanApprover({
+          approvers,
+          calledFromDaemon: options?.calledFromDaemon,
+        });
+      }
       // If block has dependsOnState predicates, check them via the daemon.
       // If predicates are not all satisfied (or daemon unreachable), downgrade
       // to review so the user can decide rather than being hard-blocked.
@@ -752,10 +794,12 @@ async function _authorizeHeadlessCore(
         if (predicatesMet && policyResult.recoveryCommand) {
           statefulRecoveryCommand = policyResult.recoveryCommand;
         }
-      } else if (isDaemonRunning() && !isTestEnv) {
-        // Local development: daemon is running and not in a test/CI environment,
-        // so a human is at the keyboard. Downgrade hard-block to review — the user
-        // gets a popup and can approve or deny. Hard blocks stay hard in CI.
+      } else if (daemonUp && !isTestEnv && humanApproverReachable) {
+        // A genuine human approver is reachable (GUI popup or connected tail),
+        // so downgrade hard-block to review — the user gets a card and can
+        // approve or deny. Without a reachable human this branch is skipped and
+        // the block stays hard (the `else` below): never a review a non-human
+        // channel could auto-allow. Hard blocks also stay hard in CI/test.
         //
         // Make the downgrade visible. Two changes vs. a regular review:
         //   1. Audit `checkedBy` is 'smart-rule-block-override' — the dashboard

--- a/src/auth/orchestrator.ts
+++ b/src/auth/orchestrator.ts
@@ -822,7 +822,20 @@ async function _authorizeHeadlessCore(
     explainableLabel = policyResult.blockedByLabel || 'Local Config';
     policyMatchedField = policyResult.matchedField;
     policyMatchedWord = policyResult.matchedWord;
-    if (policyResult.ruleName) localSmartRuleMatched = true;
+    // B1 (#6): the tier-7 strict fallback reviews with NO ruleName (it is a
+    // mode, not a rule) — keying this guard on ruleName alone let the SaaS
+    // gate's immediate-allow for an unmatched tool ("no org rule matched",
+    // NOT an approval) resolve the call, silently bypassing a cloud-managed
+    // strict mode. Strict says "unmatched requires a human"; cloud's no-match
+    // allow must never pre-empt that.
+    // Deliberately tier-7-only: other rule-less reviews (e.g. dangerous-word)
+    // stay cloud-resolvable — pinned by core.test.ts ("calls cloud API and
+    // returns approved:true") and a semantics change that wide needs its own
+    // decision, not a rider on this fix.
+    // (The name `localSmartRuleMatched` is kept — it crosses the daemon HTTP
+    // boundary (auth/daemon.ts → daemon/server.ts) and renaming the wire field
+    // would silently drop the guard on a hook↔daemon version skew.)
+    if (policyResult.ruleName || policyResult.tier === 7) localSmartRuleMatched = true;
     // Capture the human-readable description so it survives through the race
     // engine and appears in sendBlock even when the user denies at the daemon.
     if (policyResult.ruleDescription) policyRuleDescription = policyResult.ruleDescription;

--- a/src/auth/orchestrator.ts
+++ b/src/auth/orchestrator.ts
@@ -759,9 +759,47 @@ async function _authorizeHeadlessCore(
           calledFromDaemon: options?.calledFromDaemon,
         });
       }
-      // If block has dependsOnState predicates, check them via the daemon.
-      // If predicates are not all satisfied (or daemon unreachable), downgrade
-      // to review so the user can decide rather than being hard-blocked.
+      // A hard block softens into a review/recovery card ONLY when a genuine
+      // human approver is reachable (GUI popup or connected tail). With none —
+      // CI, headless, a piped non-interactive agent — it stays hard so the
+      // approver race can never resolve it to allow (a cloud immediate-allow of
+      // a client-side shield the SaaS has no rule for). Fails closed.
+      const mayDowngrade = daemonUp && !isTestEnv && humanApproverReachable;
+
+      // The audit row + hard-block result, shared by every non-softening path so
+      // a fail-closed decision is a single call.
+      const hardBlock = (): AuthResult => {
+        // Include policyResult.ruleName so the [2] Report SHIELDS panel can
+        // attribute this block to its specific shield via the rule→shield map.
+        if (!isManual)
+          appendLocalAudit(
+            toolName,
+            args,
+            'deny',
+            'smart-rule-block',
+            { ...meta, ruleName: policyResult.ruleName },
+            hashAuditArgs
+          );
+        return {
+          approved: false,
+          reason: policyResult.reason ?? 'Action explicitly blocked by Smart Policy.',
+          blockedBy: 'local-config',
+          blockedByLabel: policyResult.blockedByLabel,
+          ruleHit: policyResult.ruleName,
+          ...(policyResult.recoveryCommand && { recoveryCommand: policyResult.recoveryCommand }),
+          ...(policyResult.ruleDescription && { ruleDescription: policyResult.ruleDescription }),
+        };
+      };
+
+      // Stateful (dependsOnState) rules keep their DELIBERATE downgrade-to-review
+      // semantics: when predicates are unknown / the daemon can't check them,
+      // they soften into the STATE GUARD recovery card rather than hard-blocking
+      // a legitimate action (e.g. a deploy) just because state is unavailable —
+      // an availability choice for that feature, tested in stateful-rules.spec.
+      // The fail-closed human-reachability gate applies to PLAIN blocks only
+      // (below). KNOWN RESIDUAL: a stateful block can still soften in a fully
+      // non-interactive context — tracked as its own decision (design doc §2b),
+      // not ridden onto the shield fix.
       if (policyResult.dependsOnStatePredicates?.length) {
         const stateResults = await checkStatePredicates(policyResult.dependsOnStatePredicates);
         // Strict === true check: undefined (missing key) and false are both treated
@@ -794,7 +832,7 @@ async function _authorizeHeadlessCore(
         if (predicatesMet && policyResult.recoveryCommand) {
           statefulRecoveryCommand = policyResult.recoveryCommand;
         }
-      } else if (daemonUp && !isTestEnv && humanApproverReachable) {
+      } else if (mayDowngrade) {
         // A genuine human approver is reachable (GUI popup or connected tail),
         // so downgrade hard-block to review — the user gets a card and can
         // approve or deny. Without a reachable human this branch is skipped and
@@ -834,32 +872,9 @@ async function _authorizeHeadlessCore(
         }
         // Fall through to the race engine with the override label visible.
       } else {
-        if (!isManual)
-          appendLocalAudit(
-            toolName,
-            args,
-            'deny',
-            'smart-rule-block',
-            // Include policyResult.ruleName so the [2] Report SHIELDS
-            // panel can attribute this block to its specific shield
-            // (e.g. `shield:project-jail:block-read-ssh`) via the
-            // rule→shield map. checkedBy stays as the generic
-            // `smart-rule-block` for backward compat with existing
-            // log readers.
-            { ...meta, ruleName: policyResult.ruleName },
-            hashAuditArgs
-          );
-        // (Cloud delivery via the outbox shipper — the old fire-and-forget
-        // POST here was killed by the immediate process exit on block.)
-        return {
-          approved: false,
-          reason: policyResult.reason ?? 'Action explicitly blocked by Smart Policy.',
-          blockedBy: 'local-config',
-          blockedByLabel: policyResult.blockedByLabel,
-          ruleHit: policyResult.ruleName,
-          ...(policyResult.recoveryCommand && { recoveryCommand: policyResult.recoveryCommand }),
-          ...(policyResult.ruleDescription && { ruleDescription: policyResult.ruleDescription }),
-        };
+        // No reachable human → the block stays hard (fail closed). Cloud
+        // delivery of the deny rides the outbox shipper from the audit row.
+        return hardBlock();
       }
     }
 

--- a/src/cli/aggregate/report-audit.ts
+++ b/src/cli/aggregate/report-audit.ts
@@ -24,6 +24,7 @@ import { decodeProjectDirName } from '../../costSync';
 import { pricingFor, normalizeModel } from '../../pricing/litellm';
 import { codexSessionCost } from '../../cost-codex';
 import type { BuildReportJsonInput, ReportPeriod } from '../render/report-json';
+import { classifyDecision } from '../../audit/decision';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -301,8 +302,43 @@ function parseAuditLog(logPath: string): AuditEntry[] {
   });
 }
 
-function isAllow(decision: string): boolean {
-  return decision.startsWith('allow');
+/**
+ * How one row counts in this report. The fifth hand-rolled copy of this rule
+ * used to live here as `decision.startsWith('allow')`, which asked only "does
+ * the word begin with allow" and so bucketed everything else as a BLOCK —
+ * including 913 shadow-mode rows that RAN and 5 MCP-discovery events that were
+ * never verdicts at all.
+ *
+ * It cannot simply delegate to `classifyDecision`, because `outcome === 'allow'`
+ * alone is also wrong here: shadow mode writes `allow`/observe-mode-would-block
+ * for actions that ran, and a straight swap would have moved 8,217 of them into
+ * the block path. This report needs THREE questions, not one:
+ *
+ *   ran      — the action executed (a plain allow, or observe mode letting it
+ *              through after flagging it). Never a block.
+ *   blocked  — the action was refused. Only this feeds block counts.
+ *   info     — a finding or a discovery event. Neither; counted as a call but
+ *              never as a verdict.
+ *
+ * `unknown` counts as blocked, preserving the previous fail-toward-visible
+ * behaviour: an unrecognised decision should show up, not vanish into allows.
+ */
+interface RowView {
+  ran: boolean;
+  blocked: boolean;
+  info: boolean;
+  observed: boolean;
+}
+
+function viewOf(e: { decision?: unknown; checkedBy?: unknown; source?: unknown }): RowView {
+  const outcome = classifyDecision(e).outcome;
+  const observed = outcome === 'observe';
+  return {
+    observed,
+    ran: outcome === 'allow' || observed,
+    blocked: outcome === 'deny' || outcome === 'unknown',
+    info: outcome === 'info',
+  };
 }
 
 function isDlp(checkedBy: string | undefined): boolean {
@@ -1063,14 +1099,19 @@ export function aggregateReportFromAudit(
   const periodMs = end.getTime() - start.getTime();
   const priorEnd = new Date(start.getTime() - 1);
   const priorStart = new Date(start.getTime() - periodMs);
+  // The prior-period population must match the current one below, or the trend
+  // arrow compares two different denominators. `response-dlp` and event rows
+  // were previously dropped from the current period only — so the same log
+  // scored a higher block RATE in the past than in the present purely by which
+  // rows each filter let through.
   const priorEntries = allEntries.filter((e) => {
     if (e.source === 'post-hook') return false;
+    if (e.source === 'response-dlp') return false;
+    if (typeof e.decision !== 'string') return false;
     const ts = new Date(e.ts);
     return ts >= priorStart && ts <= priorEnd;
   });
-  const priorBlocked = priorEntries.filter(
-    (e) => typeof e.decision === 'string' && !isAllow(e.decision)
-  ).length;
+  const priorBlocked = priorEntries.filter((e) => viewOf(e).blocked).length;
   const priorBlockRate = priorEntries.length > 0 ? priorBlocked / priorEntries.length : null;
 
   // PreToolUse entries inside the period (post-hook + response-dlp dropped)
@@ -1152,16 +1193,24 @@ export function aggregateReportFromAudit(
     // misattributes a single decision to two different outcomes.
     if (superseded.has(supersedeKey(e))) continue;
 
-    const allow = isAllow(e.decision);
+    const view = viewOf(e);
     const dateKey = e.ts.slice(0, 10);
     const userInteracted = e.source === 'daemon';
 
-    if (userInteracted) {
-      if (allow) userApproved++;
+    // Shadow mode is neither an approval nor a refusal: node9 flagged the
+    // action and it ran anyway. It gets its own counter and is kept out of
+    // every block bucket below.
+    if (view.observed) {
+      if (e.checkedBy === 'observe-mode-dlp-would-block') observeDlp++;
+    } else if (view.info) {
+      // A finding or an MCP-discovery event — not a verdict. These carry
+      // source='daemon', so the branch below would have scored all 5 of them
+      // as the USER denying an action they never saw.
+    } else if (userInteracted) {
+      if (view.ran) userApproved++;
       else userDenied++;
-    } else if (!allow) {
+    } else if (view.blocked) {
       if (e.checkedBy === 'timeout') timedOut++;
-      else if (e.checkedBy === 'observe-mode-dlp-would-block') observeDlp++;
       else if (isDlp(e.checkedBy)) dlpBlocked++;
       // A native-OS popup deny — the user clicked Block. Same intent
       // as a SaaS-approver deny (source=daemon), just a different
@@ -1183,7 +1232,7 @@ export function aggregateReportFromAudit(
     if (cb.includes('would-block') && (cb.includes('pii') || cb.includes('dlp'))) {
       dimDataObserved++;
     }
-    if (!allow && !userInteracted) {
+    if (view.blocked && !userInteracted) {
       switch (dimensionOfBlock(cb, e.ruleName ?? '')) {
         case 'network':
           dimNetworkBlocked++;
@@ -1204,10 +1253,10 @@ export function aggregateReportFromAudit(
 
     const t = toolMap.get(e.tool) ?? { calls: 0, blocked: 0 };
     t.calls++;
-    if (!allow) t.blocked++;
+    if (view.blocked) t.blocked++;
     toolMap.set(e.tool, t);
 
-    if (!allow) {
+    if (view.blocked) {
       // SaaS-approver denials (source=daemon, no checkedBy tag) are
       // user-initiated denies — the same conceptual bucket as native-
       // popup denies (checkedBy=local-decision). Without this fold,
@@ -1220,10 +1269,12 @@ export function aggregateReportFromAudit(
         blockMap.set(key, (blockMap.get(key) ?? 0) + 1);
       }
     }
-    // Specific-rule attribution: only present on smart-rule paths.
-    // Counts both block and review fires (everything that wasn't an
-    // explicit allow).
-    if (!allow && e.ruleName) {
+    // Specific-rule attribution: only present on smart-rule paths. Counts
+    // block and review fires — and observe fires, because a rule that matched
+    // in shadow mode still FIRED; excluding them would make a shield look dead
+    // in exactly the mode you turn on to see whether it works. (No observe row
+    // carries a ruleName today, so this is intent, not a live delta.)
+    if ((view.blocked || view.observed) && e.ruleName) {
       ruleMap.set(e.ruleName, (ruleMap.get(e.ruleName) ?? 0) + 1);
     }
 
@@ -1235,7 +1286,7 @@ export function aggregateReportFromAudit(
 
     const d = dailyMap.get(dateKey) ?? { calls: 0, blocked: 0 };
     d.calls++;
-    if (!allow) d.blocked++;
+    if (view.blocked) d.blocked++;
     dailyMap.set(dateKey, d);
   }
 

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -53,7 +53,9 @@ export function registerAuditCommand(program: Command): void {
         // `startsWith('allow') ? allow : deny` this replaces bucketed `dlp` and
         // `mcp-discovered` — findings, not verdicts — as DENY, inventing
         // refusals that never happened.
-        view: classifyDecision(e.decision, e.checkedBy),
+        // Pass the ROW, never a field pair — the attribution key differs by
+        // producer (`checkedBy` from the gate, `source` from the hook/daemon).
+        view: classifyDecision(e),
       }));
 
       if (options.tool) entries = entries.filter((e) => String(e.tool).includes(options.tool!));

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -4,6 +4,7 @@ import type { Command } from 'commander';
 import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
+import { classifyDecision } from '../../audit/decision';
 import os from 'os';
 
 function formatRelativeTime(timestamp: string): string {
@@ -48,11 +49,17 @@ export function registerAuditCommand(program: Command): void {
       // Normalize decision field — some older entries use "allowed"/"denied"
       entries = entries.map((e) => ({
         ...e,
-        decision: String(e.decision).startsWith('allow') ? 'allow' : 'deny',
+        // classifyDecision is the ONE mapper (audit/decision.ts). The inline
+        // `startsWith('allow') ? allow : deny` this replaces bucketed `dlp` and
+        // `mcp-discovered` — findings, not verdicts — as DENY, inventing
+        // refusals that never happened.
+        view: classifyDecision(e.decision, e.checkedBy),
       }));
 
       if (options.tool) entries = entries.filter((e) => String(e.tool).includes(options.tool!));
-      if (options.deny) entries = entries.filter((e) => e.decision === 'deny');
+      // `--deny` means every refusal: a rule block, a human denial, AND a
+      // timeout. Matching the literal string missed `auto-deny` and `block`.
+      if (options.deny) entries = entries.filter((e) => e.view.outcome === 'deny');
 
       const limit = Math.max(1, parseInt(options.tail, 10) || 20);
       entries = entries.slice(-limit);
@@ -80,7 +87,13 @@ export function registerAuditCommand(program: Command): void {
         const time = formatRelativeTime(String(e.ts)).padEnd(12);
         const tool = String(e.tool).slice(0, 17).padEnd(18);
         const result =
-          e.decision === 'allow' ? chalk.green('ALLOW'.padEnd(10)) : chalk.red('DENY'.padEnd(10));
+          e.view.outcome === 'allow'
+            ? chalk.green(e.view.label.padEnd(14))
+            : e.view.outcome === 'deny'
+              ? chalk.red(e.view.label.padEnd(14))
+              : e.view.outcome === 'observe'
+                ? chalk.yellow(e.view.label.padEnd(14))
+                : chalk.gray(e.view.label.padEnd(14));
         const checker = String(e.checkedBy || 'unknown')
           .slice(0, 14)
           .padEnd(15);
@@ -88,8 +101,8 @@ export function registerAuditCommand(program: Command): void {
         console.log(`  ${time} ${tool} ${result} ${checker} ${agent}`);
       }
 
-      const allowed = entries.filter((e) => e.decision === 'allow').length;
-      const denied = entries.filter((e) => e.decision === 'deny').length;
+      const allowed = entries.filter((e) => e.view.outcome === 'allow').length;
+      const denied = entries.filter((e) => e.view.outcome === 'deny').length;
       console.log(chalk.dim('  ' + '─'.repeat(65)));
       console.log(
         `  ${entries.length} entries  |  ${chalk.green(allowed + ' allowed')}  |  ${chalk.red(denied + ' denied')}\n`

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -10,7 +10,7 @@ import os from 'os';
 import { authorizeHeadless } from '../../auth/orchestrator';
 import { checkPause } from '../../auth/state';
 import { isDaemonRunning } from '../../auth/daemon';
-import { openStartupLogFd } from '../../daemon/startup-log';
+import { openStartupLogFd, recordStartupState } from '../../daemon/startup-log';
 import { getConfig, type Config } from '../../config';
 import { shouldSnapshot } from '../../policy';
 import { buildNegotiationMessage, buildReviewMessage } from '../../policy/negotiation';
@@ -416,11 +416,28 @@ export function registerCheckCommand(program: Command): void {
               // child already holds its own copy. Close in finally so a spawn() throw
               // (→ outer catch) can't leak the fd.
               const startupFd = openStartupLogFd();
+              // Mark the attempt BEFORE spawning. If the child dies at module load
+              // (the ERR_REQUIRE_ESM class), it never runs a line of our code and
+              // cannot report anything itself — this marker plus "daemon still
+              // down" is the only evidence that a start was even attempted.
+              recordStartupState('starting');
               try {
                 const d = spawn(process.execPath, [scriptPath, 'daemon'], {
                   detached: true,
                   stdio: ['ignore', 'ignore', startupFd ?? 'ignore'],
                   env: { ...safeEnv, NODE9_AUTO_STARTED: '1' },
+                });
+                // MANDATORY, and not merely for diagnostics: spawn() reports exec
+                // failures (EMFILE/EAGAIN under load) on this event, and an 'error'
+                // event with NO listener is an uncaught exception. That would print a
+                // stack to stderr — and this file's own comments (:515, :634) record
+                // that Claude Code treats ANY stderr from the hook as a hook error and
+                // FAILS OPEN, letting the tool call through unenforced. Without this
+                // listener a transient resource failure becomes an enforcement bypass.
+                d.on('error', (err: Error) => {
+                  // Best-effort: the hook may exit before this runs, which is why the
+                  // 'starting' marker remains the real backstop on this path.
+                  recordStartupState('failed', 'spawn-failed', err.message);
                 });
                 d.unref();
               } finally {
@@ -437,6 +454,23 @@ export function registerCheckCommand(program: Command): void {
               // of silently swallowed — makes install-path mismatches diagnosable.
               const logPath = path.join(os.homedir(), '.node9', 'hook-debug.log');
               const msg = spawnErr instanceof Error ? spawnErr.message : String(spawnErr);
+              // The validation throws above (argv[1] not absolute, or resolving
+              // outside the package dist — a real install-path mismatch) happen
+              // BEFORE the 'starting' marker is written, so without this an aborted
+              // start leaves no state at all and doctor says nothing. Record it as
+              // the conclusive failure it is; 'starting' would be a lie, since no
+              // spawn was ever attempted.
+              recordStartupState('failed', 'spawn-aborted', msg);
+              // NOTE: deliberately no recordStartupState() for the SPAWN itself here.
+              // spawn() reports exec
+              // failures on the child's 'error' event, not by throwing, so this catch
+              // only sees synchronous TypeErrors — a recording here looked like a
+              // safety net while being unreachable for every failure it named. An
+              // 'error' listener is no better on this path: the target is
+              // process.execPath (so ENOENT is near-impossible) and the hook exits
+              // abruptly at several points, so the listener may never run. The
+              // 'starting' marker is the backstop — nothing resolves it, and doctor
+              // reports the start did not come up once the grace window passes.
               try {
                 fs.appendFileSync(
                   logPath,

--- a/src/cli/commands/daemon-cmd.ts
+++ b/src/cli/commands/daemon-cmd.ts
@@ -3,6 +3,8 @@
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import { spawn } from 'child_process';
+import fs from 'fs';
+import { openStartupLogFd, recordStartupState } from '../../daemon/startup-log';
 import {
   startDaemon,
   stopDaemon,
@@ -62,14 +64,31 @@ export function registerDaemonCommand(program: Command): void {
         if (cmd === 'restart') {
           stopDaemon();
           await new Promise((r) => setTimeout(r, 500));
+          // Same spawner contract as --background: capture the child's stderr, mark
+          // the attempt, and ALWAYS attach an 'error' listener (an 'error' event with
+          // no listener is an uncaught exception).
+          const restartFd = openStartupLogFd();
+          recordStartupState('starting');
           const child = spawn(process.execPath, [process.argv[1], 'daemon'], {
             detached: true,
-            stdio: 'ignore',
+            stdio: ['ignore', 'ignore', restartFd ?? 'ignore'],
             env: { ...process.env, NODE9_AUTO_STARTED: '1' },
           });
+          child.on('error', (err: Error) =>
+            recordStartupState('failed', 'spawn-failed', err.message)
+          );
           child.unref();
+          if (restartFd !== undefined) {
+            try {
+              fs.closeSync(restartFd);
+            } catch {
+              /* non-fatal */
+            }
+          }
           if (child.pid) {
-            console.log(chalk.green(`✓ Daemon restarted (PID ${child.pid})`));
+            // Same caveat as --background: the child may not survive startup.
+            console.log(chalk.green(`✓ Daemon relaunching (PID ${child.pid})`));
+            console.log(chalk.gray('   Confirm with: node9 status'));
           } else {
             console.error(chalk.red('✗ Failed to restart daemon — spawn returned no PID'));
             process.exit(1);
@@ -99,12 +118,43 @@ export function registerDaemonCommand(program: Command): void {
         }
 
         if (options.background) {
-          const child = spawn(process.execPath, [process.argv[1], 'daemon'], {
-            detached: true,
-            stdio: 'ignore',
-          });
-          child.unref();
-          console.log(chalk.green(`\n🛡️  Node9 daemon started in background  (PID ${child.pid})`));
+          // This is the command `doctor` tells users to run, so it must follow the
+          // same contract as the other two spawners — otherwise the fix we recommend
+          // fails silently and doctor keeps showing the PREVIOUS cause, i.e. the tool
+          // appears to lie about a repair it just suggested.
+          const startupFd = openStartupLogFd();
+          try {
+            recordStartupState('starting');
+            const child = spawn(process.execPath, [process.argv[1], 'daemon'], {
+              detached: true,
+              // Capture the child's stderr: a module-load crash prints its stack there
+              // and dies before it can record anything itself.
+              stdio: ['ignore', 'ignore', startupFd ?? 'ignore'],
+            });
+            // An 'error' event with NO listener is an uncaught exception. It may not
+            // fire before the exit below — that is fine, the 'starting' marker is the
+            // backstop and doctor reports it — but it must never crash this command.
+            child.on('error', (err: Error) =>
+              recordStartupState('failed', 'spawn-failed', err.message)
+            );
+            child.unref();
+            // "started" would assert something we cannot know here: the child may
+            // still exit during startup (import crash, or a port held by a foreign
+            // process). Say what actually happened — it was launched — and point at
+            // the command that reports the truth.
+            console.log(
+              chalk.green(`\n🛡️  Node9 daemon launching in background  (PID ${child.pid})`)
+            );
+            console.log(chalk.gray('   Confirm with: node9 status'));
+          } finally {
+            if (startupFd !== undefined) {
+              try {
+                fs.closeSync(startupFd);
+              } catch {
+                /* non-fatal */
+              }
+            }
+          }
           process.exit(0);
         }
 

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -16,6 +16,7 @@ import {
   autostartAdvice,
 } from '../../daemon/service';
 import { agoLabel } from '../../lib/relative-time';
+import { readStartupCause } from '../../daemon/startup-log';
 
 export function registerDoctorCommand(program: Command, version: string): void {
   program
@@ -152,6 +153,36 @@ export function registerDoctorCommand(program: Command, version: string): void {
           'Daemon not running — terminal & native approvals unavailable',
           'Run: node9 daemon --background'
         );
+        // …and WHY, if the last start attempt left a trace. Without this the crash
+        // capture in daemon-startup.log has no reader: the diagnostic exists but
+        // stays undiscovered, which is most of the way back to a silent failure.
+        // A detail line on the warning above — deliberately not a second warn()
+        // (it isn't a second finding) and never a fail() (a dead daemon still
+        // enforces cached policy, so doctor's exit code must not flip).
+        const cause = readStartupCause();
+        if (cause) {
+          // Carry the age: the window is 24h, so without it a cause from
+          // yesterday morning reads as though it just happened.
+          // `detail` is optional on a recorded failure, so only append the dash when
+          // there is something after it.
+          const suffix = cause.detail ? ` — ${cause.detail}` : '';
+          // No parentheses around the age: the label supplies its own grammar
+          // ("last start attempt 5 min ago" / "start attempts failing since 5 min
+          // ago"), and a fixed "(…)" reads wrong for the second.
+          console.log(
+            chalk.gray(
+              `       ${cause.label} ${agoLabel(cause.at.toISOString())}: ${cause.kind}${suffix}`
+            )
+          );
+        }
+        // Deliberately NOT reporting "autostart is enabled but the daemon is down"
+        // as a startup failure: after a clean `systemctl --user stop` or the 12h
+        // idle-exit the state correctly reads 'ok', so that message would accuse a
+        // failure that provably did not happen. A daemon killed at module load
+        // under systemd is genuinely indistinguishable from a deliberate stop by
+        // this file alone — its stack is in the journal
+        // (`journalctl --user -u node9-daemon`), not here. A known gap is better
+        // than a confident wrong answer.
       }
       // Autostart health — the installed-but-disabled state that silently staled
       // policy for 6 days. warn (not fail) so a still-enforcing machine's doctor

--- a/src/cli/commands/mcp-pin.ts
+++ b/src/cli/commands/mcp-pin.ts
@@ -14,6 +14,7 @@ import {
 } from '../../mcp-pin';
 import fs from 'fs';
 import { registerMcpGatewayCommand } from './mcp-gateway-cmd';
+import { inventoryMcp, inventoryServerKeys } from '../../mcp-wrap';
 
 export function registerMcpPinCommand(program: Command): void {
   const pinCmd = program
@@ -160,4 +161,83 @@ export function registerMcpPinCommand(program: Command): void {
       console.log(chalk.green(`\n🔓 Cleared ${count} MCP pin(s).`));
       console.log(chalk.gray('   Next connection to each server will re-pin.\n'));
     });
+
+  // ── node9 mcp forget ────────────────────────────────────────────────────────
+  pinCmd
+    .command('forget [serverKey]')
+    .option('--stale', 'Remove all stale (orphaned) servers at once')
+    .description('Remove a server pin that is no longer configured in any agent')
+    .action((serverKey: string | undefined, opts: { stale?: boolean }) => {
+      if (opts.stale) {
+        forgetAllStale();
+        return;
+      }
+      if (!serverKey) {
+        console.error(
+          chalk.red('\n❌ Please provide a server key, or use --stale to remove all orphans.\n')
+        );
+        process.exit(1);
+      }
+
+      let pins;
+      try {
+        pins = readMcpPins();
+      } catch {
+        console.error(chalk.red('\n❌ Pin file is corrupt.'));
+        console.error(chalk.yellow('   Run: node9 mcp pin reset\n'));
+        process.exit(1);
+      }
+      if (!pins.servers[serverKey]) {
+        console.error(chalk.red(`\n❌ No pin found for server key "${serverKey}"\n`));
+        console.error(`Run ${chalk.cyan('node9 mcp pin list')} to see pinned servers.\n`);
+        process.exit(1);
+      }
+
+      // Guard: refuse to forget a server still in an agent config.
+      const inv = inventoryMcp();
+      const liveKeys = inventoryServerKeys(inv);
+
+      if (liveKeys.has(serverKey)) {
+        const agent = 'an agent config';
+        console.error(chalk.red(`\n❌ Server "${serverKey}" is still configured in ${agent}.`));
+        console.error(
+          chalk.yellow(
+            `   Remove it from the agent config first, then run: node9 mcp forget ${serverKey}\n`
+          )
+        );
+        process.exit(1);
+      }
+
+      const label = pins.servers[serverKey].label;
+      removePin(serverKey);
+      console.log(chalk.green(`\n✓ Forgot server ${chalk.cyan(serverKey)}`));
+      console.log(chalk.gray(`   Was: ${label}`));
+      console.log(chalk.gray('   Pin removed — server will no longer appear in the dashboard.\n'));
+    });
+}
+
+function forgetAllStale(): void {
+  let pins;
+  try {
+    pins = readMcpPins();
+  } catch {
+    console.error(chalk.red('\n❌ Pin file is corrupt.'));
+    console.error(chalk.yellow('   Run: node9 mcp pin reset\n'));
+    process.exit(1);
+  }
+
+  const inv = inventoryMcp();
+  const liveKeys = inventoryServerKeys(inv);
+
+  const stale = Object.entries(pins.servers).filter(([sk]) => !liveKeys.has(sk));
+  if (stale.length === 0) {
+    console.log(chalk.gray('\nNo stale servers to remove.\n'));
+    return;
+  }
+
+  for (const [sk, pin] of stale) {
+    removePin(sk);
+    console.log(chalk.green(`  ✓ ${chalk.cyan(sk)}  ${chalk.gray(pin.label)}`));
+  }
+  console.log(chalk.green(`\nRemoved ${stale.length} stale server(s).\n`));
 }

--- a/src/cli/commands/mcp-pin.ts
+++ b/src/cli/commands/mcp-pin.ts
@@ -7,6 +7,7 @@ import {
   readMcpPins,
   readMcpPinsSafe,
   removePin,
+  writeMcpPins,
   clearAllPins,
   findPinsFilePath,
   promotePin,
@@ -216,7 +217,8 @@ export function registerMcpPinCommand(program: Command): void {
     });
 }
 
-function forgetAllStale(): void {
+// Exported for unit testing (A1 empty-inventory guard + B1 single write).
+export function forgetAllStale(): void {
   let pins;
   try {
     pins = readMcpPins();
@@ -229,15 +231,35 @@ function forgetAllStale(): void {
   const inv = inventoryMcp();
   const liveKeys = inventoryServerKeys(inv);
 
+  // A1: refuse to mass-remove when NO live server is detected. An empty
+  // inventory can't distinguish "no servers configured" from "every agent
+  // config was missing/unreadable", and a wrongly-forgotten pin silently
+  // re-pins to whatever tools the server presents next — resetting the rug-pull
+  // baseline. Fail closed: keep the pins, tell the user, remove one at a time.
+  if (liveKeys.size === 0) {
+    console.error(chalk.red('\n❌ No live MCP servers detected — refusing to remove every pin.'));
+    console.error(
+      chalk.yellow(
+        '   This usually means an agent config is missing or unreadable, not that\n' +
+          '   every server is gone. Check your agent configs, or remove one at a\n' +
+          '   time: node9 mcp forget <key>\n'
+      )
+    );
+    process.exit(1);
+  }
+
   const stale = Object.entries(pins.servers).filter(([sk]) => !liveKeys.has(sk));
   if (stale.length === 0) {
     console.log(chalk.gray('\nNo stale servers to remove.\n'));
     return;
   }
 
+  // B1: one read-modify-write, not N removePin() calls (each re-reads the file
+  // and re-writes it — N windows for a concurrent gateway/daemon write to lose).
   for (const [sk, pin] of stale) {
-    removePin(sk);
+    delete pins.servers[sk];
     console.log(chalk.green(`  ✓ ${chalk.cyan(sk)}  ${chalk.gray(pin.label)}`));
   }
+  writeMcpPins(pins);
   console.log(chalk.green(`\nRemoved ${stale.length} stale server(s).\n`));
 }

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -9,6 +9,7 @@ import type { Command } from 'commander';
 import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
+import { classifyDecision } from '../../audit/decision';
 import os from 'os';
 import { agentDisplayName, agentColorName, agentBadgeText } from '../../scan-summary';
 import { pricingFor } from '../../pricing/litellm';
@@ -264,7 +265,9 @@ export function loadAuditEntries(auditPath?: string): RawAuditEntry[] {
       const e = JSON.parse(line) as RawAuditEntry;
       if (!e.ts || !e.tool || !e.decision) continue;
       // Skip allow/allowed — we only want intercepted calls
-      if (e.decision === 'allow' || e.decision === 'allowed') continue;
+      // Shared mapper — a fourth hand-rolled copy of this rule is how the
+      // readers drifted apart in the first place.
+      if (classifyDecision(e.decision, e.checkedBy).outcome === 'allow') continue;
       entries.push(e);
     } catch {
       // skip malformed lines

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -267,7 +267,7 @@ export function loadAuditEntries(auditPath?: string): RawAuditEntry[] {
       // Skip allow/allowed — we only want intercepted calls
       // Shared mapper — a fourth hand-rolled copy of this rule is how the
       // readers drifted apart in the first place.
-      if (classifyDecision(e.decision, e.checkedBy).outcome === 'allow') continue;
+      if (classifyDecision(e).outcome === 'allow') continue;
       entries.push(e);
     } catch {
       // skip malformed lines

--- a/src/cli/daemon-starter.ts
+++ b/src/cli/daemon-starter.ts
@@ -11,7 +11,7 @@ import path from 'path';
 import fs from 'fs';
 import os from 'os';
 import { isDaemonRunning, isDaemonReachable } from '../auth/daemon';
-import { openStartupLogFd } from '../daemon/startup-log';
+import { openStartupLogFd, recordStartupState, readStartupState } from '../daemon/startup-log';
 
 export function isTestingMode(): boolean {
   return /^(1|true|yes)$/i.test(process.env.NODE9_TESTING ?? '');
@@ -34,9 +34,26 @@ export function logAutostartSkipThrottled(reason: string): void {
     } catch {
       /* no stamp yet → not throttled */
     }
-    fs.writeFileSync(stamp, '', 'utf-8'); // touch the throttle stamp
+    // On a fresh machine ~/.node9 may not exist yet: this runs BEFORE the writes
+    // that would otherwise create it, so without this the stamp write throws
+    // ENOENT into the catch below and the very FIRST breadcrumb is lost — on the
+    // machine most likely to have a broken daemon. Mirrors startup-log.ts.
+    const dir = path.join(os.homedir(), '.node9');
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    // Stamp FIRST, unconditionally. The throttle must be armed before anything
+    // that can fail, because this runs on the enforcement hot path — once per tool
+    // call. Every alternative is worse:
+    //   append-first        → an unwritable stamp removes throttling entirely and
+    //                         we append on EVERY tool call, forever.
+    //   stamp-then-unlink   → a persistently failing append becomes an unbounded
+    //                         write+unlink cycle on that same hot path.
+    // The cost of this ordering is bounded and small: if the append fails, up to
+    // one hour of breadcrumbs is lost. These are diagnostics — losing an hour of
+    // them on a machine whose disk is already refusing writes is a far better
+    // outcome than doing unbounded filesystem work per tool call.
+    fs.writeFileSync(stamp, '', 'utf-8');
     fs.appendFileSync(
-      path.join(os.homedir(), '.node9', 'hook-debug.log'),
+      path.join(dir, 'hook-debug.log'),
       `[${new Date().toISOString()}] daemon-autostart-skip: ${reason}\n`,
       'utf-8'
     );
@@ -58,6 +75,10 @@ export async function autoStartDaemonAndWait(): Promise<boolean> {
   // A4b: capture the child's stderr to daemon-startup.log (capped) so a startup
   // crash (e.g. an import-time ERR_REQUIRE_ESM) leaves a trace instead of vanishing.
   const startupFd = openStartupLogFd();
+  // See check.ts: mark the attempt before spawning, so a child that dies at module
+  // load (before it can run any of our code) still leaves evidence.
+  recordStartupState('starting');
+  let spawned = false;
   try {
     const child = spawn(process.execPath, [resolvedArgv1, 'daemon'], {
       detached: true,
@@ -67,7 +88,20 @@ export async function autoStartDaemonAndWait(): Promise<boolean> {
         NODE9_AUTO_STARTED: '1',
       },
     });
+    // spawn() reports an exec failure on THIS EVENT, never by throwing — a
+    // try/catch around spawn() cannot see ENOENT/EACCES/EMFILE. Without a listener
+    // the attempt would also be left marked 'starting' forever and later reported
+    // as an import-time crash that never happened. We out-live the event because of
+    // the poll below, which is why this works here and not in the check hot path.
+    child.on('error', (err: Error) => {
+      // Only blame the attempt if nothing conclusive has landed since. This fires
+      // asynchronously, so a racer's daemon may already have recorded 'ok' — and a
+      // losing racer's exec failure must not overwrite a healthy daemon's state.
+      if (readStartupState()?.outcome !== 'starting') return;
+      recordStartupState('failed', 'spawn-failed', err.message);
+    });
     child.unref();
+    spawned = true; // past here a child exists and OWNS the outcome
     for (let i = 0; i < 20; i++) {
       await new Promise((r) => setTimeout(r, 250));
       if (!isDaemonRunning()) continue;
@@ -77,8 +111,19 @@ export async function autoStartDaemonAndWait(): Promise<boolean> {
       // request. The process may be alive but still mid-listen().
       if (await isDaemonReachable()) return true;
     }
-  } catch {
-    /* spawn/poll failure → not started */
+  } catch (err) {
+    // This catch also wraps the POLL loop, so it must not blame the attempt once a
+    // child exists: by then the child has recorded (or will record) its own outcome,
+    // and a poll-time throw here would overwrite a legitimate 'ok' with 'failed'
+    // for a daemon that is actually up. Only a spawn that produced no child at all
+    // may claim the attempt failed — and note exec failures do NOT arrive here at
+    // all (they land on the 'error' listener above); this is for synchronous throws.
+    if (!spawned)
+      recordStartupState(
+        'failed',
+        'spawn-failed',
+        err instanceof Error ? err.message : String(err)
+      );
   } finally {
     // The child inherited its own fd copy at spawn(); close ours whether we
     // returned true, fell through, or threw — no leak across the poll loop.

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -111,6 +111,7 @@ export const ConfigFileSchema = z
         // nudge-only (default), and the scan cadence in minutes.
         mcpAutoWrap: z.boolean().optional(),
         mcpReconcileIntervalMinutes: z.number().positive().optional(),
+        mcpStaleAfterDays: z.number().min(0).optional(),
         cloudSyncIntervalHours: z.number().positive().optional(),
         // Seconds-granular override for the cloud policy sync cadence. Wins over
         // cloudSyncIntervalHours when set. Lets you opt into fast apply (e.g. 20)

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -22,6 +22,10 @@ import { normalizeHost } from '../auth/trusted-hosts';
 // the rest of this file reference SmartRule by bare name.
 export type { SmartCondition, SmartRule } from '@node9/policy-engine';
 import type { SmartRule } from '@node9/policy-engine';
+// The trusted shield catalog. A cloud-mandated shield resolves its body from
+// here directly, never a user ~/.node9/shields/<name>.json that shadows the
+// builtin (B1: a mandate's rules must come from the fleet, not the dev's file).
+import { BUILTIN_SHIELDS } from '@node9/policy-engine';
 
 export interface EnvironmentConfig {
   requireApproval?: boolean;
@@ -753,6 +757,12 @@ export function getConfig(cwd?: string): Config {
   // Enforced at the override loop below (`cloudManagedSet`), where a local
   // per-rule override is skipped for any shield in this set (B1).
   let cloudManagedShields: string[] = [];
+  // B1 (#1): true once the cloud has SET or LOCKED the mode. When true, the
+  // NODE9_MODE env var (applied last, below) must not override it — otherwise a
+  // single `NODE9_MODE=observe` defeats a `locked:['mode']` mandate and turns
+  // every block into a would-block. Where the cloud hasn't spoken, the env var
+  // stays a dev convenience.
+  let modeCloudControlled = false;
   {
     const cacheFile = path.join(os.homedir(), '.node9', 'rules-cache.json');
     try {
@@ -811,6 +821,11 @@ export function getConfig(cwd?: string): Config {
             mc.mode,
             locked.includes('mode')
           );
+        }
+        // The cloud has spoken about mode iff it set one or locked it — NODE9_MODE
+        // must not override either (B1 #1).
+        if (typeof mc.mode === 'string' || locked.includes('mode')) {
+          modeCloudControlled = true;
         }
         // M2b + Step 2: policy.egress. enabled force-on; mode off<review<block;
         // allow replaces local; deny unions; allowPrivate floor boolean.
@@ -984,26 +999,34 @@ export function getConfig(cwd?: string): Config {
   // enabled the same shield first.
   const cloudManagedSet = new Set(cloudManagedShields);
   for (const shieldName of activeShieldNames) {
-    const shield = getShield(shieldName);
+    const isCloudMandated = cloudManagedSet.has(shieldName);
+    // B1 (#2): a cloud-mandated shield resolves its BODY from the trusted
+    // builtin catalog, never getShield() — which returns a user
+    // ~/.node9/shields/<name>.json shadowing the same name (its rules could be
+    // empty or all-allow). A local/self-enabled shield keeps full user-shadow
+    // power (power-user customisation); only a mandate is locked to the fleet.
+    const shield = isCloudMandated
+      ? (BUILTIN_SHIELDS[shieldName] ?? getShield(shieldName))
+      : getShield(shieldName);
     if (!shield) continue;
     // Deduplicate smartRules by name — prevents duplicates if the user also
     // has the same rule name in their config.
     const existingRuleNames = new Set(mergedPolicy.smartRules.map((r) => r.name));
-    const isCloudMandated = cloudManagedSet.has(shieldName);
     const ruleOverrides = isCloudMandated ? {} : (shieldOverrides[shieldName] ?? {});
     for (const rule of shield.smartRules) {
       const collides = rule.name ? existingRuleNames.has(rule.name) : false;
-      // B1 (part 2): a cloud-mandated shield rule must WIN a name collision.
-      // User config (global config.json AND a repo-checked-in project
-      // node9.config.json) is merged into mergedPolicy.smartRules *before* this
-      // loop, so a rule named `shield:redis:block-flushall` verdict `allow`
-      // would otherwise SUPPRESS the shield's block version as a "duplicate" —
-      // the config.json twin of the `node9 shield set` override hole, and worse
-      // because a cloned repo can carry it. Drop the pre-empting rule and
-      // install the cloud verdict.
-      if (isCloudMandated && collides) {
-        mergedPolicy.smartRules = mergedPolicy.smartRules.filter((r) => r.name !== rule.name);
-        mergedPolicy.smartRules.push(rule);
+      if (isCloudMandated) {
+        // A mandate is un-weakenable. Its rule WINS a name collision (part 2 —
+        // a config.json twin of `node9 shield set`, and worse because a cloned
+        // repo can carry it) AND is PINNED (#1): the engine's resolvePinned
+        // makes the strictest pinned verdict win regardless of array order, so
+        // a DIFFERENTLY-named local `allow` rule sitting earlier in smartRules
+        // can no longer out-precede the shield's `block` (the first-match hole
+        // the earlier B1 review wrongly believed closed).
+        if (collides) {
+          mergedPolicy.smartRules = mergedPolicy.smartRules.filter((r) => r.name !== rule.name);
+        }
+        mergedPolicy.smartRules.push({ ...rule, pinned: true });
       } else if (!collides) {
         const overrideVerdict = rule.name ? ruleOverrides[rule.name] : undefined;
         mergedPolicy.smartRules.push(
@@ -1024,7 +1047,29 @@ export function getConfig(cwd?: string): Config {
     if (!existingAdvisoryNames.has(rule.name)) mergedPolicy.smartRules.push(rule);
   }
 
-  if (process.env.NODE9_MODE) mergedSettings.mode = process.env.NODE9_MODE as string;
+  // NODE9_MODE is a local dev convenience — honoured only when the cloud hasn't
+  // set/locked the mode (B1 #1), and only for a valid value (a garbage value was
+  // previously stored verbatim and then enforced).
+  const envMode = process.env.NODE9_MODE;
+  if (
+    envMode &&
+    !modeCloudControlled &&
+    (['observe', 'audit', 'standard', 'strict'] as const).includes(envMode as never)
+  ) {
+    mergedSettings.mode = envMode;
+  }
+
+  // B1 (#3/#5/#6): local ignoredTools / sandboxPaths must not fast-path a tool
+  // to allow BEFORE a mandated shield runs (the engine's ignored-tool and
+  // sandbox short-circuits return allow ahead of the smart-rule tier). When the
+  // fleet mandates shields, discard local (global + repo-carried) additions and
+  // keep only the safe read-only defaults — a coarse but absolute guard, matching
+  // the mandate-is-not-opt-out-able principle. A dev loses custom local ignores
+  // ONLY while their org mandates shields.
+  if (cloudManagedShields.length > 0) {
+    mergedPolicy.ignoredTools = [...DEFAULT_CONFIG.policy.ignoredTools];
+    mergedPolicy.sandboxPaths = [...DEFAULT_CONFIG.policy.sandboxPaths];
+  }
 
   mergedPolicy.sandboxPaths = [...new Set(mergedPolicy.sandboxPaths)];
   mergedPolicy.dangerousWords = [...new Set(mergedPolicy.dangerousWords)];

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -54,6 +54,8 @@ export interface Config {
     /** Reconcile scan cadence in minutes (default 60, clamp 5-1440). A managed
      *  value from the dashboard overrides this. */
     mcpReconcileIntervalMinutes?: number;
+    /** Days before an orphaned MCP pin is auto-removed (default 7, 0 = never). */
+    mcpStaleAfterDays?: number;
     /** Outbox shipper (audit.log → SaaS batch ingest). */
     shipper: { enabled: boolean; intervalSeconds: number };
     hud?: {
@@ -634,6 +636,7 @@ export function getConfig(cwd?: string): Config {
     if (s.mcpAutoWrap !== undefined) mergedSettings.mcpAutoWrap = s.mcpAutoWrap === true;
     if (s.mcpReconcileIntervalMinutes !== undefined)
       mergedSettings.mcpReconcileIntervalMinutes = s.mcpReconcileIntervalMinutes;
+    if (s.mcpStaleAfterDays !== undefined) mergedSettings.mcpStaleAfterDays = s.mcpStaleAfterDays;
     if (s.hud !== undefined) mergedSettings.hud = { ...mergedSettings.hud, ...s.hud };
 
     if (p.sandboxPaths) mergedPolicy.sandboxPaths.push(...p.sandboxPaths);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -559,6 +559,61 @@ export function getActiveEnvironment(config: Config): EnvironmentConfig | null {
   return config.environments[env] ?? null;
 }
 
+let cacheReadFailureLogged = false;
+
+/**
+ * Read + parse rules-cache.json defensively.
+ *
+ * The daemon rewrites this file on every policy change (sync.ts writeCache).
+ * A hook's getConfig() reading it concurrently used to `JSON.parse` a single
+ * `readFileSync` inside a fail-OPEN catch: a torn/partial read threw and the
+ * catch silently dropped ALL cloud enforcement (shields, managed mode) for
+ * that call — a non-deterministic fail-open. `writeCache` is now atomic
+ * (temp+rename), so a reader never sees a partial file; this reader adds
+ * defense in depth: retry a torn read (belt-and-suspenders for any other
+ * writer), distinguish an ABSENT cache (no cloud policy — normal) from a
+ * PRESENT-but-corrupt one, and never drop enforcement without a trace.
+ *
+ * Returns the parsed object, or `{}` when there is nothing usable — callers
+ * guard every field (`Array.isArray(raw.rules)` etc.), so `{}` is a safe
+ * "no cloud layer" without special-casing.
+ */
+export function readRulesCacheResilient(cacheFile: string): Record<string, unknown> {
+  let existed = false;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    let content: string;
+    try {
+      content = fs.readFileSync(cacheFile, 'utf-8');
+      existed = true;
+    } catch (err) {
+      // ENOENT = no cloud policy configured — normal, not an error.
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return {};
+      continue; // transient FS error — retry
+    }
+    try {
+      return JSON.parse(content) as Record<string, unknown>;
+    } catch {
+      /* partial/torn read — retry; atomic writeCache means the next read is whole */
+    }
+  }
+  // Present but unparseable after retries: cloud enforcement is EXPECTED (the
+  // file exists) yet unreadable. Never let that vanish silently — log once.
+  // We still fall back rather than hard-block every call; fail-closed-on-corrupt
+  // is a separate policy decision (see daemon-enforcement-nondeterminism-design).
+  if (existed && !cacheReadFailureLogged) {
+    cacheReadFailureLogged = true;
+    try {
+      fs.appendFileSync(
+        path.join(os.homedir(), '.node9', 'hook-debug.log'),
+        `[${new Date().toISOString()}] RULES_CACHE_UNREADABLE ${cacheFile} — cloud enforcement skipped this read\n`
+      );
+    } catch {
+      /* logging is best-effort — never break config loading */
+    }
+  }
+  return {};
+}
+
 export function getConfig(cwd?: string): Config {
   // When an explicit cwd is provided (hook commands passing payload.cwd), skip
   // the cache entirely — each project directory may have its own node9.config.json,
@@ -776,7 +831,9 @@ export function getConfig(cwd?: string): Config {
   {
     const cacheFile = path.join(os.homedir(), '.node9', 'rules-cache.json');
     try {
-      const raw = JSON.parse(fs.readFileSync(cacheFile, 'utf-8')) as Record<string, unknown>;
+      // Resilient read: retries a torn read and, on a present-but-corrupt
+      // cache, logs instead of silently dropping cloud enforcement (fail-open).
+      const raw = readRulesCacheResilient(cacheFile);
       if (Array.isArray(raw.rules) && raw.rules.length > 0) {
         applyLayer({ policy: { smartRules: raw.rules } });
       }
@@ -986,7 +1043,8 @@ export function getConfig(cwd?: string): Config {
         modeCloudStaged = true; // cloud chose observe — a shield mandate honors it
       }
     } catch {
-      /* cache absent or corrupted — silent fallback to local config */
+      /* malformed field shape within an otherwise-valid cache — skip cloud
+         layer. (Absent/corrupt FILE is handled by readRulesCacheResilient.) */
     }
   }
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -984,13 +984,24 @@ export function getConfig(cwd?: string): Config {
     const shield = getShield(shieldName);
     if (!shield) continue;
     // Deduplicate smartRules by name — prevents duplicates if the user also
-    // has the same rule name in their config (shouldn't happen, but be safe).
+    // has the same rule name in their config.
     const existingRuleNames = new Set(mergedPolicy.smartRules.map((r) => r.name));
-    const ruleOverrides = cloudManagedSet.has(shieldName)
-      ? {}
-      : (shieldOverrides[shieldName] ?? {});
+    const isCloudMandated = cloudManagedSet.has(shieldName);
+    const ruleOverrides = isCloudMandated ? {} : (shieldOverrides[shieldName] ?? {});
     for (const rule of shield.smartRules) {
-      if (!existingRuleNames.has(rule.name)) {
+      const collides = rule.name ? existingRuleNames.has(rule.name) : false;
+      // B1 (part 2): a cloud-mandated shield rule must WIN a name collision.
+      // User config (global config.json AND a repo-checked-in project
+      // node9.config.json) is merged into mergedPolicy.smartRules *before* this
+      // loop, so a rule named `shield:redis:block-flushall` verdict `allow`
+      // would otherwise SUPPRESS the shield's block version as a "duplicate" —
+      // the config.json twin of the `node9 shield set` override hole, and worse
+      // because a cloned repo can carry it. Drop the pre-empting rule and
+      // install the cloud verdict.
+      if (isCloudMandated && collides) {
+        mergedPolicy.smartRules = mergedPolicy.smartRules.filter((r) => r.name !== rule.name);
+        mergedPolicy.smartRules.push(rule);
+      } else if (!collides) {
         const overrideVerdict = rule.name ? ruleOverrides[rule.name] : undefined;
         mergedPolicy.smartRules.push(
           overrideVerdict !== undefined ? { ...rule, verdict: overrideVerdict } : rule

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1163,14 +1163,40 @@ export function getConfig(cwd?: string): Config {
     mergedSettings.mode = 'standard';
   }
 
-  // B1 (#3/#5/#6): local ignoredTools / sandboxPaths must not fast-path a tool
-  // to allow BEFORE a mandated shield runs (the engine's ignored-tool and
-  // sandbox short-circuits return allow ahead of the smart-rule tier). When the
-  // fleet mandates shields, discard local (global + repo-carried) additions and
-  // keep only the safe read-only defaults — a coarse but absolute guard, matching
-  // the mandate-is-not-opt-out-able principle. A dev loses custom local ignores
-  // ONLY while their org mandates shields.
-  if (cloudManagedShields.length > 0) {
+  // Task #16: a CLOUD-managed enforcement floor must not be silently weakened by
+  // local/repo config — the same config-home law already applied to mode/egress/
+  // dlp: the org's decision wins, local config may only tighten. The floor is
+  // active whenever the fleet has imposed one: a mandated shield OR a
+  // cloud-controlled strict mode. (A LOCALLY-chosen strict is NOT a floor — a dev
+  // keeps their own escapes; this is gated on modeCloudControlled so we never
+  // over-tighten a self-chosen posture.)
+  const managedFloorActive =
+    cloudManagedShields.length > 0 || (modeCloudControlled && mergedSettings.mode === 'strict');
+
+  // Vector A (task #16): under a managed strict, neutralise the engine's strict
+  // ESCAPE (`activeEnvironment.requireApproval === false` at policy/index.ts,
+  // which turns strict's catch-all review into a blanket allow). A cloned repo's
+  // node9.config.json must not be able to define an environment that disables a
+  // cloud-mandated strict. Strip the escape from every merged environment; a
+  // locally-chosen strict is untouched (modeCloudControlled is false there).
+  if (modeCloudControlled && mergedSettings.mode === 'strict') {
+    for (const name of Object.keys(mergedEnvironments)) {
+      if (mergedEnvironments[name]?.requireApproval === false) {
+        const cleaned = { ...mergedEnvironments[name] };
+        delete cleaned.requireApproval;
+        mergedEnvironments[name] = cleaned;
+      }
+    }
+  }
+
+  // Vector B (task #16) + B1 (#3/#5/#6): local ignoredTools / sandboxPaths must
+  // not fast-path a tool to allow BEFORE the managed floor runs (the engine's
+  // ignored-tool and sandbox short-circuits return allow ahead of the smart-rule
+  // AND strict-fallback tiers). Under any managed floor — mandated shields OR a
+  // cloud strict — discard local (global + repo-carried) additions and keep only
+  // the safe read-only defaults. A dev loses custom local ignores ONLY while
+  // their org imposes a floor.
+  if (managedFloorActive) {
     mergedPolicy.ignoredTools = [...DEFAULT_CONFIG.policy.ignoredTools];
     mergedPolicy.sandboxPaths = [...DEFAULT_CONFIG.policy.sandboxPaths];
   }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -747,6 +747,8 @@ export function getConfig(cwd?: string): Config {
   // Shields the dashboard enforces fleet-wide (Managed Config M1). Captured from
   // the rules-cache here and unioned with local shields in the shield layer
   // below — additive/on: a developer can add more locally, never weaken these.
+  // Enforced at the override loop below (`cloudManagedSet`), where a local
+  // per-rule override is skipped for any shield in this set (B1).
   let cloudManagedShields: string[] = [];
   {
     const cacheFile = path.join(os.homedir(), '.node9', 'rules-cache.json');
@@ -968,13 +970,25 @@ export function getConfig(cwd?: string): Config {
   // Local shields ∪ cloud-managed shields (M1). Deduped so a shield enabled both
   // locally and from the dashboard is applied once.
   const activeShieldNames = [...new Set([...readActiveShields(), ...cloudManagedShields])];
+  // B1: a cloud-mandated shield is enforced EXACTLY as the cloud defines it —
+  // local per-rule overrides (`node9 shield set`) do not apply to it, weakening
+  // OR tightening. This is what the comment above the union has always promised
+  // ("a developer can add more locally, never weaken these") and, until this
+  // set existed, did not enforce: the override loop below applied to every
+  // shield in the union, so `node9 shield set redis <rule> allow` weakened a
+  // fleet-mandated redis shield. A shield that is both locally-enabled AND
+  // cloud-mandated resolves to cloud — a mandate is not opt-out-able by having
+  // enabled the same shield first.
+  const cloudManagedSet = new Set(cloudManagedShields);
   for (const shieldName of activeShieldNames) {
     const shield = getShield(shieldName);
     if (!shield) continue;
     // Deduplicate smartRules by name — prevents duplicates if the user also
     // has the same rule name in their config (shouldn't happen, but be safe).
     const existingRuleNames = new Set(mergedPolicy.smartRules.map((r) => r.name));
-    const ruleOverrides = shieldOverrides[shieldName] ?? {};
+    const ruleOverrides = cloudManagedSet.has(shieldName)
+      ? {}
+      : (shieldOverrides[shieldName] ?? {});
     for (const rule of shield.smartRules) {
       if (!existingRuleNames.has(rule.name)) {
         const overrideVerdict = rule.name ? ruleOverrides[rule.name] : undefined;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -596,22 +596,40 @@ export function readRulesCacheResilient(cacheFile: string): Record<string, unkno
       /* partial/torn read — retry; atomic writeCache means the next read is whole */
     }
   }
-  // Present but unparseable after retries: cloud enforcement is EXPECTED (the
-  // file exists) yet unreadable. Never let that vanish silently — log once.
-  // We still fall back rather than hard-block every call; fail-closed-on-corrupt
-  // is a separate policy decision (see daemon-enforcement-nondeterminism-design).
-  if (existed && !cacheReadFailureLogged) {
-    cacheReadFailureLogged = true;
-    try {
-      fs.appendFileSync(
-        path.join(os.homedir(), '.node9', 'hook-debug.log'),
-        `[${new Date().toISOString()}] RULES_CACHE_UNREADABLE ${cacheFile} — cloud enforcement skipped this read\n`
-      );
-    } catch {
-      /* logging is best-effort — never break config loading */
+  // Present but unparseable after retries. Before dropping ALL cloud
+  // enforcement (a fail-open), fall back to the last-known-good copy the daemon
+  // keeps beside the primary — so an externally-corrupted primary still
+  // enforces the last policy we successfully read, not nothing.
+  if (existed) {
+    const backup = path.join(path.dirname(cacheFile), 'rules-cache.last-good.json');
+    if (backup !== cacheFile) {
+      try {
+        const raw = JSON.parse(fs.readFileSync(backup, 'utf-8')) as Record<string, unknown>;
+        logCacheReadIssue(cacheFile, 'RULES_CACHE_CORRUPT_USED_BACKUP');
+        return raw;
+      } catch {
+        /* no usable backup either — fall through to the empty (logged) result */
+      }
     }
+    // Cloud enforcement is EXPECTED (the file exists) yet neither the primary
+    // nor the backup is readable. Never let that vanish silently — log it.
+    logCacheReadIssue(cacheFile, 'RULES_CACHE_UNREADABLE');
   }
   return {};
+}
+
+/** Log a rules-cache read problem once per process (avoids hot-path spam). */
+function logCacheReadIssue(cacheFile: string, kind: string): void {
+  if (cacheReadFailureLogged) return;
+  cacheReadFailureLogged = true;
+  try {
+    fs.appendFileSync(
+      path.join(os.homedir(), '.node9', 'hook-debug.log'),
+      `[${new Date().toISOString()}] ${kind} ${cacheFile}\n`
+    );
+  } catch {
+    /* logging is best-effort — never break config loading */
+  }
 }
 
 export function getConfig(cwd?: string): Config {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -662,12 +662,18 @@ export function getConfig(cwd?: string): Config {
       // override the default (user rule wins), rather than stacking on top of it.
       // This prevents rules 1-N in DEFAULT_CONFIG from appearing twice when a user's
       // config.json was seeded with the same rule names.
-      const userRuleNames = new Set(p.smartRules.filter((r) => r.name).map((r) => r.name));
+      // B1 (#3): local rules may never be `pinned` — pinning is a
+      // cloud-mandate-only property (a pinned local `allow` would compete with a
+      // cloud rule in the engine's resolvePinned). zod already drops the unknown
+      // key in sanitizeConfig, but strip it explicitly so this security property
+      // survives a future schema change (a `.passthrough()` or an added field).
+      const localRules = p.smartRules.map(({ pinned: _pinned, ...r }) => r);
+      const userRuleNames = new Set(localRules.filter((r) => r.name).map((r) => r.name));
       const filteredBlocks = defaultBlocks.filter((r) => !r.name || !userRuleNames.has(r.name));
       const filteredNonBlocks = defaultNonBlocks.filter(
         (r) => !r.name || !userRuleNames.has(r.name)
       );
-      mergedPolicy.smartRules = [...filteredBlocks, ...p.smartRules, ...filteredNonBlocks];
+      mergedPolicy.smartRules = [...filteredBlocks, ...localRules, ...filteredNonBlocks];
     }
     if (p.snapshot) {
       const s = p.snapshot as Partial<Config['policy']['snapshot']>;
@@ -763,6 +769,10 @@ export function getConfig(cwd?: string): Config {
   // every block into a would-block. Where the cloud hasn't spoken, the env var
   // stays a dev convenience.
   let modeCloudControlled = false;
+  // B1 (#1): true when the CLOUD chose observe (shadowMode staged rollout). A
+  // shield mandate floors LOCAL observe/audit to standard, but honors a cloud
+  // staged observe — the fleet chose that.
+  let modeCloudStaged = false;
   {
     const cacheFile = path.join(os.homedir(), '.node9', 'rules-cache.json');
     try {
@@ -973,6 +983,7 @@ export function getConfig(cwd?: string): Config {
         // proxy in observe mode locally — admin can flip it without each
         // user editing their config.
         mergedSettings.mode = 'observe';
+        modeCloudStaged = true; // cloud chose observe — a shield mandate honors it
       }
     } catch {
       /* cache absent or corrupted — silent fallback to local config */
@@ -1001,13 +1012,14 @@ export function getConfig(cwd?: string): Config {
   for (const shieldName of activeShieldNames) {
     const isCloudMandated = cloudManagedSet.has(shieldName);
     // B1 (#2): a cloud-mandated shield resolves its BODY from the trusted
-    // builtin catalog, never getShield() — which returns a user
+    // builtin catalog ONLY — never getShield(), which returns a user
     // ~/.node9/shields/<name>.json shadowing the same name (its rules could be
-    // empty or all-allow). A local/self-enabled shield keeps full user-shadow
-    // power (power-user customisation); only a mandate is locked to the fleet.
-    const shield = isCloudMandated
-      ? (BUILTIN_SHIELDS[shieldName] ?? getShield(shieldName))
-      : getShield(shieldName);
+    // empty or all-allow). A mandated name absent from the catalog fails CLOSED
+    // (dropped) rather than falling back to a shadowable local body — no trusted
+    // body means don't pretend to enforce. A local/self-enabled shield keeps
+    // full user-shadow power (power-user customisation); only a mandate is
+    // locked to the fleet.
+    const shield = isCloudMandated ? BUILTIN_SHIELDS[shieldName] : getShield(shieldName);
     if (!shield) continue;
     // Deduplicate smartRules by name — prevents duplicates if the user also
     // has the same rule name in their config.
@@ -1057,6 +1069,22 @@ export function getConfig(cwd?: string): Config {
     (['observe', 'audit', 'standard', 'strict'] as const).includes(envMode as never)
   ) {
     mergedSettings.mode = envMode;
+  }
+
+  // B1 (#1): a mandated shield must actually enforce. observe and audit modes
+  // make the orchestrator return approved:true for every call (no enforcement),
+  // so a LOCAL observe/audit (from config.json settings.mode OR NODE9_MODE)
+  // would disable every mandated shield. Under a mandate, floor it to standard.
+  // A CLOUD staged observe (shadowMode) or a cloud-controlled/locked mode is
+  // left alone — the fleet chose that. Floor to standard, not strict: enough to
+  // enforce, no over-tightening.
+  if (
+    cloudManagedShields.length > 0 &&
+    !modeCloudControlled &&
+    !modeCloudStaged &&
+    (mergedSettings.mode === 'observe' || mergedSettings.mode === 'audit')
+  ) {
+    mergedSettings.mode = 'standard';
   }
 
   // B1 (#3/#5/#6): local ignoredTools / sandboxPaths must not fast-path a tool

--- a/src/daemon/mcp-reconciler.ts
+++ b/src/daemon/mcp-reconciler.ts
@@ -209,7 +209,13 @@ export function reconcileStale(
   }
 
   const staleDays = getConfig().settings.mcpStaleAfterDays ?? DEFAULT_STALE_DAYS;
-  if (staleDays > 0) {
+  // A1: only auto-remove when we POSITIVELY saw live servers this tick. An empty
+  // liveKeys can't distinguish "no servers configured" from "every agent config
+  // was unreadable" — and a wrongly-removed pin re-pins to whatever tools the
+  // server presents next, silently resetting the rug-pull baseline. Fail closed:
+  // keep the pins (lastSeen was still stamped/backfilled above; they age out
+  // once inventory reads cleanly again).
+  if (staleDays > 0 && liveKeys.size > 0) {
     const staleMs = staleDays * 86_400_000;
     for (const sk of serverKeys) {
       const pin = pins.servers[sk];

--- a/src/daemon/mcp-reconciler.ts
+++ b/src/daemon/mcp-reconciler.ts
@@ -8,11 +8,19 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import crypto from 'crypto';
-import { inventoryMcp, toGateway, fromGateway, writeMcpEntry, type McpEntry } from '../mcp-wrap';
+import {
+  inventoryMcp,
+  inventoryServerKeys,
+  toGateway,
+  fromGateway,
+  writeMcpEntry,
+  type McpEntry,
+} from '../mcp-wrap';
 import { sendDesktopNotification } from '../ui/native';
 import { getConfig, getCredentials } from '../config';
 import { auditLocalAllow } from '../auth/cloud';
 import { appendToLog, HOOK_DEBUG_LOG } from '../audit/index.js';
+import { readMcpPins, writeMcpPins, type PinsFile } from '../mcp-pin';
 
 const BASELINE_FILE = path.join(os.homedir(), '.node9', 'mcp-baseline.json');
 const BASELINE_CAP = 500;
@@ -114,6 +122,10 @@ export function runMcpReconcile(): void {
 
   const baseline = loadBaseline();
   const creds = getCredentials(); // once per pass (fix #10)
+
+  // ── Orphan detection + stale removal (runs every tick, before early-return) ──
+  reconcileStale(inv, creds);
+
   const fresh = inv.filter((e) => e.state === 'ungoverned' && !baseline.has(idKey(e)));
   if (fresh.length === 0) return;
 
@@ -161,6 +173,90 @@ export function runMcpReconcile(): void {
     );
   }
   saveBaseline(baseline);
+}
+
+const DEFAULT_STALE_DAYS = 7;
+
+/** Stamp lastSeen on active pins, auto-remove pins stale beyond threshold. */
+export function reconcileStale(
+  inv: McpEntry[],
+  creds: { apiKey: string; apiUrl: string } | null
+): void {
+  let pins: PinsFile;
+  try {
+    pins = readMcpPins();
+  } catch {
+    return; // corrupt pin file — don't crash the daemon
+  }
+  const serverKeys = Object.keys(pins.servers);
+  if (serverKeys.length === 0) return;
+
+  const liveKeys = inventoryServerKeys(inv);
+  const now = new Date().toISOString();
+  let dirty = false;
+
+  for (const sk of serverKeys) {
+    const pin = pins.servers[sk];
+    if (liveKeys.has(sk)) {
+      if (pin.lastSeen !== now) {
+        pin.lastSeen = now;
+        dirty = true;
+      }
+    } else if (!pin.lastSeen) {
+      pin.lastSeen = pin.pinnedAt;
+      dirty = true;
+    }
+  }
+
+  const staleDays = getConfig().settings.mcpStaleAfterDays ?? DEFAULT_STALE_DAYS;
+  if (staleDays > 0) {
+    const staleMs = staleDays * 86_400_000;
+    for (const sk of serverKeys) {
+      const pin = pins.servers[sk];
+      if (liveKeys.has(sk)) continue;
+      const age = Date.now() - Date.parse(pin.lastSeen ?? pin.pinnedAt);
+      if (age >= staleMs) {
+        appendToLog(HOOK_DEBUG_LOG, {
+          event: 'mcp-pin-auto-removed',
+          serverKey: sk,
+          label: pin.label,
+          lastSeen: pin.lastSeen,
+          pinnedAt: pin.pinnedAt,
+        });
+        if (creds) {
+          try {
+            void auditLocalAllow(
+              `mcp-server:${sk}`,
+              {
+                serverKey: sk,
+                label: pin.label,
+                lastSeen: pin.lastSeen,
+                reason: 'stale',
+                staleDays,
+              },
+              'mcp-server-removed',
+              creds,
+              { mcpServer: pin.label },
+              undefined,
+              false
+            );
+          } catch {
+            /* cloud reporting must never affect the reconcile */
+          }
+        }
+        delete pins.servers[sk];
+        dirty = true;
+      }
+    }
+  }
+
+  if (dirty) {
+    try {
+      writeMcpPins(pins);
+    } catch {
+      /* never crash daemon on a pin write */
+    }
+  }
 }
 
 /** Start the reconcile loop: once at daemon start, then on the configured

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -74,7 +74,7 @@ import { startAuditShipper } from './audit-shipper.js';
 import { startDlpScanner } from './dlp-scanner.js';
 import { startMcpReconciler } from './mcp-reconciler.js';
 import { startHookHeal } from './hook-heal.js';
-import { logDaemonStartup } from './startup-log.js';
+import { logDaemonStartup, recordStartupState } from './startup-log.js';
 import { readMcpToolsConfig, updateServerDiscovery, approveServer } from './mcp-tools.js';
 
 export function startDaemon(): void {
@@ -99,6 +99,7 @@ export function startDaemon(): void {
     const stack = err instanceof Error ? (err.stack ?? err.message) : String(err);
     console.error('\n🛑 Node9 daemon startup failed:\n' + stack);
     logDaemonStartup('startup-throw', err instanceof Error ? err.message : String(err));
+    recordStartupState('failed', 'startup-throw', err instanceof Error ? err.message : String(err));
     process.exit(1);
   }
   // Single per-process token. Stored in ~/.node9/daemon.pid (mode 0600)
@@ -1200,6 +1201,31 @@ export function startDaemon(): void {
   setDaemonServer(server);
 
   // ── Port Conflict Resolution ─────────────────────────────────────────────
+  //
+  // The retry below MUST be bounded. Unbounded, a foreign process on the port (a
+  // dev server, a rebound socket) puts this daemon in a permanent ~1 Hz loop:
+  //   EADDRINUSE → no pid file → probe /settings → not a daemon → listen() → …
+  // never serving, never exiting, and never recording anything beyond 'starting'.
+  let bindAttempts = 0;
+  const MAX_BIND_ATTEMPTS = 3;
+  function retryListen(): void {
+    if (++bindAttempts >= MAX_BIND_ATTEMPTS) {
+      logDaemonStartup(
+        'port-unavailable',
+        `:${DAEMON_PORT} is held by something that is not a node9 daemon`
+      );
+      recordStartupState(
+        'failed',
+        'port-unavailable',
+        `:${DAEMON_PORT} is held by another process that is not a node9 daemon — free the port, then: node9 daemon --background`
+      );
+      // exit 0, NOT 1: under Restart=on-failure a non-zero exit turns a permanently
+      // occupied port into a restart storm. This is a stable, explained condition.
+      return process.exit(0);
+    }
+    server.listen(DAEMON_PORT, DAEMON_HOST);
+  }
+
   server.on('error', (e: NodeJS.ErrnoException) => {
     if (e.code === 'EADDRINUSE') {
       try {
@@ -1207,13 +1233,21 @@ export function startDaemon(): void {
           const { pid } = JSON.parse(fs.readFileSync(DAEMON_PID_FILE, 'utf-8'));
           process.kill(pid, 0); // Throws if process is dead
           logDaemonStartup('port-in-use', `another daemon (pid ${pid}) owns :${DAEMON_PORT}`);
+          // A healthy daemon owns the port and its pid file names it — nothing wrong.
+          recordStartupState('ok-elsewhere');
           return process.exit(0);
         }
       } catch {
+        // The pid file names a dead process (or is corrupt): drop it and retry.
+        // BOUNDED, via retryListen: the unlink can FAIL (read-only dir, permissions)
+        // and is swallowed here, in which case the next EADDRINUSE lands back on
+        // this same branch — an infinite loop. An earlier version of this fix left
+        // this site unbounded, reasoning that removing the pid file makes it
+        // converge; that assumed an operation that can fail.
         try {
           fs.unlinkSync(DAEMON_PID_FILE);
         } catch {}
-        server.listen(DAEMON_PORT, DAEMON_HOST);
+        retryListen();
         return;
       }
 
@@ -1226,6 +1260,7 @@ export function startDaemon(): void {
             // Try to recover the orphan's PID and re-create the PID file so
             // future stop/status calls can find it. Try `ss` first (Linux,
             // fast); fall back to `lsof` (macOS + portable Linux).
+            let adopted = false;
             try {
               let orphanPid: number | null = null;
               const ss = spawnSync('ss', ['-Htnp', `sport = :${DAEMON_PORT}`], {
@@ -1256,19 +1291,53 @@ export function startDaemon(): void {
                   JSON.stringify({ pid: orphanPid, port: DAEMON_PORT, internalToken, autoStarted }),
                   { mode: 0o600 }
                 );
+                adopted = true;
               }
             } catch {}
+            // The two outcomes here are NOT the same, and recording them
+            // identically is how a silent failure loop gets built:
+            if (adopted) {
+              // A healthy daemon owns the port and the pid file now names it.
+              logDaemonStartup(
+                'port-in-use-orphan',
+                `adopted the daemon already on :${DAEMON_PORT}`
+              );
+              recordStartupState('ok-elsewhere');
+            } else {
+              // Something holds the port but we could not identify it (no ss/lsof,
+              // or the pid is not ours to signal), so NO pid file was written —
+              // and every CLI keeps reporting "daemon not running" while each new
+              // start exits 0 right here. That loop is invisible unless it is
+              // recorded as the failure it is.
+              // NB: this branch is gated on /settings answering OK, so the daemon
+              // on the port is provably HEALTHY — it just could not be identified
+              // (no `ss`/`lsof`, or its pid is not ours to signal). Telling the
+              // user to kill it would be wrong; the problem is only that every
+              // pid-file-based command will keep reporting "not running".
+              logDaemonStartup(
+                'orphan-unidentified',
+                `healthy daemon on :${DAEMON_PORT} could not be identified — no pid file written`
+              );
+              recordStartupState(
+                'failed',
+                'orphan-unidentified',
+                `a healthy daemon is running on :${DAEMON_PORT} but its process could not be identified, so node9 cannot track it — install \`ss\` or \`lsof\`, or restart it with: node9 daemon --background`
+              );
+            }
             process.exit(0);
           } else {
-            server.listen(DAEMON_PORT, DAEMON_HOST);
+            // Something answered on the port but it is not a healthy daemon.
+            retryListen();
           }
         })
         .catch(() => {
-          server.listen(DAEMON_PORT, DAEMON_HOST);
+          // Nothing answered (timeout / refused) — the holder is not a daemon.
+          retryListen();
         });
       return;
     }
     logDaemonStartup('bind-failed', e.message);
+    recordStartupState('failed', 'bind-failed', e.message);
     console.error(chalk.red('\n🛑 Node9 Daemon Error:'), e.message);
     process.exit(1);
   });
@@ -1290,6 +1359,13 @@ export function startDaemon(): void {
       { mode: 0o600 }
     );
     console.error(chalk.green(`🛡️  Node9 Guard LIVE on 127.0.0.1:${DAEMON_PORT}`));
+    // Record the SUCCESS, not just the failures. daemon-startup.log is append-only
+    // and the auto-start path pipes this process's stderr into it, so without a
+    // terminating "it worked" entry an old crash stays the newest recognisable
+    // line forever — and doctor would blame a months-dead ERR_REQUIRE_ESM for a
+    // daemon that has started cleanly a hundred times since.
+    logDaemonStartup('ok', `listening on ${DAEMON_HOST}:${DAEMON_PORT}`);
+    recordStartupState('ok');
   });
 
   // ── Flight Recorder ──────────────────────────────────────────────────────

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -35,6 +35,7 @@ import {
   setAbandonTimer,
   getHadBrowserClient,
   setHadBrowserClient,
+  hasInteractiveClient,
   daemonRejectionHandlerRegistered,
   markRejectionHandlerRegistered,
   atomicWriteSync,
@@ -700,6 +701,16 @@ export function startDaemon(): void {
         res.writeHead(500, { 'Content-Type': 'application/json' });
         return res.end(JSON.stringify({ error: 'internal' }));
       }
+    }
+
+    // Is a genuine human approver reachable RIGHT NOW — i.e. is a `node9 tail`
+    // (or other input-capable client) connected to the daemon? The orchestrator
+    // uses this to decide whether a shield hard-block may be downgraded to a
+    // review: with no reachable human it must stay a hard block (fail closed),
+    // never a review the cloud racer can auto-allow in a non-interactive context.
+    if (req.method === 'GET' && pathname === '/approver') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ interactive: hasInteractiveClient() }));
     }
 
     if (req.method === 'GET' && pathname === '/state/check') {

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -735,12 +735,8 @@ export function startDaemon(): void {
           // "blocked" — so DLP findings, MCP-discovery events and, worst, all
           // the observe-mode "would have blocked" rows inflated the blocked
           // count with things that were never refusals.
-          allowed: entries.filter(
-            (e) => classifyDecision(e.decision, e.checkedBy).outcome === 'allow'
-          ).length,
-          blocked: entries.filter(
-            (e) => classifyDecision(e.decision, e.checkedBy).outcome === 'deny'
-          ).length,
+          allowed: entries.filter((e) => classifyDecision(e).outcome === 'allow').length,
+          blocked: entries.filter((e) => classifyDecision(e).outcome === 'deny').length,
           dlp: entries.filter((e) => e.checkedBy && e.checkedBy.includes('dlp')).length,
           loops: entries.filter((e) => e.checkedBy === 'loop-detected').length,
         };
@@ -759,14 +755,14 @@ export function startDaemon(): void {
             const key = String(hour).padStart(2, '0') + ':00';
             const d = dailyMap.get(key)!;
             d.calls++;
-            if (classifyDecision(e.decision, e.checkedBy).outcome === 'deny') d.blocked++;
+            if (classifyDecision(e).outcome === 'deny') d.blocked++;
           }
         } else {
           for (const e of entries) {
             const date = e.ts.slice(0, 10);
             const d = dailyMap.get(date) || { date, calls: 0, blocked: 0 };
             d.calls++;
-            if (classifyDecision(e.decision, e.checkedBy).outcome === 'deny') d.blocked++;
+            if (classifyDecision(e).outcome === 'deny') d.blocked++;
             dailyMap.set(date, d);
           }
         }

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -71,6 +71,7 @@ import { extractCommandPattern } from '../auth/state.js';
 import { startCostSync } from '../costSync.js';
 import { startCloudSync, startForensicBroadcast } from './sync.js';
 import { startAuditShipper } from './audit-shipper.js';
+import { classifyDecision } from '../audit/decision.js';
 import { startDlpScanner } from './dlp-scanner.js';
 import { startMcpReconciler } from './mcp-reconciler.js';
 import { startHookHeal } from './hook-heal.js';
@@ -729,8 +730,17 @@ export function startDaemon(): void {
 
         const summary = {
           total: entries.length,
-          allowed: entries.filter((e) => e.decision && e.decision.startsWith('allow')).length,
-          blocked: entries.filter((e) => e.decision && !e.decision.startsWith('allow')).length,
+          // classifyDecision is THE mapper (audit/decision.ts). The inline
+          // startsWith('allow') this replaces counted every non-allow row as
+          // "blocked" — so DLP findings, MCP-discovery events and, worst, all
+          // the observe-mode "would have blocked" rows inflated the blocked
+          // count with things that were never refusals.
+          allowed: entries.filter(
+            (e) => classifyDecision(e.decision, e.checkedBy).outcome === 'allow'
+          ).length,
+          blocked: entries.filter(
+            (e) => classifyDecision(e.decision, e.checkedBy).outcome === 'deny'
+          ).length,
           dlp: entries.filter((e) => e.checkedBy && e.checkedBy.includes('dlp')).length,
           loops: entries.filter((e) => e.checkedBy === 'loop-detected').length,
         };
@@ -749,14 +759,14 @@ export function startDaemon(): void {
             const key = String(hour).padStart(2, '0') + ':00';
             const d = dailyMap.get(key)!;
             d.calls++;
-            if (e.decision && !e.decision.startsWith('allow')) d.blocked++;
+            if (classifyDecision(e.decision, e.checkedBy).outcome === 'deny') d.blocked++;
           }
         } else {
           for (const e of entries) {
             const date = e.ts.slice(0, 10);
             const d = dailyMap.get(date) || { date, calls: 0, blocked: 0 };
             d.calls++;
-            if (e.decision && !e.decision.startsWith('allow')) d.blocked++;
+            if (classifyDecision(e.decision, e.checkedBy).outcome === 'deny') d.blocked++;
             dailyMap.set(date, d);
           }
         }

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -78,6 +78,122 @@ import { startHookHeal } from './hook-heal.js';
 import { logDaemonStartup, recordStartupState } from './startup-log.js';
 import { readMcpToolsConfig, updateServerDiscovery, approveServer } from './mcp-tools.js';
 
+export type DaemonReportPeriod = 'today' | '7d' | '30d' | 'month';
+
+export interface DaemonReportBody {
+  summary: { total: number; allowed: number; blocked: number; dlp: number; loops: number };
+  daily: Array<{ date: string; calls: number; blocked: number }>;
+  topTools: Array<{ name: string; value: number }>;
+  topBlockedTools: Array<{ name: string; value: number }>;
+  byAgent: Array<{ agent: string; total: number; blocked: number; dlp: number }>;
+}
+
+/**
+ * Aggregate GET /report from raw audit rows.
+ *
+ * Extracted from the route handler so the one invariant that matters here can
+ * be tested: EVERY blocked count in the response comes from the same mapper.
+ * When this lived inline, `summary.blocked` was converged onto
+ * `classifyDecision` while `topBlockedTools` and `byAgent.blocked` kept their
+ * own `startsWith('allow')` rule twelve lines below — so a single response
+ * disagreed with itself by 950 rows on a real log, and there was no seam to
+ * write a test against.
+ */
+export function buildDaemonReport(
+  allEntries: Array<Record<string, unknown>>,
+  period: DaemonReportPeriod,
+  now: Date
+): DaemonReportBody {
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  let start = new Date(todayStart);
+  if (period === '7d') start.setDate(start.getDate() - 6);
+  else if (period === '30d') start.setDate(start.getDate() - 29);
+  else if (period === 'month') start = new Date(now.getFullYear(), now.getMonth(), 1);
+
+  const entries = allEntries.filter((e) => {
+    if (e.source === 'post-hook' || e.source === 'response-dlp') return false;
+    return new Date(e.ts as string) >= start;
+  });
+
+  // THE rule for this endpoint. Every blocked count below calls this and
+  // nothing else — that is the whole point of the extraction.
+  const isBlocked = (e: Record<string, unknown>) => classifyDecision(e).outcome === 'deny';
+  const checkedBy = (e: Record<string, unknown>) =>
+    typeof e.checkedBy === 'string' ? e.checkedBy : undefined;
+
+  const summary = {
+    total: entries.length,
+    // The inline `startsWith('allow')` this replaces counted every non-allow
+    // row as "blocked" — so DLP findings, MCP-discovery events and, worst, all
+    // the observe-mode "would have blocked" rows inflated the blocked count
+    // with things that were never refusals.
+    allowed: entries.filter((e) => classifyDecision(e).outcome === 'allow').length,
+    blocked: entries.filter(isBlocked).length,
+    dlp: entries.filter((e) => checkedBy(e)?.includes('dlp')).length,
+    loops: entries.filter((e) => checkedBy(e) === 'loop-detected').length,
+  };
+
+  // For "today" we group by hour (00-23) so the chart has real shape.
+  // Other periods group by calendar day.
+  const dailyMap = new Map<string, { date: string; calls: number; blocked: number }>();
+  if (period === 'today') {
+    // Pre-populate 24 hour buckets so the chart always shows a full day
+    for (let h = 0; h < 24; h++) {
+      const key = String(h).padStart(2, '0') + ':00';
+      dailyMap.set(key, { date: key, calls: 0, blocked: 0 });
+    }
+    for (const e of entries) {
+      const hour = new Date(e.ts as string).getHours();
+      const key = String(hour).padStart(2, '0') + ':00';
+      const d = dailyMap.get(key)!;
+      d.calls++;
+      if (isBlocked(e)) d.blocked++;
+    }
+  } else {
+    for (const e of entries) {
+      const date = (e.ts as string).slice(0, 10);
+      const d = dailyMap.get(date) || { date, calls: 0, blocked: 0 };
+      d.calls++;
+      if (isBlocked(e)) d.blocked++;
+      dailyMap.set(date, d);
+    }
+  }
+
+  const topToolsMap = new Map<string, number>();
+  const topBlockedMap = new Map<string, number>();
+  for (const e of entries) {
+    const tool = String(e.tool ?? '');
+    topToolsMap.set(tool, (topToolsMap.get(tool) || 0) + 1);
+    if (isBlocked(e)) topBlockedMap.set(tool, (topBlockedMap.get(tool) || 0) + 1);
+  }
+  const top5 = (m: Map<string, number>) =>
+    [...m.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([name, value]) => ({ name, value }));
+
+  const agentMap = new Map<
+    string,
+    { agent: string; total: number; blocked: number; dlp: number }
+  >();
+  for (const e of entries) {
+    const key = (e.agent as string) || 'unknown';
+    const a = agentMap.get(key) ?? { agent: key, total: 0, blocked: 0, dlp: 0 };
+    a.total++;
+    if (isBlocked(e)) a.blocked++;
+    if (checkedBy(e)?.includes('dlp')) a.dlp++;
+    agentMap.set(key, a);
+  }
+
+  return {
+    summary,
+    daily: [...dailyMap.values()].sort((a, b) => a.date.localeCompare(b.date)),
+    topTools: top5(topToolsMap),
+    topBlockedTools: top5(topBlockedMap),
+    byAgent: [...agentMap.values()].sort((a, b) => b.total - a.total),
+  };
+}
+
 export function startDaemon(): void {
   // A4c: a synchronous throw in these inits used to exit the process silently
   // (stdio:'ignore' on the auto-start path). Record it so a startup death is
@@ -716,98 +832,8 @@ export function startDaemon(): void {
           }
         });
 
-        const now = new Date();
-        const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-        let start = new Date(todayStart);
-        if (period === '7d') start.setDate(start.getDate() - 6);
-        else if (period === '30d') start.setDate(start.getDate() - 29);
-        else if (period === 'month') start = new Date(now.getFullYear(), now.getMonth(), 1);
-
-        const entries = allEntries.filter((e) => {
-          if (e.source === 'post-hook' || e.source === 'response-dlp') return false;
-          return new Date(e.ts) >= start;
-        });
-
-        const summary = {
-          total: entries.length,
-          // classifyDecision is THE mapper (audit/decision.ts). The inline
-          // startsWith('allow') this replaces counted every non-allow row as
-          // "blocked" — so DLP findings, MCP-discovery events and, worst, all
-          // the observe-mode "would have blocked" rows inflated the blocked
-          // count with things that were never refusals.
-          allowed: entries.filter((e) => classifyDecision(e).outcome === 'allow').length,
-          blocked: entries.filter((e) => classifyDecision(e).outcome === 'deny').length,
-          dlp: entries.filter((e) => e.checkedBy && e.checkedBy.includes('dlp')).length,
-          loops: entries.filter((e) => e.checkedBy === 'loop-detected').length,
-        };
-
-        // For "today" we group by hour (00-23) so the chart has real shape.
-        // Other periods group by calendar day.
-        const dailyMap = new Map();
-        if (period === 'today') {
-          // Pre-populate 24 hour buckets so the chart always shows a full day
-          for (let h = 0; h < 24; h++) {
-            const key = String(h).padStart(2, '0') + ':00';
-            dailyMap.set(key, { date: key, calls: 0, blocked: 0 });
-          }
-          for (const e of entries) {
-            const hour = new Date(e.ts).getHours();
-            const key = String(hour).padStart(2, '0') + ':00';
-            const d = dailyMap.get(key)!;
-            d.calls++;
-            if (classifyDecision(e).outcome === 'deny') d.blocked++;
-          }
-        } else {
-          for (const e of entries) {
-            const date = e.ts.slice(0, 10);
-            const d = dailyMap.get(date) || { date, calls: 0, blocked: 0 };
-            d.calls++;
-            if (classifyDecision(e).outcome === 'deny') d.blocked++;
-            dailyMap.set(date, d);
-          }
-        }
-
-        const topToolsMap = new Map();
-        const topBlockedMap = new Map();
-        for (const e of entries) {
-          topToolsMap.set(e.tool, (topToolsMap.get(e.tool) || 0) + 1);
-          if (e.decision && !e.decision.startsWith('allow')) {
-            topBlockedMap.set(e.tool, (topBlockedMap.get(e.tool) || 0) + 1);
-          }
-        }
-        const topTools = [...topToolsMap.entries()]
-          .sort((a, b) => b[1] - a[1])
-          .slice(0, 5)
-          .map(([name, value]) => ({ name, value }));
-        const topBlockedTools = [...topBlockedMap.entries()]
-          .sort((a, b) => b[1] - a[1])
-          .slice(0, 5)
-          .map(([name, value]) => ({ name, value }));
-
-        const agentMap = new Map<
-          string,
-          { agent: string; total: number; blocked: number; dlp: number }
-        >();
-        for (const e of entries) {
-          const key = (e.agent as string) || 'unknown';
-          const a = agentMap.get(key) ?? { agent: key, total: 0, blocked: 0, dlp: 0 };
-          a.total++;
-          if (e.decision && !(e.decision as string).startsWith('allow')) a.blocked++;
-          if ((e.checkedBy as string | undefined)?.includes('dlp')) a.dlp++;
-          agentMap.set(key, a);
-        }
-        const byAgent = [...agentMap.values()].sort((a, b) => b.total - a.total);
-
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        return res.end(
-          JSON.stringify({
-            summary,
-            daily: [...dailyMap.values()].sort((a, b) => a.date.localeCompare(b.date)),
-            topTools,
-            topBlockedTools,
-            byAgent,
-          })
-        );
+        return res.end(JSON.stringify(buildDaemonReport(allEntries, period, new Date())));
       } catch {
         res.writeHead(500, { 'Content-Type': 'application/json' });
         return res.end(JSON.stringify({ error: 'Failed to parse report' }));

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -126,6 +126,15 @@ function isLaunchdInstalled(): boolean {
 
 // ── Linux systemd ──────────────────────────────────────────────────────────
 
+// DO NOT add `StandardError=append:%h/.node9/daemon-startup.log` to the unit below.
+// It looks like the systemd equivalent of the auto-start path's stderr capture, but
+// systemd opens that file ITSELF and does not create parent directories: with
+// ~/.node9 absent (e.g. after the documented `rm -rf ~/.node9` reset) the unit fails
+// with status=222/STDERR *before exec*, and Restart=on-failure then crash-loops it to
+// the start limit and leaves it permanently dead. That is precisely the
+// silent-stale-policy incident this diagnostic exists to prevent — caused by the
+// diagnostic. Verified on systemd 255, 2026-07-18. A module-load crash under systemd
+// goes to the journal instead: `journalctl --user -u node9-daemon`.
 function systemdUnit(binaryPath: string): string {
   // Use the Node.js runtime + script path explicitly so the unit works correctly
   // when node9 is installed via nvm, volta, or any version manager whose shims

--- a/src/daemon/startup-log.ts
+++ b/src/daemon/startup-log.ts
@@ -1,9 +1,15 @@
 // src/daemon/startup-log.ts
-// A4c (policy-sync-commit2-liveness): a tiny structured log for daemon STARTUP
-// outcomes, written to ~/.node9/daemon-startup.log. The daemon's startup deaths
-// (a sync-init throw, a fatal bind error) and benign port-in-use exits used to be
-// silent under stdio:'ignore'; this makes them diagnosable, and `doctor` tails the
-// last line when it reports the daemon down. Best-effort — never throws.
+// Daemon startup diagnostics, in two deliberately separate halves:
+//
+//   daemon-startup.log        HUMAN artifact. Whatever the child wrote to stderr,
+//                             plus one-line breadcrumbs. NOTHING parses it.
+//   daemon-startup-state.json MACHINE signal. One atomically-overwritten object
+//                             that `doctor` reads to explain a down daemon.
+//
+// They were one file once. Every review round found another way the mixed text
+// lied, because a log is written for people and a diagnostic is read by code.
+// Best-effort throughout — diagnostics must never break daemon startup or the
+// enforcement hot path.
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -14,6 +20,17 @@ export const DAEMON_STARTUP_LOG = () => path.join(os.homedir(), '.node9', 'daemo
 // re-spawned on many tool calls, each appending its startup stderr here. Cap the
 // file so that loop can't grow it without bound (old code discarded stderr entirely).
 const MAX_STARTUP_LOG_BYTES = 256 * 1024;
+
+/** Keep the human log bounded. Called from BOTH writers: the spawner opens it as
+ *  an fd, while a systemd-launched daemon never goes through the spawner at all, so
+ *  neither one alone is enough. Never throws. */
+function capStartupLog(file: string): void {
+  try {
+    if (fs.statSync(file).size > MAX_STARTUP_LOG_BYTES) fs.truncateSync(file);
+  } catch {
+    /* absent → nothing to truncate */
+  }
+}
 
 /**
  * Open daemon-startup.log (append) for a spawned daemon's stderr — creating ~/.node9
@@ -26,14 +43,181 @@ export function openStartupLogFd(): number | undefined {
     const file = DAEMON_STARTUP_LOG();
     const dir = path.dirname(file);
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-    try {
-      if (fs.statSync(file).size > MAX_STARTUP_LOG_BYTES) fs.truncateSync(file);
-    } catch {
-      /* absent → nothing to truncate */
-    }
+    capStartupLog(file);
     return fs.openSync(file, 'a');
   } catch {
     return undefined;
+  }
+}
+
+// ── Startup STATE (the machine-readable half) ────────────────────────────────
+//
+// daemon-startup.log above is a HUMAN artifact: it holds whatever the child wrote
+// to stderr, in whatever shape, from any number of concurrent starts. Nothing
+// parses it — an earlier design did, and every review round found another way the
+// text lied (a crash dump's last line is Node's version banner; `Error [CODE]:`
+// does not match `Error:`; a successful start looks like nothing at all; a
+// multi-line err.message forges an entry; an old line resurfaces whenever an
+// unrelated append refreshes the file's mtime).
+//
+// The machine signal lives here instead: ONE small JSON object, atomically
+// overwritten, carrying its own timestamp. No ordering, no shapes, no parsing.
+
+/** Where the last start attempt got to. */
+export type StartupOutcome =
+  /** a spawn was issued and has not reported back — if the daemon is also down,
+   *  the child died before it could run any of its own code (the ERR_REQUIRE_ESM
+   *  class of crash, which happens at module load and no try/catch can observe) */
+  | 'starting'
+  /** bound the port and is serving */
+  | 'ok'
+  /** found a healthy daemon already running and stood down */
+  | 'ok-elsewhere'
+  /** reached its own code and failed there */
+  | 'failed';
+
+export interface StartupState {
+  outcome: StartupOutcome;
+  kind?: string;
+  detail?: string;
+  /** ISO-8601. The state's OWN time — never the file's mtime. */
+  at: string;
+}
+
+export const DAEMON_STARTUP_STATE = () =>
+  path.join(os.homedir(), '.node9', 'daemon-startup-state.json');
+
+/** doctor's output is a scannable list, not a log viewer. */
+const MAX_DETAIL = 200;
+/** How long a 'starting' marker is treated as "still booting" rather than "died".
+ *
+ *  The polling spawner gives up after 5s, but the `check` hot path does NOT poll —
+ *  it spawns and returns — so nothing bounds how slow a healthy start may be on a
+ *  loaded machine. Exposure is limited because the only caller reads this from
+ *  doctor's daemon-DOWN branch (a start that eventually succeeded is never
+ *  described), but the window is generous anyway: over-reporting "did not start"
+ *  for a daemon that is merely slow is the same class of lie this whole feature
+ *  exists to avoid. */
+const STARTING_GRACE_MS = 90 * 1000;
+
+/**
+ * Record where this start attempt got to. Overwrites — only the latest matters.
+ * Atomic (temp + rename) so a concurrent reader never sees a half-written object.
+ * Never throws: diagnostics must not break daemon startup or the check hot path.
+ */
+export function recordStartupState(outcome: StartupOutcome, kind?: string, detail?: string): void {
+  try {
+    // Keep the FIRST attempt of a failing streak. The hook fires on every tool
+    // call, so a crash-looping daemon gets re-marked every few seconds; if each
+    // one reset the clock, the grace window below would never expire and doctor
+    // would stay silent for exactly as long as the user kept working — the busier
+    // the session, the more reliably the crash loop is hidden. A streak ends when
+    // something conclusive ('ok' / 'failed') overwrites it.
+    if (outcome === 'starting') {
+      const prev = readStartupState();
+      if (prev?.outcome === 'starting') {
+        const prevAt = new Date(prev.at).getTime();
+        // …unless the streak is itself ancient, in which case it has already aged
+        // out of the reporting window and would silence us for the opposite reason.
+        // Math.abs, not a bare subtraction: a FUTURE-dated timestamp (clock skew, a
+        // corrected system clock, a hand-edited file) makes `now - prevAt` negative,
+        // which passes a `< 24h` test forever — pinning the marker permanently and
+        // silencing every later attempt.
+        const age = Math.abs(Date.now() - prevAt);
+        if (!isNaN(prevAt) && age < 24 * 60 * 60 * 1000) return;
+      }
+    }
+    const file = DAEMON_STARTUP_STATE();
+    const dir = path.dirname(file);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const state: StartupState = { outcome, at: new Date().toISOString() };
+    if (kind) state.kind = kind;
+    // JSON escapes newlines, so a multi-line err.message can no longer forge a
+    // second entry — the whole class of bug that came from a line-oriented format.
+    if (detail) state.detail = detail.slice(0, MAX_DETAIL);
+    const tmp = `${file}.${process.pid}.tmp`;
+    try {
+      fs.writeFileSync(tmp, JSON.stringify(state), 'utf-8');
+      fs.renameSync(tmp, file);
+    } catch (err) {
+      try {
+        fs.unlinkSync(tmp);
+      } catch {
+        /* may not exist */
+      }
+      throw err;
+    }
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Read the raw state object. Never throws; returns null if absent or corrupt. */
+export function readStartupState(): StartupState | null {
+  try {
+    const raw = fs.readFileSync(DAEMON_STARTUP_STATE(), 'utf-8');
+    const s = JSON.parse(raw) as StartupState;
+    if (!s || typeof s.outcome !== 'string' || typeof s.at !== 'string') return null;
+    return s;
+  } catch {
+    return null;
+  }
+}
+
+/** What `doctor` prints beneath "Daemon not running" to explain it.
+ *  `label` exists because `at` does not always mean the same thing: for a failing
+ *  streak it is the FIRST attempt (preserved so the grace window can expire), so
+ *  calling it "last start attempt" would misreport the age by the length of the
+ *  streak. Each outcome names its own timestamp. */
+export type StartupCause = { kind: string; detail: string; at: Date; label: string } | null;
+
+/**
+ * Why the last start attempt did not leave a daemon running — or null if there is
+ * nothing honest to say.
+ *
+ * Only meaningful when the daemon is in fact down; `doctor` calls it from that
+ * branch. Returns null rather than guessing: a wrong cause under "Daemon not
+ * running" sends someone down the wrong path, which is worse than silence.
+ */
+export function readStartupCause(maxAgeMs = 24 * 60 * 60 * 1000): StartupCause {
+  const s = readStartupState();
+  if (!s) return null;
+  const at = new Date(s.at);
+  // Recency judged on the state's own timestamp — the reason this is a state file
+  // and not a log tail.
+  if (isNaN(at.getTime()) || Date.now() - at.getTime() > maxAgeMs) return null;
+
+  switch (s.outcome) {
+    case 'ok':
+    case 'ok-elsewhere':
+      // A start succeeded. If the daemon is down NOW it died later, which this
+      // function knows nothing about — saying anything here would be invention.
+      return null;
+    case 'starting':
+      // A daemon takes a moment to bind. Reporting "did not start" during that
+      // window would accuse a start that is simply still in progress — so a fresh
+      // marker means nothing yet.
+      if (Date.now() - at.getTime() < STARTING_GRACE_MS) return null;
+      // Issued but never reported back. TWO different things produce this, and the
+      // wording must cover both: the child died at module load (its stack is in
+      // daemon-startup.log), or no child was ever created — an exec failure on the
+      // check path, which deliberately records nothing (see check.ts) and leaves
+      // daemon-startup.log with no trace of this attempt at all. Claiming it
+      // "exited during startup" would assert a death that may never have happened
+      // and point at an empty file, so state only what is known and name both
+      // places evidence can live.
+      return {
+        kind: 'did-not-start',
+        detail: 'the daemon did not come up — see ~/.node9/daemon-startup.log and hook-debug.log',
+        at,
+        // `at` is the FIRST attempt of the streak, not the most recent one.
+        label: 'start attempts failing since',
+      };
+    case 'failed':
+      // A conclusive outcome overwrites, so here `at` really is the last attempt.
+      return { kind: s.kind || 'failed', detail: s.detail || '', at, label: 'last start attempt' };
+    default:
+      return null; // unknown outcome from a newer version — say nothing
   }
 }
 
@@ -43,6 +227,11 @@ export function logDaemonStartup(kind: string, detail?: string): void {
     const file = DAEMON_STARTUP_LOG();
     const dir = path.dirname(file);
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    // NO capStartupLog() here. This is called by a daemon that has just written its
+    // crash stack to stderr — which the spawner redirects into THIS file — so
+    // truncating now would delete the stack milliseconds after it landed, leaving
+    // the user with a one-line breadcrumb and the log that doctor points them at
+    // empty. Capping belongs before the writes, which is what openStartupLogFd does.
     const line = `[${new Date().toISOString()}] daemon-startup:${kind}${detail ? ` ${detail}` : ''}\n`;
     fs.appendFileSync(file, line, 'utf-8');
   } catch {

--- a/src/daemon/sync.ts
+++ b/src/daemon/sync.ts
@@ -15,6 +15,7 @@ import { runPosture } from '../posture/index.js';
 import { shipPosture } from '../posture/ship.js';
 import { buildPolicySnapshot } from '../policy-snapshot/build.js';
 import { readMcpToolsConfig } from './mcp-tools.js';
+import { atomicWriteSync } from './state.js';
 import { resolveMcpStatus } from '../mcp-status.js';
 import { shipPolicySnapshot } from '../policy-snapshot/ship.js';
 import { readActiveShields, readShieldOverrides } from '../shields.js';
@@ -672,16 +673,26 @@ export function extractManagedConfig(body: CloudPolicyBody): ManagedConfigCache 
 }
 
 /**
- * Write the policy cache atomically. Best-effort: directory creation
- * failures fall through silently — the proxy will fall back to local
- * config and surface the issue via `node9 sync` if the user runs it
- * explicitly.
+ * Write the policy cache atomically (temp file + rename).
+ *
+ * This MUST be atomic. The previous plain `fs.writeFileSync` truncated
+ * rules-cache.json in place, so a hook process reading it via getConfig()
+ * mid-write got a partial file → JSON.parse threw → the reader's fail-open
+ * catch dropped ALL cloud enforcement (shields, managed mode) for that call,
+ * silently allowing a command a shield should have blocked. Non-deterministic
+ * (depended on read/write overlap) and fail-open. `atomicWriteSync` writes to
+ * a sibling `.tmp` and renames — a POSIX-atomic swap, so a concurrent reader
+ * always sees either the complete old file or the complete new one.
+ *
+ * Best-effort: creation/write failures fall through silently — the proxy
+ * falls back to local config and surfaces the issue via `node9 sync`.
  */
 function writeCache(cache: RulesCache): void {
-  const dir = path.dirname(rulesCacheFile());
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(rulesCacheFile(), JSON.stringify(cache, null, 2) + '\n', 'utf-8');
+  atomicWriteSync(rulesCacheFile(), JSON.stringify(cache, null, 2) + '\n', 'utf-8');
 }
+
+/** Exported for the atomic-write regression test. */
+export const __writeCacheForTest = writeCache;
 
 async function syncOnce(): Promise<void> {
   const creds = readCredentials();

--- a/src/daemon/sync.ts
+++ b/src/daemon/sync.ts
@@ -106,6 +106,9 @@ export function buildSessionDeltas(
 
 // Computed lazily so tests can mock os.homedir() before any call
 const rulesCacheFile = () => path.join(os.homedir(), '.node9', 'rules-cache.json');
+// Last-known-good sibling — the reader falls back to it when the primary is
+// present but unparseable (external corruption). Kept in sync by writeCache.
+const rulesCacheBackupFile = () => path.join(os.homedir(), '.node9', 'rules-cache.last-good.json');
 const DEFAULT_API_URL = 'https://api.node9.ai/api/v1/intercept/policies/sync';
 const DEFAULT_INTERVAL_HOURS = 5;
 // Floor + ceiling for the resolved sync interval. The 15s floor keeps a
@@ -688,7 +691,19 @@ export function extractManagedConfig(body: CloudPolicyBody): ManagedConfigCache 
  * falls back to local config and surfaces the issue via `node9 sync`.
  */
 function writeCache(cache: RulesCache): void {
-  atomicWriteSync(rulesCacheFile(), JSON.stringify(cache, null, 2) + '\n', 'utf-8');
+  const data = JSON.stringify(cache, null, 2) + '\n';
+  atomicWriteSync(rulesCacheFile(), data, 'utf-8');
+  // Keep a last-known-good copy alongside the primary. If the primary is later
+  // corrupted by anything OTHER than our (atomic) writer — a disk fault, a crash
+  // during an external edit — getConfig falls back to this instead of silently
+  // dropping ALL cloud enforcement (shields, managed mode) for the call.
+  // Best-effort: the primary is the source of truth; a backup-write failure
+  // never blocks the sync.
+  try {
+    atomicWriteSync(rulesCacheBackupFile(), data, 'utf-8');
+  } catch {
+    /* best-effort */
+  }
 }
 
 /** Exported for the atomic-write regression test. */

--- a/src/mcp-pin.ts
+++ b/src/mcp-pin.ts
@@ -26,6 +26,8 @@ export interface PinEntry {
   toolCount: number;
   /** ISO 8601 timestamp of when the pin was created */
   pinnedAt: string;
+  /** ISO 8601 timestamp of when the reconciler last saw this server in agent configs */
+  lastSeen?: string;
 }
 
 export interface PinsFile {
@@ -163,7 +165,7 @@ function writePinsFile(filePath: string, data: PinsFile): void {
 }
 
 /** Atomic write of the home pin registry. */
-function writeMcpPins(data: PinsFile): void {
+export function writeMcpPins(data: PinsFile): void {
   writePinsFile(getHomePinsFilePath(), data);
 }
 

--- a/src/mcp-server/index.ts
+++ b/src/mcp-server/index.ts
@@ -715,7 +715,7 @@ function handleAuditGet(args: Record<string, unknown>): string {
       // classifyDecision is the ONE mapper (audit/decision.ts). This used to be
       // an inline `!== 'block' ? '[allow]'`, which reported every one of the
       // log's `deny` rows as ALLOWED.
-      const view = classifyDecision(e.decision, e.checkedBy ?? e.source);
+      const view = classifyDecision(e);
       if (wanted && view.outcome !== wanted) continue;
 
       // The gate stores `argsPreview` (its args are redacted/hashed); only the

--- a/src/mcp-server/index.ts
+++ b/src/mcp-server/index.ts
@@ -14,6 +14,7 @@ import os from 'os';
 import path from 'path';
 import { spawnSync } from 'child_process';
 import { getSnapshotHistory, applyUndo } from '../undo';
+import { classifyDecision, decisionTag } from '../audit/decision';
 import { getConfig, checkPause } from '../core';
 import { isDaemonRunning } from '../auth/daemon';
 import {
@@ -238,9 +239,11 @@ export const TOOLS = [
   {
     name: 'node9_audit_get',
     description:
-      'Read recent entries from the node9 audit log (~/.node9/audit.log). ' +
-      'Each entry shows timestamp, tool name, decision (allow/block/review), command/args, and agent. ' +
-      'Use this to review what AI actions have been taken recently, especially blocked or reviewed ops.',
+      'Read recent entries from the node9 audit log (~/.node9/audit.log). Each entry shows ' +
+      'timestamp, outcome, tool name, the command, and the rule that fired. Outcomes use the ' +
+      'same words as the dashboard: Auto-allowed, Approved, Ran, Blocked, Denied (a human ' +
+      'refused), Timed out (nobody answered), Would block (shadow mode let it through), ' +
+      'Finding, Info. Use this to review what AI actions were taken, especially refused ones.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -250,8 +253,11 @@ export const TOOLS = [
         },
         filter: {
           type: 'string',
-          enum: ['all', 'block', 'review'],
-          description: 'Filter by decision. Omit or use "all" to show every entry.',
+          enum: ['all', 'allow', 'deny', 'observe', 'info', 'block'],
+          description:
+            'Filter by outcome. "deny" covers every refusal (rule block, human denial, ' +
+            'timeout); "observe" is shadow-mode would-blocks; "block" is an alias for "deny". ' +
+            'Omit or use "all" for every entry.',
         },
       },
       required: [],
@@ -696,41 +702,54 @@ function handleAuditGet(args: Record<string, unknown>): string {
 
   const rawLines = fs.readFileSync(auditPath, 'utf-8').trim().split('\n').filter(Boolean);
 
-  // Parse all, filter by decision if requested, then take the last N
-  const parsed: Array<{ raw: string; decision: string; formatted: string }> = [];
+  // `block` is kept as an alias for `deny`: this tool's published schema
+  // advertised it, and a client may already be sending it. It matched nothing
+  // before — the log writes `deny`, never `block`.
+  const wanted = filter === 'block' ? 'deny' : filter;
+
+  // Parse all, filter by outcome if requested, then take the last N
+  const parsed: Array<{ raw: string; outcome: string; formatted: string }> = [];
   for (const line of rawLines) {
     try {
       const e = JSON.parse(line) as Record<string, unknown>;
-      const decision = String(e.decision ?? 'allow');
-      if (filter && decision !== filter) continue;
+      // classifyDecision is the ONE mapper (audit/decision.ts). This used to be
+      // an inline `!== 'block' ? '[allow]'`, which reported every one of the
+      // log's `deny` rows as ALLOWED.
+      const view = classifyDecision(e.decision, e.checkedBy ?? e.source);
+      if (wanted && view.outcome !== wanted) continue;
 
-      // Extract the most useful arg: command for Bash, file_path for Edit/Write, sql for DB tools
+      // The gate stores `argsPreview` (its args are redacted/hashed); only the
+      // PostToolUse hook stores `args`. Reading just `args` left every BLOCKED
+      // action with an empty detail column.
       const argsObj = e.args as Record<string, unknown> | undefined;
       let detail = '';
       if (argsObj) {
         const cmd = argsObj.command ?? argsObj.file_path ?? argsObj.path ?? argsObj.sql;
-        if (typeof cmd === 'string' && cmd) {
-          detail = cmd.length > 80 ? cmd.slice(0, 80) + '…' : cmd;
-        }
+        if (typeof cmd === 'string' && cmd) detail = cmd;
       }
+      if (!detail && typeof e.argsPreview === 'string') detail = e.argsPreview;
+      detail = detail.replace(/\s+/g, ' ').trim();
+      if (detail.length > 80) detail = detail.slice(0, 80) + '…';
 
-      const decisionPad =
-        decision === 'block' ? '[BLOCK] ' : decision === 'review' ? '[review]' : '[allow] ';
+      // Name the rule that fired — a refusal the reader can't attribute is
+      // half an audit trail.
+      const why = typeof e.ruleName === 'string' && e.ruleName ? `  (${e.ruleName})` : '';
       const toolPad = String(e.tool ?? '').padEnd(20);
-      const line2 = `${e.ts}  ${decisionPad}  ${toolPad}  ${detail}`;
-      parsed.push({ raw: line, decision, formatted: line2 });
+      const line2 = `${e.ts}  ${decisionTag(view)}  ${toolPad}  ${detail}${why}`;
+      parsed.push({ raw: line, outcome: view.outcome, formatted: line2 });
     } catch {
-      parsed.push({ raw: line, decision: 'allow', formatted: line });
+      // An unparseable row is NOT an allow — surface it rather than bury it.
+      parsed.push({ raw: line, outcome: 'unknown', formatted: `[? unparseable]  ${line}` });
     }
   }
 
   const recent = parsed.slice(-limit);
   if (recent.length === 0) {
-    return filter ? `No ${filter} entries found in audit log.` : 'Audit log is empty.';
+    return filter ? `No ${wanted} entries found in audit log.` : 'Audit log is empty.';
   }
 
   const header = filter
-    ? `Last ${recent.length} ${filter.toUpperCase()} entries:`
+    ? `Last ${recent.length} ${String(wanted).toUpperCase()} entries:`
     : `Last ${recent.length} audit entries:`;
 
   return `${header}\n\n${recent.map((e) => e.formatted).join('\n')}`;

--- a/src/mcp-wrap.ts
+++ b/src/mcp-wrap.ts
@@ -9,6 +9,7 @@ import os from 'os';
 import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
 import { AGENT_SPECS, readMcpServers, type McpServer, type McpFormat } from './agent-wiring';
 import { tokenize, quoteArg } from './mcp-cmd';
+import { getServerKey } from './mcp-pin';
 export type { McpServer, McpFormat } from './agent-wiring';
 export { tokenize } from './mcp-cmd';
 
@@ -110,6 +111,33 @@ export function inventoryMcp(home: string = os.homedir()): McpEntry[] {
     }
   }
   return out;
+}
+
+/**
+ * Derive the set of serverKeys (pin identities) from an inventory snapshot.
+ * For gatewayed entries: hashes the --upstream value (matching how the gateway pins).
+ * For ungoverned entries: hashes the upstream string the gateway WOULD build on
+ * wrapping — which is `toGateway`'s `[command, ...args].map(quoteArg).join(' ')`,
+ * NOT a naive join. A naive join diverges the moment an arg needs quoting (a path
+ * with a space), producing a different serverKey than the pin the gateway created,
+ * so a still-configured server would look orphaned. Used by both the reconciler
+ * and the CLI forget command.
+ */
+export function inventoryServerKeys(inv: McpEntry[]): Set<string> {
+  const keys = new Set<string>();
+  for (const e of inv) {
+    if (e.state === 'gatewayed') {
+      const i = e.args.indexOf('--upstream');
+      if (i >= 0 && e.args[i + 1]) {
+        keys.add(getServerKey(e.args[i + 1]));
+      }
+    } else if (e.state === 'ungoverned') {
+      // Mirror toGateway exactly — quoteArg each token before joining.
+      const cmd = [e.command, ...e.args].map(quoteArg).join(' ');
+      keys.add(getServerKey(cmd));
+    }
+  }
+  return keys;
 }
 
 /**

--- a/src/posture/__tests__/posture.test.ts
+++ b/src/posture/__tests__/posture.test.ts
@@ -376,9 +376,56 @@ describe('deriveHeadline', () => {
     expect(h?.risk).toMatch(/no container/i); // isolation woven in
   });
 
-  it('makes egress the first action (close the exit breaks the chain)', () => {
+  it('makes egress the first action, derived from the Egress finding (close the exit breaks the chain)', () => {
     const h = deriveHeadline([f('Secrets', 'critical'), f('Egress')]);
-    expect(h?.action).toMatch(/lock egress/i);
+    // The action comes from the EGRESS finding (ladder order), not the secrets one…
+    expect(h?.action).toContain('fix Egress');
+    // …and keeps the chain rationale the ladder is built on.
+    expect(h?.action).toContain('exfiltration chain');
+  });
+
+  it("egress action carries the finding's real command + the chain rationale", () => {
+    const egress: Finding = {
+      category: 'Egress',
+      severity: 'high',
+      title: 'Egress is open',
+      detail: [],
+      fix: 'Fix it now: run `node9 egress watch` (or `node9 egress lock` to hard-block).',
+    };
+    const h = deriveHeadline([egress]);
+    expect(h?.action).toContain('node9 egress watch');
+    expect(h?.action).toContain('exfiltration chain');
+    expect(h?.action).not.toMatch(/fix it now:/i);
+  });
+
+  it('egress falls back to the allowlist generic when the finding has no fix', () => {
+    const h = deriveHeadline([
+      { category: 'Egress', severity: 'high', title: 'Egress is open', detail: [] },
+    ]);
+    expect(h?.action).toMatch(/lock egress to an allowlist/i);
+  });
+
+  it("gate action carries the finding's real command", () => {
+    const gate: Finding = {
+      category: 'Approval gate',
+      severity: 'critical',
+      title: 'No approval gate is active — destructive commands run unchecked',
+      detail: [],
+      fix:
+        'Turn on the gate: run `node9 shield enable bash-safe` (or add a smart rule). ' +
+        "node9 then blocks dangerous commands and the negotiation loop tells the agent what's allowed.",
+    };
+    const h = deriveHeadline([gate]);
+    expect(h?.action).toContain('Turn on the gate');
+    expect(h?.action).toContain('node9 shield enable bash-safe');
+  });
+
+  it('gate falls back to a command-bearing generic when the finding has no fix', () => {
+    const h = deriveHeadline([
+      { category: 'Approval gate', severity: 'critical', title: 'No approval gate', detail: [] },
+    ]);
+    expect(h?.action).toContain('destructive-command blocking');
+    expect(h?.action).toContain('node9 shield enable bash-safe');
   });
 
   it('prioritizes "node9 init" when node9 is not wired, over any other fix', () => {

--- a/src/posture/__tests__/posture.test.ts
+++ b/src/posture/__tests__/posture.test.ts
@@ -400,6 +400,77 @@ describe('deriveHeadline', () => {
   it('returns null for a clean run', () => {
     expect(deriveHeadline([])).toBeNull();
   });
+
+  // ── P1: the action derives from the FINDING, never a canned exemplar ──────
+  // Repro 2026-07-23: the secrets branch printed hardcoded "~/.ssh, ~/.aws"
+  // while the actual finding was a DB connection string in ~/.claude.json.
+  const plaintextSecret = (over: Partial<Finding> = {}): Finding => ({
+    category: 'Secrets',
+    severity: 'critical',
+    title: '1 plaintext secret on disk',
+    detail: ['Database Connection String in ~/.claude.json'],
+    fix: 'Fix it now: run `node9 shield enable project-jail` (blocks credential-file reads in-path).',
+    ...over,
+  });
+
+  it("secrets action carries the finding's own command + location, not a canned path list", () => {
+    const h = deriveHeadline([plaintextSecret()]);
+    expect(h?.action).toContain('node9 shield enable project-jail');
+    expect(h?.action).toContain('~/.claude.json');
+    expect(h?.action).not.toContain('~/.ssh'); // the canned exemplar must be gone
+  });
+
+  it('strips the "Fix it now:" prefix so render\'s "Do this first:" composes cleanly', () => {
+    const h = deriveHeadline([plaintextSecret()]);
+    expect(h?.action).not.toMatch(/fix it now:/i);
+  });
+
+  it('caps locations at the first + a count, never the full list', () => {
+    const h = deriveHeadline([
+      plaintextSecret({ detail: ['A in ~/.claude.json', 'B in ~/.env', 'C in ~/x'] }),
+    ]);
+    expect(h?.action).toContain('A in ~/.claude.json');
+    expect(h?.action).toContain('and 2 more');
+    expect(h?.action).not.toContain('B in ~/.env');
+  });
+
+  it('falls back to a command-bearing generic — with NO path claims — when the finding has no fix', () => {
+    const h = deriveHeadline([plaintextSecret({ fix: undefined, detail: [] })]);
+    expect(h?.action).toContain('node9 shield enable project-jail');
+    expect(h?.action).not.toContain('~/.ssh'); // a fallback may not assert specifics
+  });
+
+  it('the worstFinding fallback branch also normalizes the prefix', () => {
+    // A category outside every ladder branch → the fallback path.
+    const other: Finding = {
+      category: 'Supply chain',
+      severity: 'high',
+      title: 's',
+      detail: [],
+      fix: 'Fix it now: run `node9 mcp gateway --all`.',
+    };
+    const h = deriveHeadline([other]);
+    expect(h?.action).toContain('node9 mcp gateway --all');
+    expect(h?.action).not.toMatch(/fix it now:/i);
+  });
+
+  it('a same-severity fallback pick is deterministic regardless of input order', () => {
+    const a: Finding = {
+      category: 'Supply chain',
+      severity: 'high',
+      title: 'a',
+      detail: [],
+      fix: 'fix a',
+    };
+    const b: Finding = {
+      category: 'Tool governance',
+      severity: 'high',
+      title: 'b',
+      detail: [],
+      fix: 'fix b',
+    };
+    expect(deriveHeadline([a, b])?.action).toBe(deriveHeadline([b, a])?.action);
+  });
 });
 
 describe('renderPosture grouping', () => {
@@ -447,6 +518,23 @@ describe('renderPosture grouping', () => {
     expect(out).toContain('Track this across your fleet');
     // The old link pointed at a route that doesn't exist (/posture) — must be gone.
     expect(out).not.toContain('app.node9.ai/posture');
+  });
+
+  it('the rendered headline composes ONE prefix — never "Do this first: Fix it now:"', () => {
+    const out = renderPosture(
+      result([
+        {
+          category: 'Secrets',
+          severity: 'critical',
+          title: '1 plaintext secret on disk',
+          detail: ['Database Connection String in ~/.claude.json'],
+          owner: 'node9',
+          fix: 'Fix it now: run `node9 shield enable project-jail` (blocks credential-file reads in-path).',
+        },
+      ])
+    );
+    expect(out).toContain('Do this first: run');
+    expect(out).not.toMatch(/do this first: fix it now/i);
   });
 
   it('groups open findings by owner — node9-fixable before only-you', () => {

--- a/src/posture/__tests__/posture.test.ts
+++ b/src/posture/__tests__/posture.test.ts
@@ -567,6 +567,136 @@ describe('renderPosture grouping', () => {
     expect(out).not.toContain('app.node9.ai/posture');
   });
 
+  // ── P3: D3 collision labels + D4 headroom copy ────────────────────────────
+  // The new headroom sentence word-wraps, so phrase assertions run on a
+  // whitespace-flattened copy to avoid straddling a line break.
+  const flat = (s: string) => s.replace(/\s+/g, ' ');
+
+  it('a category both covered and open gets (guarded)/(exposed) + names what is guarded', () => {
+    const out = renderPosture(
+      result([
+        {
+          category: 'Secrets',
+          severity: 'high',
+          title: '2 credential files readable by the agent',
+          detail: ['~/.ssh/id_rsa', '~/.aws/credentials'],
+          coverage: { state: 'covered', level: 'block', via: 'node9 DLP' },
+          coverageProbe: { kind: 'fileRead', paths: ['/x'] },
+        },
+        {
+          category: 'Secrets',
+          severity: 'critical',
+          title: '1 plaintext secret on disk',
+          detail: ['Database Connection String in ~/.claude.json'],
+          owner: 'node9',
+          fix: 'Fix it now: run `node9 shield enable project-jail`.',
+        },
+      ])
+    );
+    expect(out).toContain('Secrets (guarded)');
+    expect(out).toContain('Secrets (exposed)');
+    expect(out).toContain('reads of ~/.ssh/id_rsa and 1 more');
+  });
+
+  it('a covered-only category keeps its bare label (no qualifier outside a collision)', () => {
+    const out = renderPosture(
+      result([
+        {
+          category: 'Egress',
+          severity: 'high',
+          title: 'e',
+          detail: [],
+          coverage: { state: 'covered', level: 'review', via: 'node9 egress' },
+        },
+      ])
+    );
+    expect(out).not.toContain('(guarded)');
+    expect(out).not.toContain('(exposed)');
+  });
+
+  it('a covered row without detail falls back to "…this"', () => {
+    const out = renderPosture(
+      result([
+        {
+          category: 'Egress',
+          severity: 'high',
+          title: 'e',
+          detail: [],
+          coverage: { state: 'covered', level: 'review', via: 'node9 egress' },
+        },
+      ])
+    );
+    expect(out).toContain('node9 egress is approval-gating this');
+  });
+
+  it('headroom line names both buckets when genuine exposures are open', () => {
+    const out = flat(
+      renderPosture(
+        result([
+          { category: 'Egress', severity: 'high', title: 'e', detail: [], owner: 'node9' },
+          {
+            category: 'Isolation',
+            severity: 'advisory',
+            title: 'i',
+            detail: [],
+            owner: 'os',
+            node9Reduces: true,
+            scoreWeight: 12,
+          },
+        ])
+      )
+    );
+    expect(out).toContain('Of the gap to 100');
+    expect(out).toContain('the rest is the open findings');
+  });
+
+  it('headroom line stays single-bucket when only optional hardening is open', () => {
+    const out = flat(
+      renderPosture(
+        result([
+          {
+            category: 'Isolation',
+            severity: 'advisory',
+            title: 'i',
+            detail: [],
+            owner: 'os',
+            node9Reduces: true,
+            scoreWeight: 12,
+          },
+        ])
+      )
+    );
+    expect(out).toContain('pts of headroom');
+    expect(out).not.toContain('the rest is');
+  });
+
+  it('advisory-only exposures do not trigger the both-buckets variant (advisories never deduct)', () => {
+    const out = flat(
+      renderPosture(
+        result([
+          {
+            category: 'Network exposure',
+            severity: 'advisory',
+            title: 'n',
+            detail: [],
+            owner: 'os',
+          },
+          {
+            category: 'Isolation',
+            severity: 'advisory',
+            title: 'i',
+            detail: [],
+            owner: 'os',
+            node9Reduces: true,
+            scoreWeight: 12,
+          },
+        ])
+      )
+    );
+    expect(out).toContain('pts of headroom');
+    expect(out).not.toContain('the rest is');
+  });
+
   it('the rendered headline composes ONE prefix — never "Do this first: Fix it now:"', () => {
     const out = renderPosture(
       result([

--- a/src/posture/headline.ts
+++ b/src/posture/headline.ts
@@ -16,7 +16,33 @@ const SEVERITY_RANK: Record<Severity, number> = {
 };
 
 function worstFinding(findings: Finding[]): Finding | undefined {
-  return [...findings].sort((a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity])[0];
+  // Tie-break beyond severity: the headline surfaces finding CONTENT, so the
+  // pick must not depend on check execution order.
+  return [...findings].sort(
+    (a, b) =>
+      SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity] ||
+      a.category.localeCompare(b.category) ||
+      a.title.localeCompare(b.title)
+  )[0];
+}
+
+/**
+ * Self-contained action text derived from a finding: its own `fix` minus any
+ * "Fix it now:" prefix (render prepends "Do this first:"), plus the first
+ * concrete location so the CTA names the actual evidence — never a canned
+ * exemplar (a headline that mislabels the mechanism is worse than silence).
+ * `detail` holds secret types + locations only, never values (see secrets.ts).
+ */
+function actionFromFinding(f: Finding | undefined): string | null {
+  if (!f?.fix) return null;
+  const fix = f.fix.replace(/^fix it now:\s*/i, '');
+  const where =
+    f.detail.length === 0
+      ? ''
+      : f.detail.length === 1
+        ? ` — found: ${f.detail[0]}`
+        : ` — found: ${f.detail[0]} and ${f.detail.length - 1} more`;
+  return fix + where;
 }
 
 /**
@@ -81,11 +107,17 @@ export function deriveHeadline(allFindings: Finding[]): Headline | null {
     action =
       'lock egress to an allowlist (node9 can enforce it) — it closes the exit the exfiltration needs.';
   } else if (secrets) {
-    action = 'node9 can block reads of sensitive paths (~/.ssh, ~/.aws) in-path.';
+    // The finding is the source of truth — its fix names the exact command and
+    // its detail names the actual file. The fallback carries the command but
+    // asserts NO specifics (a canned path list here is how the 07-23 repro
+    // showed "~/.ssh, ~/.aws" against a secret living in ~/.claude.json).
+    action =
+      actionFromFinding(worstFinding(findings.filter((f) => f.category === 'Secrets'))) ??
+      'node9 can block reads of sensitive credential files in-path (`node9 shield enable project-jail`).';
   } else if (gateWeak) {
     action = 'node9 can enforce destructive-command blocking in-path.';
   } else {
-    action = worstFinding(findings)?.fix ?? 'Review the findings below.';
+    action = actionFromFinding(worstFinding(findings)) ?? 'Review the findings below.';
   }
 
   return { risk, action };

--- a/src/posture/headline.ts
+++ b/src/posture/headline.ts
@@ -17,12 +17,15 @@ const SEVERITY_RANK: Record<Severity, number> = {
 
 function worstFinding(findings: Finding[]): Finding | undefined {
   // Tie-break beyond severity: the headline surfaces finding CONTENT, so the
-  // pick must not depend on check execution order.
+  // pick must not depend on check execution order. Code-point compare, not
+  // localeCompare — host-locale collation must not pick different findings on
+  // different machines.
+  const cmp = (x: string, y: string) => (x < y ? -1 : x > y ? 1 : 0);
   return [...findings].sort(
     (a, b) =>
       SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity] ||
-      a.category.localeCompare(b.category) ||
-      a.title.localeCompare(b.title)
+      cmp(a.category, b.category) ||
+      cmp(a.title, b.title)
   )[0];
 }
 

--- a/src/posture/headline.ts
+++ b/src/posture/headline.ts
@@ -104,8 +104,15 @@ export function deriveHeadline(allFindings: Finding[]): Headline | null {
   } else if (observeOnly) {
     action = 'Switch node9 to enforcing mode — right now it is only watching, not blocking.';
   } else if (egressOpen) {
-    action =
-      'lock egress to an allowlist (node9 can enforce it) — it closes the exit the exfiltration needs.';
+    // Finding-first + keep the chain rationale the ladder is built on: egress
+    // outranks secrets because closing the exit breaks the exfiltration chain —
+    // the finding's fix names the command but not WHY it goes first.
+    const egressFix = actionFromFinding(
+      worstFinding(findings.filter((f) => f.category === 'Egress'))
+    );
+    action = egressFix
+      ? `${egressFix} Closing the exit breaks the exfiltration chain.`
+      : 'lock egress to an allowlist (node9 can enforce it) — it closes the exit the exfiltration needs.';
   } else if (secrets) {
     // The finding is the source of truth — its fix names the exact command and
     // its detail names the actual file. The fallback carries the command but
@@ -115,7 +122,9 @@ export function deriveHeadline(allFindings: Finding[]): Headline | null {
       actionFromFinding(worstFinding(findings.filter((f) => f.category === 'Secrets'))) ??
       'node9 can block reads of sensitive credential files in-path (`node9 shield enable project-jail`).';
   } else if (gateWeak) {
-    action = 'node9 can enforce destructive-command blocking in-path.';
+    action =
+      actionFromFinding(worstFinding(findings.filter((f) => f.category === 'Approval gate'))) ??
+      'node9 can enforce destructive-command blocking in-path (`node9 shield enable bash-safe`).';
   } else {
     action = actionFromFinding(worstFinding(findings)) ?? 'Review the findings below.';
   }

--- a/src/posture/render.ts
+++ b/src/posture/render.ts
@@ -124,7 +124,7 @@ export function renderPosture(result: PostureResult): string {
       openExposures > 0
         ? `Of the gap to 100: ${headroom} pts is optional hardening you can choose ` +
           'to turn on (the 🔒 tier below, each at some cost to flexibility); the ' +
-          'rest is the open findings — the ❌ rows below. Fix those first.'
+          'rest is the open findings — the flagged rows below. Fix those first.'
         : `${headroom} pts of headroom — optional hardening you can choose to ` +
           'turn on (the 🔒 tier below), each at some cost to flexibility.';
     for (const l of wrap(note, 76)) lines.push('  ' + chalk.gray(l));

--- a/src/posture/render.ts
+++ b/src/posture/render.ts
@@ -42,12 +42,25 @@ function label(category: string): string {
   return chalk.bold(category.padEnd(Math.max(LABEL_WIDTH, category.length + 1)));
 }
 
-function renderFinding(f: Finding, showWeight = false): string[] {
+/** What a covered row is guarding, from the finding's own detail — data-first,
+ *  first entry + a count (the P1 cap rule). 'this' when it has no specifics. */
+function guardedWhat(f: Finding): string {
+  if (f.detail.length === 0) return 'this';
+  const reads = f.coverageProbe?.kind === 'fileRead' ? 'reads of ' : '';
+  const more = f.detail.length > 1 ? ` and ${f.detail.length - 1} more` : '';
+  return `${reads}${f.detail[0]}${more}`;
+}
+
+function renderFinding(
+  f: Finding,
+  showWeight = false,
+  displayLabel: string = f.category
+): string[] {
   const lines: string[] = [];
   // In the AVAILABLE tier, lead with the score gain (+N) so the value of turning
   // the layer on is the first thing read.
   const wt = showWeight && f.scoreWeight ? chalk.cyan.bold(`+${f.scoreWeight} `) : '';
-  lines.push(`  ${ICON[f.severity]} ${label(f.category)}${wt}${f.title}`);
+  lines.push(`  ${ICON[f.severity]} ${label(displayLabel)}${wt}${f.title}`);
   const indent = ' '.repeat(2 + 3 + LABEL_WIDTH);
   // Plain-language explanation first (what / why / who), wrapped so that
   // indent + text stays under ~80 columns.
@@ -94,17 +107,27 @@ export function renderPosture(result: PostureResult): string {
       `        ${chalk.bold(`Score: ${result.score}/100`)}  (${tier})`
   );
   // The headroom line: a sub-100 score isn't a failure — it's hardening you
-  // can choose to turn on. Naming the points (and that each costs flexibility)
-  // is what keeps the number honest AND non-nagging.
+  // can choose to turn on. When genuine exposures are ALSO open, name both
+  // buckets — otherwise the reader computes score+headroom≠100 and mistrusts
+  // the number. Advisories never deduct (score.ts), so they don't count as
+  // the "rest".
   const headroom = openHeadroom(result.findings);
   if (headroom > 0) {
-    lines.push(
-      '  ' +
-        chalk.gray(
-          `${headroom} pts of headroom below — each layer adds security at some ` +
-            'cost to flexibility. You choose which to close.'
-        )
-    );
+    const openExposures = result.findings.filter(
+      (f) =>
+        f.coverage?.state !== 'covered' &&
+        f.coverage?.state !== 'cant-fix' &&
+        !f.scoreWeight &&
+        f.severity !== 'advisory'
+    ).length;
+    const note =
+      openExposures > 0
+        ? `Of the gap to 100: ${headroom} pts is optional hardening you can choose ` +
+          'to turn on (the 🔒 tier below, each at some cost to flexibility); the ' +
+          'rest is the open findings — the ❌ rows below. Fix those first.'
+        : `${headroom} pts of headroom — optional hardening you can choose to ` +
+          'turn on (the 🔒 tier below), each at some cost to flexibility.';
+    for (const l of wrap(note, 76)) lines.push('  ' + chalk.gray(l));
   }
   lines.push('');
 
@@ -121,13 +144,22 @@ export function renderPosture(result: PostureResult): string {
   // a risk. (Covered findings are excluded from the open-findings render below.)
   const covered = result.findings.filter((f) => f.coverage?.state === 'covered');
   const open = result.findings.filter((f) => f.coverage?.state !== 'covered');
+  // A category present in BOTH lists reads as a contradiction (✅ Secrets six
+  // lines above ❌ Secrets) — qualify the labels ONLY then; a category on one
+  // side keeps its bare name.
+  const collision = new Set(
+    covered.map((f) => f.category).filter((c) => open.some((o) => o.category === c))
+  );
+  const openLabel = (f: Finding) =>
+    collision.has(f.category) ? `${f.category} (exposed)` : f.category;
   if (covered.length > 0) {
     lines.push('  ' + chalk.green('🟢 ON NOW — node9 is enforcing these (your floor)'));
     for (const f of covered) {
       const gated = f.coverage?.level === 'review' ? 'approval-gating' : 'blocking';
       const via = f.coverage?.via ?? 'node9';
+      const lbl = collision.has(f.category) ? `${f.category} (guarded)` : f.category;
       lines.push(
-        `  ${chalk.green('✅')} ${label(f.category)}${chalk.gray(`${via} is ${gated} this`)}`
+        `  ${chalk.green('✅')} ${label(lbl)}${chalk.gray(`${via} is ${gated} ${guardedWhat(f)}`)}`
       );
     }
     lines.push('');
@@ -144,17 +176,17 @@ export function renderPosture(result: PostureResult): string {
 
   if (node9Open.length > 0) {
     lines.push('  ' + chalk.cyan.bold('🔧 node9 can fix these — run the command'));
-    for (const f of node9Open) lines.push(...renderFinding(f, true));
+    for (const f of node9Open) lines.push(...renderFinding(f, true, openLabel(f)));
   }
   if (reduceOpen.length > 0) {
     if (node9Open.length > 0) lines.push('');
     lines.push('  ' + chalk.yellow.bold('🔒 AVAILABLE — turn on to harden (each has a tradeoff)'));
-    for (const f of reduceOpen) lines.push(...renderFinding(f, true));
+    for (const f of reduceOpen) lines.push(...renderFinding(f, true, openLabel(f)));
   }
   if (osOpen.length > 0) {
     if (node9Open.length > 0 || reduceOpen.length > 0) lines.push('');
     lines.push('  ' + chalk.bold("🧱 YOUR PART — node9 can't fix these (OS-level)"));
-    for (const f of osOpen) lines.push(...renderFinding(f));
+    for (const f of osOpen) lines.push(...renderFinding(f, false, openLabel(f)));
   }
 
   for (const cat of result.passedCategories) {

--- a/src/posture/types.ts
+++ b/src/posture/types.ts
@@ -69,7 +69,8 @@ export interface Finding {
   fix?: string;
   /** Set by `annotateCoverage` — node9's enforcement relationship to this finding. */
   coverage?: Coverage;
-  /** How to assess coverage for this finding (internal; not rendered/shipped). */
+  /** How to assess coverage for this finding (internal; not shipped — render
+   *  may read `kind` for phrasing, e.g. "reads of" on fileRead). */
   coverageProbe?: CoverageProbe;
   /** Internal: this finding is only OPEN because node9 isn't enforcing — the
    *  Coverage check already reports that gap, so drop it when open to avoid

--- a/src/tui/tail.ts
+++ b/src/tui/tail.ts
@@ -6,6 +6,7 @@ import os from 'os';
 import path from 'path';
 import readline from 'readline';
 import { spawn } from 'child_process';
+import { openStartupLogFd, recordStartupState } from '../daemon/startup-log';
 import { DAEMON_PORT } from '../daemon';
 import { getInternalToken } from '../auth/daemon';
 
@@ -364,12 +365,27 @@ async function ensureDaemon(): Promise<number> {
 
   // Not running — start it in the background
   console.log(chalk.dim('🛡️  Starting Node9 daemon...'));
+  // Same spawner contract as the other three: capture the child's stderr so a
+  // module-load crash leaves a trace, mark the attempt so a child that never runs
+  // our code is still visible to `doctor`, and attach an 'error' listener — an
+  // 'error' event with no listener is an uncaught exception. The 5s poll below
+  // means the listener reliably outlives the event here.
+  const startupFd = openStartupLogFd();
+  recordStartupState('starting');
   const child = spawn(process.execPath, [process.argv[1], 'daemon'], {
     detached: true,
-    stdio: 'ignore',
+    stdio: ['ignore', 'ignore', startupFd ?? 'ignore'],
     env: { ...process.env, NODE9_AUTO_STARTED: '1' },
   });
+  child.on('error', (err: Error) => recordStartupState('failed', 'spawn-failed', err.message));
   child.unref();
+  if (startupFd !== undefined) {
+    try {
+      fs.closeSync(startupFd);
+    } catch {
+      /* non-fatal */
+    }
+  }
 
   // Wait up to 5s for it to be ready
   for (let i = 0; i < 20; i++) {


### PR DESCRIPTION
## Summary

Batches the work accumulated on `dev` since the last release. All 3698 tests
(24 skipped, 3 todo), typecheck, lint, and format pass.

> ⚠️ **Merge gate:** this diff includes enforcement/gate changes (B1 shield
> cluster, auth strict-review floors, `deed707` config strict-floor). Per the
> repo's rule for gate/auth/DLP diffs, run the `/code-review` adversarial
> workflow on that cluster before merging — a single-pass self-review does not
> clear it. The posture and MCP-lifecycle work is display/lifecycle-only and not
> subject to that gate.

### 🛡 Shield hardening (B1)
- **A cloud-mandated shield cannot be weakened locally** (`ad51b47`), **a local
  config rule cannot suppress a cloud shield rule** (`48d7203`, part 2), **the
  remaining local bypasses closed** (`c186cc0`), and **a shield mandate floors
  local mode; non-builtin fails closed** (`025641a`). Together these close the
  paths by which local state could soften a workspace-mandated shield.
- **Redis shield rules require Redis, not just the word** (`db79fcd`) — an
  unrelated command containing a Redis keyword no longer trips the shield.

### 🔐 Auth / strict-floor integrity
- **Cloud no-match allow must not resolve a tier-7 strict review** (`2600809`)
  and **a pre-strict "Always Allow" must not pre-satisfy a tier-7 review**
  (`fe679b1`) — B1 #6: a persisted or cloud allow can't short-circuit a strict
  catch-all review.
- **A shield hard-block downgrades to review only when a human is reachable**
  (`998bfaf`); **rules-cache written atomically + read resiliently** so a shield
  fails open only under a genuine read error, not a torn write (`2ef873a`);
  pre-push review follow-ups — dedupe the hard-block path + last-good cache
  backup (`47e9bcb`).
- **A cloud-managed strict floor can't be disabled by repo config** (`deed707`,
  task #16): a cloned repo's `node9.config.json` could neutralize an org's
  managed strict two ways — `environments.requireApproval:false` (the engine's
  strict escape → blanket allow) and local `ignoredTools` (the ignored-tool
  fast-path allows before policy eval). Both now stripped/reset under a
  cloud-managed floor via one `managedFloorActive` predicate; a **locally**
  chosen strict keeps its dev-convenience escapes (verified — no over-tighten).
  Failing-first + two real-gate `evaluatePolicy` E2E assertions.

### 🧾 Audit decision convergence
One source of truth for allow/deny classification, so the same event can never
render as an allow in one reader and a deny in another:
- **One decision mapper — a denial can never render as an allow** (`162cb7d`);
  **classify from the row, not a field pair** (`389816a`); **converge a 4th
  reader, keep `\s+`, restore library-call coverage** (`92a88ce`); **converge the
  last two daemon readers + fix row detection** (`4bae6e2`).
- **Shadow-mode rows and findings are not blocks** (`ff36447`).

### 🧭 Posture scorecard — honest CTAs (`node9 posture`)
The free front door's "one next step" was a hardcoded string that mismatched the
actual finding. Now every headline/label/count derives from the finding itself.
Design: `doc/roadmap/active/posture-headline-cta-fix-design.md`.
- **P1** (`35192b2`): the headline action comes from the worst finding's own
  `fix` + its real location, not a canned `~/.ssh, ~/.aws` exemplar; the render
  double-prefix (`Do this first: Fix it now:`) is normalized away; the pick is
  deterministic.
- **P2** (`f64b9c3`): the egress and approval-gate branches derive the same way,
  keeping the chain rationale that orders the ladder; `notWired`/`observeOnly`
  stay hardcoded by design (install-state context the finding can't know).
- **P3** (`355e1c5`): a category rendered as both ✅ and ❌ is disambiguated
  (`Secrets (guarded)` / `Secrets (exposed)`) only on a genuine collision; the
  headroom line names both buckets so `score + headroom ≠ 100` no longer reads as
  broken math.
- **Polish** (`1212971`): code-point tie-break (fleet-deterministic, not
  host-locale), severity-neutral copy, comment fix — all from a pre-push review.

### 🩺 Daemon diagnostics
- **Explain WHY the daemon is down via a startup-state file** (`62b1ac7`) — the
  doctor/status surface can say what actually failed instead of guessing.

### 🔌 MCP pin lifecycle (new)
- The reconciler stamps `lastSeen` and auto-removes pins whose server has been
  gone longer than `mcpStaleAfterDays` (default 7, `0` = never); corrupt/missing
  pin files never crash the daemon; removals are audit-attributed (`8fe30e0`).
- `node9 mcp forget [serverKey] [--stale]`, guarded against forgetting a server
  still configured in any agent; **don't mass-remove pins on an empty inventory**
  (`246aca3`).
- `inventoryServerKeys()` keys a server exactly as the gateway does
  (`quoteArg`-per-token), so a still-configured server whose arg needs quoting
  isn't misread as orphaned. Failing-first test covers it.

## Test plan
- `npm test` — 3698 passed / 24 skipped / 3 todo. New specs: `mcp-lifecycle.spec.ts`,
  `managed-strict-config-floor.spec.ts` (real-gate E2E), plus 13 posture cases in
  `posture.test.ts` — all verified failing-first.
- typecheck / lint / format:check — green (pre-commit + pre-push hooks).
- `node9 posture` run live on a real box: headline, guarded/exposed labels, and
  headroom copy verified against a genuine finding set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
