### PR TITLE
Merge dev → main: inline-ask v2 (inline = THE review channel) + dlp.reviewAction + /code-review fixes

### DIFF
--- a/packages/policy-engine/src/policy/index.ts
+++ b/packages/policy-engine/src/policy/index.ts
@@ -33,7 +33,13 @@ export interface PolicyConfig {
     ignoredTools: string[];
     toolInspection: Record<string, string>;
     smartRules: SmartRule[];
-    dlp: { enabled: boolean; scanIgnoredTools: boolean };
+    dlp: {
+      enabled: boolean;
+      scanIgnoredTools: boolean;
+      /** Inline-ask v2: 'block' upgrades review-severity DLP matches to a hard
+       *  block. Optional for back-compat with callers that don't set it. */
+      reviewAction?: 'review' | 'block';
+    };
     /** Egress / destination control (GAP-5). Optional for back-compat with
      *  callers/tests that build a PolicyConfig without it. */
     egress?: EgressPolicy;
@@ -251,7 +257,13 @@ export async function evaluatePolicy(
     const dlpMatch = args !== undefined ? scanArgs(args) : null;
     if (dlpMatch) {
       return {
-        decision: dlpMatch.severity,
+        // reviewAction:'block' (inline-ask v2): the admin upgraded
+        // review-severity matches to a hard block — every evaluatePolicy
+        // caller (orchestrator, explain, gateway) must agree with the gate.
+        decision:
+          dlpMatch.severity === 'block' || config.policy.dlp.reviewAction === 'block'
+            ? 'block'
+            : 'review',
         blockedByLabel: `DLP: ${dlpMatch.patternName}`,
         reason: `${dlpMatch.patternName} detected in ${dlpMatch.fieldPath}`,
       };

--- a/src/__tests__/app-permissions.spec.ts
+++ b/src/__tests__/app-permissions.spec.ts
@@ -247,17 +247,17 @@ describe('managed appPermissions apply + enforce (P3 Phase 2)', () => {
     expect(r.blockedByLabel).toContain('Panic mode');
   });
 
-  it('deferReview (inline ask) DEFERS an app-perm review to the agent prompt (v2)', async () => {
-    // v1 excluded app-perm reviews from inline-ask. v2 removes the exclusion:
-    // an org-set `review` means "the dev decides" — inline is the dev's seat.
-    // (Full v2 guard matrix: inline-ask-v2-defer.spec.ts.)
+  it('app-perm review takes the approver race — the gateway (the only serverKey producer) never defers', async () => {
+    // Test-honesty (/code-review round 2): deferReview is set ONLY by check.ts
+    // (agent hooks), whose meta never carries serverKey; the mcp-gateway
+    // carries serverKey but passes no deferReview (JSON-RPC has no ask
+    // channel). This is the real caller shape — see inline-ask-v2-defer.spec.
     const r = await authorizeHeadless(
       'edit_file',
       { path: '/x' },
-      { agent: 'MCP-Gateway', serverKey: 'srv1' },
-      { deferReview: true }
+      { agent: 'MCP-Gateway', serverKey: 'srv1' }
     );
-    expect(r.review).toBe(true);
+    expect(r.review).not.toBe(true);
     expect(r.approved).toBe(false);
   });
 

--- a/src/__tests__/app-permissions.spec.ts
+++ b/src/__tests__/app-permissions.spec.ts
@@ -247,14 +247,17 @@ describe('managed appPermissions apply + enforce (P3 Phase 2)', () => {
     expect(r.blockedByLabel).toContain('Panic mode');
   });
 
-  it('deferReview (inline ask) is EXCLUDED for app-perm reviews', async () => {
+  it('deferReview (inline ask) DEFERS an app-perm review to the agent prompt (v2)', async () => {
+    // v1 excluded app-perm reviews from inline-ask. v2 removes the exclusion:
+    // an org-set `review` means "the dev decides" — inline is the dev's seat.
+    // (Full v2 guard matrix: inline-ask-v2-defer.spec.ts.)
     const r = await authorizeHeadless(
       'edit_file',
       { path: '/x' },
       { agent: 'MCP-Gateway', serverKey: 'srv1' },
       { deferReview: true }
     );
-    expect(r.review).not.toBe(true); // must not hand the prompt to the agent
+    expect(r.review).toBe(true);
     expect(r.approved).toBe(false);
   });
 

--- a/src/__tests__/audit-decision.unit.test.ts
+++ b/src/__tests__/audit-decision.unit.test.ts
@@ -32,6 +32,9 @@ const LIVE_PAIRS: Array<[string | null, string, string, string]> = [
   ['auto-deny', 'daemon', 'deny', 'Denied'], //                        11
   ['mcp-discovered', 'daemon', 'info', 'Info'], //                      5
   ['allowed', 'inline-review-approved', 'allow', 'Approved'], //        1
+  // inline-ask v2: the SHIPPABLE outcome row (log.ts) — an explicit human
+  // approval must classify as Approved, not Auto-allowed.
+  ['allow', 'inline-review', 'allow', 'Approved'],
 ];
 
 describe('classifyDecision — every pair in a real log', () => {
@@ -120,7 +123,7 @@ describe('robustness', () => {
       const o = classifyDecision(d, cb).outcome;
       counts[o] = (counts[o] ?? 0) + 1;
     }
-    expect(counts).toEqual({ allow: 7, deny: 12, observe: 3, info: 2 });
+    expect(counts).toEqual({ allow: 8, deny: 12, observe: 3, info: 2 }); // +1: inline-review (v2)
     expect(counts.unknown).toBeUndefined();
   });
 });

--- a/src/__tests__/audit-shipper.unit.test.ts
+++ b/src/__tests__/audit-shipper.unit.test.ts
@@ -73,6 +73,26 @@ describe('buildWireRows', () => {
     expect(rows[0].checkedBy).toBe('local-policy');
   });
 
+  it('ships the inline-review outcome row; still skips the raw post-hook row (v2)', () => {
+    // Inline-ask v2: the dev's inline approve must reach the dashboard. log.ts
+    // writes a standard decision row (eid + allow + checkedBy:'inline-review');
+    // the legacy post-hook row (decision:'allowed', no eid) stays local-only.
+    const content =
+      row({ checkedBy: 'inline-review', ruleName: '⚠️ Smart Rule (review-git-push)' }) +
+      JSON.stringify({
+        ts: '2026-07-25T00:00:00Z',
+        tool: 'bash',
+        args: { command: 'git push' },
+        decision: 'allowed', // post-hook shape — not a wire decision
+        source: 'inline-review-approved',
+      }) +
+      '\n';
+    const { rows } = buildWireRows(Buffer.from(content));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].checkedBy).toBe('inline-review');
+    expect(rows[0].ruleName).toBe('⚠️ Smart Rule (review-git-push)');
+  });
+
   it('ships cloud-linked rows WITH cloudRequestId so the BE enriches its origin row', () => {
     // Any request that opened a pending cloud entry already has a BE-origin
     // AuditLog row. Shipping the local row with its cloudRequestId lets the

--- a/src/__tests__/check.integration.test.ts
+++ b/src/__tests__/check.integration.test.ts
@@ -754,6 +754,47 @@ describe('inline-ask (--ask routes review verdicts to the agent prompt)', () => 
     expect(body.hookSpecificOutput.permissionDecision).toBe('ask');
   });
 
+  it('ADMIN-SET reviewChannel:"approver" beats a local --ask flag (org lever not defeatable)', () => {
+    // /code-review fix: the managed value is the org's routing lever and the
+    // documented v2 rollback — a per-machine hook edit must not override it.
+    cleanupHome(tmpHome);
+    tmpHome = makeTempHome({
+      settings: {
+        mode: 'standard',
+        autoStartDaemon: false,
+        approvalTimeoutMs: 0,
+        approvers: { native: false, browser: false, cloud: true, terminal: false },
+      },
+      policy: { smartRules: [reviewRule] },
+    });
+    fs.writeFileSync(
+      path.join(tmpHome, '.node9', 'rules-cache.json'),
+      JSON.stringify({
+        fetchedAt: '2026-07-01T00:00:00Z',
+        rules: [],
+        managedConfig: { reviewChannel: 'approver', locked: [] },
+      })
+    );
+    const r = runCheckArgs(['--ask'], claudePayload, { HOME: tmpHome });
+    expect(r.stdout).not.toContain('"permissionDecision":"ask"');
+  });
+
+  it('LOCAL reviewChannel:"approver" is still overridable by --ask (debug lever intact)', () => {
+    cleanupHome(tmpHome);
+    tmpHome = makeTempHome({
+      settings: {
+        mode: 'standard',
+        autoStartDaemon: false,
+        approvalTimeoutMs: 0,
+        reviewChannel: 'approver',
+        approvers: { native: false, browser: false, cloud: false, terminal: false },
+      },
+      policy: { smartRules: [reviewRule] },
+    });
+    const r = runCheckArgs(['--ask'], claudePayload, { HOME: tmpHome });
+    expect(r.stdout).toContain('"permissionDecision":"ask"');
+  });
+
   it('Codex WITHOUT --ask → no ask (default-on must NOT leak to fail-open agents)', () => {
     const codexPayload = {
       turn_id: 't1',

--- a/src/__tests__/check.integration.test.ts
+++ b/src/__tests__/check.integration.test.ts
@@ -732,7 +732,10 @@ describe('inline-ask (--ask routes review verdicts to the agent prompt)', () => 
     expect(r.stdout).not.toContain('"permissionDecision":"ask"');
   });
 
-  it('cloud approver configured → no ask (carve-out: never bypass routed approval)', () => {
+  it('cloud approver configured → ask STILL fires (v2: cloud is the record, not a gate)', () => {
+    // v1 carved cloud-enforced setups out of inline-ask. v2 (review-ask-inline-
+    // v2-spec.md) deletes that veto: review = the dev decides, inline; the SaaS
+    // receives the outcome as audit instead of gating the review.
     cleanupHome(tmpHome);
     tmpHome = makeTempHome({
       settings: {
@@ -744,7 +747,11 @@ describe('inline-ask (--ask routes review verdicts to the agent prompt)', () => 
       policy: { smartRules: [reviewRule] },
     });
     const r = runCheckArgs([], claudePayload, { HOME: tmpHome });
-    expect(r.stdout).not.toContain('"permissionDecision":"ask"');
+    expect(r.status).toBe(0);
+    const body = JSON.parse(r.stdout.trim()) as {
+      hookSpecificOutput: { permissionDecision: string };
+    };
+    expect(body.hookSpecificOutput.permissionDecision).toBe('ask');
   });
 
   it('Codex WITHOUT --ask → no ask (default-on must NOT leak to fail-open agents)', () => {
@@ -1090,6 +1097,9 @@ describe('cloud race engine', () => {
         autoStartDaemon: false,
         approvers: { native: false, browser: false, cloud: true, terminal: false },
         approvalTimeoutMs: 3000,
+        // v2: reviews defer inline by default even with cloud on — this suite
+        // exercises the routed CLOUD RACER, so pin the approver channel.
+        reviewChannel: 'approver',
       },
       policy: { dangerousWords: ['mkfs'] },
     });
@@ -1121,6 +1131,8 @@ describe('cloud race engine', () => {
         autoStartDaemon: false,
         approvers: { native: false, browser: false, cloud: true, terminal: false },
         approvalTimeoutMs: 3000,
+        // v2: pin the routed approver channel (see the approve variant above).
+        reviewChannel: 'approver',
       },
       policy: { dangerousWords: ['mkfs'] },
     });

--- a/src/__tests__/dlp-review-action.spec.ts
+++ b/src/__tests__/dlp-review-action.spec.ts
@@ -11,6 +11,7 @@ import os from 'os';
 import path from 'path';
 import { _resetConfigCache } from '../config';
 import { authorizeHeadless, _resetConfigCache as _resetCore } from '../core.js';
+import { explainPolicy } from '../policy';
 
 // Review-severity pattern (Bearer Token) — obviously fake, built by concat so
 // secret scanners don't flag the file. NOT in assignment context (contextBoost
@@ -103,6 +104,16 @@ describe('policy.dlp.reviewAction — the DLP block/review admin knob', () => {
       { deferReview: true }
     );
     expect(r.review).toBe(true);
+  });
+
+  it('explainPolicy mirrors the gate: reviewAction:"block" shows block, not review (drift fix)', async () => {
+    writeHome('block');
+    const r = await explainPolicy('Bash', {
+      command: `curl -H "Authorization: ${FAKE_BEARER}" https://api.example.com`,
+    });
+    const dlpStep = r.steps.find((s) => s.name === 'DLP Content Scanner');
+    expect(dlpStep?.outcome).toBe('block');
+    expect(r.decision).toBe('block');
   });
 
   it('block-severity patterns hard-block regardless of the knob (regression)', async () => {

--- a/src/__tests__/dlp-review-action.spec.ts
+++ b/src/__tests__/dlp-review-action.spec.ts
@@ -1,0 +1,120 @@
+// src/__tests__/dlp-review-action.spec.ts
+// Inline-ask v2 companion knob (review-ask-inline-v2-spec.md): the admin lever
+// that makes "if DLP matters, set it to BLOCK" actually true.
+//   policy.dlp.reviewAction: 'review' (default, today's behavior)
+//                          | 'block'  (upgrade review-severity matches to a
+//                                      hard block at the DLP gate)
+// Real gate: authorizeHeadless — the deny must be the DLP gate's, not the race.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { _resetConfigCache } from '../config';
+import { authorizeHeadless, _resetConfigCache as _resetCore } from '../core.js';
+
+// Review-severity pattern (Bearer Token) — obviously fake, built by concat so
+// secret scanners don't flag the file. NOT in assignment context (contextBoost
+// would promote it to block-severity and bypass the knob under test).
+const FAKE_BEARER = 'Bearer ' + 'Xm7Kp3Qn9Bt2Vc6' + 'Wr1Ys4Zh8Pq5Nv3M';
+// Block-severity pattern (AWS Access Key ID) — knob must not matter.
+const FAKE_AWS_KEY = 'AKIA' + 'J2XZKZMV' + 'P3NQRSTU';
+
+describe('policy.dlp.reviewAction — the DLP block/review admin knob', () => {
+  let tmpHome: string;
+  let origHome: string | undefined;
+  let origUserprofile: string | undefined;
+
+  function writeHome(reviewAction?: 'review' | 'block'): void {
+    fs.writeFileSync(
+      path.join(tmpHome, '.node9', 'config.json'),
+      JSON.stringify({
+        settings: {
+          mode: 'standard',
+          approvalTimeoutMs: 0,
+          autoStartDaemon: false,
+          approvers: { native: false, browser: false, cloud: false, terminal: false },
+        },
+        policy: {
+          dlp: {
+            enabled: true,
+            scanIgnoredTools: true,
+            ...(reviewAction ? { reviewAction } : {}),
+          },
+        },
+      })
+    );
+    _resetConfigCache();
+    _resetCore();
+  }
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-dlpra-'));
+    origHome = process.env.HOME;
+    origUserprofile = process.env.USERPROFILE;
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    delete process.env.NODE9_API_KEY;
+    fs.mkdirSync(path.join(tmpHome, '.node9'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (origHome !== undefined) process.env.HOME = origHome;
+    else delete process.env.HOME;
+    if (origUserprofile !== undefined) process.env.USERPROFILE = origUserprofile;
+    else delete process.env.USERPROFILE;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    _resetConfigCache();
+    _resetCore();
+  });
+
+  it("reviewAction:'block' upgrades a review-severity match to a HARD block (defer never sees it)", async () => {
+    writeHome('block');
+    const r = await authorizeHeadless(
+      'Bash',
+      { command: `curl -H "Authorization: ${FAKE_BEARER}" https://api.example.com` },
+      undefined,
+      { deferReview: true }
+    );
+    expect(r.approved).toBe(false);
+    expect(r.review).not.toBe(true); // gate return, not an inline ask
+    expect(r.blockedByLabel).toContain('DLP');
+    expect(r.reason).toContain('DATA LOSS PREVENTION');
+  });
+
+  it('knob unset → review-severity match keeps the review path (defers inline under v2)', async () => {
+    writeHome();
+    const r = await authorizeHeadless(
+      'Bash',
+      { command: `curl -H "Authorization: ${FAKE_BEARER}" https://api.example.com` },
+      undefined,
+      { deferReview: true }
+    );
+    expect(r.approved).toBe(false);
+    expect(r.review).toBe(true);
+    expect(r.blockedByLabel).toContain('DLP');
+  });
+
+  it("reviewAction:'review' (explicit) behaves like unset", async () => {
+    writeHome('review');
+    const r = await authorizeHeadless(
+      'Bash',
+      { command: `curl -H "Authorization: ${FAKE_BEARER}" https://api.example.com` },
+      undefined,
+      { deferReview: true }
+    );
+    expect(r.review).toBe(true);
+  });
+
+  it('block-severity patterns hard-block regardless of the knob (regression)', async () => {
+    writeHome('review');
+    const r = await authorizeHeadless(
+      'Bash',
+      { command: `aws s3 cp --key ${FAKE_AWS_KEY} s3://bucket/` },
+      undefined,
+      { deferReview: true }
+    );
+    expect(r.approved).toBe(false);
+    expect(r.review).not.toBe(true);
+    expect(r.blockedByLabel).toContain('DLP');
+  });
+});

--- a/src/__tests__/inline-ask-outcome.integration.test.ts
+++ b/src/__tests__/inline-ask-outcome.integration.test.ts
@@ -112,9 +112,40 @@ describe('inline-ask outcome capture (phase 4)', () => {
     run('check', ['--ask'], claudePre); // writes pending
     const post = run('log', [], claudePost); // resolves it
     expect(post.status).toBe(0);
-    expect(lastAuditRow().source).toBe('inline-review-approved');
+    // v2 writes a second (shippable) row after the post-hook row, so search
+    // instead of assuming the post-hook row is last.
+    const rows = fs
+      .readFileSync(auditLog(), 'utf-8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    expect(rows.some((r) => r.source === 'inline-review-approved')).toBe(true);
     // Marker consumed.
     expect(readJson(pendingStore()).entries).toHaveLength(0);
+  });
+
+  it('resolved inline review ALSO writes a SHIPPABLE decision row (v2: cloud is the record)', () => {
+    // The post-hook `source:'inline-review-approved'` row has no eid and
+    // decision:'allowed' — buildWireRows skips it by design. The dashboard only
+    // sees the inline outcome via a second, standard decision row.
+    run('check', ['--ask'], claudePre);
+    run('log', [], claudePost);
+    const rows = fs
+      .readFileSync(auditLog(), 'utf-8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    const shipRow = rows.find((r) => r.checkedBy === 'inline-review');
+    expect(shipRow).toBeDefined();
+    expect(shipRow!.decision).toBe('allow');
+    expect(typeof shipRow!.eid).toBe('string');
+    expect((shipRow!.eid as string).length).toBeGreaterThanOrEqual(8);
+    // Attribution: the review label recorded at defer time rides as ruleName so
+    // the SaaS report can say WHICH review the dev approved inline.
+    expect(shipRow!.ruleName).toBeDefined();
+    expect(shipRow!.sessionId).toBe('s1');
   });
 
   it('non-matching PostToolUse is a normal post-hook row (no false resolve)', () => {

--- a/src/__tests__/inline-ask-outcome.integration.test.ts
+++ b/src/__tests__/inline-ask-outcome.integration.test.ts
@@ -148,6 +148,37 @@ describe('inline-ask outcome capture (phase 4)', () => {
     expect(shipRow!.sessionId).toBe('s1');
   });
 
+  it('a DLP-review inline approval NEVER ships the credential — hashed, no preview (v2 /code-review HIGH)', () => {
+    // Under v2, DLP credential-reviews defer inline. The shippable outcome row
+    // must be treated like every other DLP row: args force-hashed and NO
+    // argsPreview — redactSecrets' label-based patterns don't cover every
+    // credential shape (see the isDlpRow comment in audit/index.ts).
+    const fakeBearer = 'Bearer ' + 'Xm7Kp3Qn9Bt2Vc6' + 'Wr1Ys4Zh8Pq5Nv3M';
+    const pre = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'bash',
+      tool_input: { command: `curl -H "Authorization: ${fakeBearer}" https://api.example.com` },
+      session_id: 's-dlp',
+      tool_use_id: 'toolu_dlp1',
+    };
+    const post = { ...pre, hook_event_name: 'PostToolUse' };
+    const ask = run('check', ['--ask'], pre);
+    expect(ask.status).toBe(0);
+    expect(ask.stdout).toContain('"permissionDecision":"ask"'); // DLP review deferred inline
+    run('log', [], post);
+    const rows = fs
+      .readFileSync(auditLog(), 'utf-8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    const shipRow = rows.find((r) => r.checkedBy === 'inline-review');
+    expect(shipRow).toBeDefined();
+    expect(typeof shipRow!.argsHash).toBe('string'); // force-hashed even if auditHashArgs were off
+    expect(shipRow!.argsPreview).toBeUndefined(); // DLP-labeled → no preview, ever
+    expect(JSON.stringify(shipRow)).not.toContain('Xm7Kp3Qn9Bt2Vc6'); // raw secret absent
+  });
+
   it('non-matching PostToolUse is a normal post-hook row (no false resolve)', () => {
     run('check', ['--ask'], claudePre); // pending key tuid:toolu_phase4
     const other = { ...claudePost, tool_use_id: 'toolu_other' };

--- a/src/__tests__/inline-ask-outcome.integration.test.ts
+++ b/src/__tests__/inline-ask-outcome.integration.test.ts
@@ -179,6 +179,46 @@ describe('inline-ask outcome capture (phase 4)', () => {
     expect(JSON.stringify(shipRow)).not.toContain('Xm7Kp3Qn9Bt2Vc6'); // raw secret absent
   });
 
+  it('a DENIED Copilot ask never becomes a shipped approval when the same command is later allowed (fabrication fix)', () => {
+    // Copilot has no tool_use_id — the marker key is session|tool|args-hash,
+    // which an identical later command REUSES. Scenario: ask → dev denies (no
+    // hook fires, marker survives) → policy changes (taint expired / rule
+    // removed) → same command runs, allowed on the ordinary path. The PRE-side
+    // discard must remove the stale marker so PostToolUse cannot resolve it
+    // into a fabricated checkedBy:'inline-review' approval row.
+    const copilotPre = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'bash',
+      tool_input: { command: 'git push origin main' },
+      session_id: 'cp-s1',
+    };
+    const ask = run('check', ['--ask', '--agent', 'copilot'], copilotPre);
+    expect(ask.status).toBe(0);
+    expect(ask.stdout).toContain('"permissionDecision":"ask"');
+    expect(readJson(pendingStore()).entries).toHaveLength(1); // marker recorded; dev "denies" (no hook)
+
+    // The review rule disappears (stand-in for taint expiry / rule change) —
+    // the same command is now plainly allowed.
+    const cfgPath = path.join(tmpHome, '.node9', 'config.json');
+    const cfg = readJson(cfgPath);
+    cfg.policy.smartRules = [];
+    fs.writeFileSync(cfgPath, JSON.stringify(cfg));
+
+    const allowed = run('check', ['--ask', '--agent', 'copilot'], copilotPre);
+    expect(allowed.status).toBe(0);
+    expect(allowed.stdout).not.toContain('"permissionDecision":"ask"');
+
+    run('log', ['--agent', 'copilot'], { ...copilotPre, hook_event_name: 'PostToolUse' });
+    const rows = fs
+      .readFileSync(auditLog(), 'utf-8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    expect(rows.some((r) => r.checkedBy === 'inline-review')).toBe(false); // no fabricated approval
+    expect(readJson(pendingStore()).entries).toHaveLength(0); // stale marker discarded at PRE time
+  });
+
   it('non-matching PostToolUse is a normal post-hook row (no false resolve)', () => {
     run('check', ['--ask'], claudePre); // pending key tuid:toolu_phase4
     const other = { ...claudePost, tool_use_id: 'toolu_other' };

--- a/src/__tests__/inline-ask-v2-defer.spec.ts
+++ b/src/__tests__/inline-ask-v2-defer.spec.ts
@@ -121,20 +121,23 @@ describe('inline-ask v2: the defer guard has ONE exclusion (downgraded hard bloc
     expect(mockInitSaaS).not.toHaveBeenCalled();
   });
 
-  it('APP-PERMISSION review → defers inline, and the prompt reason names the tool', async () => {
+  it('APP-PERMISSION review: the REAL caller (mcp-gateway) never defers — it races', async () => {
+    // Test-honesty fix (/code-review round 2): the ONLY producer of serverKey
+    // is src/mcp-gateway/index.ts, and it does NOT pass deferReview — the
+    // gateway answers JSON-RPC and has no inline-ask channel to render. So
+    // "app-perm reviews defer inline" is principle-level only; in production
+    // they always take the approver race. This pins the real caller shape
+    // (per CLAUDE.md: tests must use the inputs the real caller produces).
     writeHome({ appPermissions: { srv1: { edit_file: 'review' } } });
     const r = await authorizeHeadless(
       'edit_file',
       { path: '/x' },
-      { agent: 'MCP-Gateway', serverKey: 'srv1' },
-      { deferReview: true }
+      { agent: 'MCP-Gateway', serverKey: 'srv1' }
+      // no options — the gateway passes none
     );
-    expect(r.review).toBe(true);
+    expect(r.review).not.toBe(true);
     expect(r.approved).toBe(false);
-    // The dev must see WHY in the inline prompt — the workspace-policy sentence
-    // rides on reason (v1 returned only the label).
-    expect(r.reason).toContain('edit_file');
-    expect(r.reason).toContain('human approval');
+    expect(r.noApprovalMechanism).toBe(true); // reached the race, no channel in tests
   });
 
   it('SESSION-TAINT review → defers inline, and the prompt reason carries the taint sentence', async () => {

--- a/src/__tests__/inline-ask-v2-defer.spec.ts
+++ b/src/__tests__/inline-ask-v2-defer.spec.ts
@@ -1,0 +1,188 @@
+// src/__tests__/inline-ask-v2-defer.spec.ts
+// Inline-ask v2 — "block = stop, review = the dev decides, inline is the dev's
+// seat" (review-ask-inline-v2-spec.md). The defer guard keeps EXACTLY ONE
+// exclusion: a DOWNGRADED HARD BLOCK (F1d — an intrinsic block softened only
+// because a human is reachable is not an admin-chosen review; "block = stop"
+// keeps it on the routed approver). The v1 exclusions — cloud-enforced, taint,
+// app-permission review — are deliberately removed: those ARE admin/detector
+// review verdicts, and review means the dev reviews, inline.
+//
+// Real gate: authorizeHeadless (feedback_verify_at_real_gate). Downgraded-block
+// regression coverage lives in shield-block-downgrade-realgate.spec.ts Test F.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { _resetConfigCache } from '../config';
+import { authorizeHeadless, _resetConfigCache as _resetCore } from '../core.js';
+import { buildReviewMessage } from '../policy/negotiation';
+
+const { mockInitSaaS, mockPollSaaS, mockSessionTaint } = vi.hoisted(() => ({
+  mockInitSaaS: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ pending: false })),
+  mockPollSaaS: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ approved: false })),
+  mockSessionTaint: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ tainted: false })),
+}));
+vi.mock('../auth/cloud', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../auth/cloud')>()),
+  initNode9SaaS: (...a: unknown[]) => mockInitSaaS(...a),
+  pollNode9SaaS: (...a: unknown[]) => mockPollSaaS(...a),
+  resolveNode9SaaS: vi.fn(async () => undefined),
+}));
+vi.mock('../auth/daemon', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../auth/daemon')>()),
+  // Session-taint is daemon-served; mock the client so the taint test doesn't
+  // need a live daemon. isDaemonRunning stays real (no daemon in tests → the
+  // race, if ever reached, has no channels and denies fast).
+  checkSessionTaint: (...a: unknown[]) => mockSessionTaint(...a),
+}));
+
+describe('inline-ask v2: the defer guard has ONE exclusion (downgraded hard block)', () => {
+  let tmpHome: string;
+  let origHome: string | undefined;
+  let origUserprofile: string | undefined;
+
+  const reviewGitPushRule = {
+    name: 'review-git-push',
+    tool: 'bash',
+    conditions: [{ field: 'command', op: 'matches', value: '\\bgit\\b.*\\bpush\\b' }],
+    conditionMode: 'all',
+    verdict: 'review',
+    reason: 'git push sends changes to a shared remote',
+  };
+
+  function writeHome(opts: { cloud?: boolean; appPermissions?: Record<string, unknown> }): void {
+    fs.writeFileSync(
+      path.join(tmpHome, '.node9', 'config.json'),
+      JSON.stringify({
+        settings: {
+          mode: 'standard',
+          approvalTimeoutMs: 0,
+          autoStartDaemon: false,
+          approvers: {
+            native: false,
+            browser: false,
+            cloud: opts.cloud === true,
+            terminal: false,
+          },
+        },
+        policy: { smartRules: [reviewGitPushRule] },
+      })
+    );
+    fs.writeFileSync(
+      path.join(tmpHome, '.node9', 'rules-cache.json'),
+      JSON.stringify({
+        fetchedAt: '2026-07-01T00:00:00Z',
+        rules: [],
+        managedConfig: {
+          ...(opts.appPermissions ? { appPermissions: opts.appPermissions } : {}),
+          locked: [],
+        },
+      })
+    );
+    _resetConfigCache();
+    _resetCore();
+  }
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-askv2-'));
+    origHome = process.env.HOME;
+    origUserprofile = process.env.USERPROFILE;
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    delete process.env.NODE9_API_KEY;
+    fs.mkdirSync(path.join(tmpHome, '.node9'), { recursive: true });
+    mockInitSaaS.mockClear();
+    mockInitSaaS.mockResolvedValue({ pending: false });
+    mockPollSaaS.mockResolvedValue({ approved: false });
+    mockSessionTaint.mockResolvedValue({ tainted: false });
+  });
+
+  afterEach(() => {
+    if (origHome !== undefined) process.env.HOME = origHome;
+    else delete process.env.HOME;
+    if (origUserprofile !== undefined) process.env.USERPROFILE = origUserprofile;
+    else delete process.env.USERPROFILE;
+    delete process.env.NODE9_API_KEY;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    _resetConfigCache();
+    _resetCore();
+  });
+
+  it('CLOUD-ENFORCED + ordinary review → defers inline; no SaaS pending entry is created', async () => {
+    writeHome({ cloud: true });
+    process.env.NODE9_API_KEY = 'nk_test_v2';
+    const r = await authorizeHeadless('Bash', { command: 'git push origin dev' }, undefined, {
+      deferReview: true,
+    });
+    expect(r.review).toBe(true);
+    expect(r.approved).toBe(false);
+    // The defer short-circuits BEFORE the handshake — an /intercept pending
+    // entry would orphan in the dashboard/Slack.
+    expect(mockInitSaaS).not.toHaveBeenCalled();
+  });
+
+  it('APP-PERMISSION review → defers inline, and the prompt reason names the tool', async () => {
+    writeHome({ appPermissions: { srv1: { edit_file: 'review' } } });
+    const r = await authorizeHeadless(
+      'edit_file',
+      { path: '/x' },
+      { agent: 'MCP-Gateway', serverKey: 'srv1' },
+      { deferReview: true }
+    );
+    expect(r.review).toBe(true);
+    expect(r.approved).toBe(false);
+    // The dev must see WHY in the inline prompt — the workspace-policy sentence
+    // rides on reason (v1 returned only the label).
+    expect(r.reason).toContain('edit_file');
+    expect(r.reason).toContain('human approval');
+  });
+
+  it('SESSION-TAINT review → defers inline, and the prompt reason carries the taint sentence', async () => {
+    writeHome({});
+    mockSessionTaint.mockResolvedValue({
+      tainted: true,
+      record: { source: 'a GitHub token (DLP:github-token)' },
+    });
+    const r = await authorizeHeadless(
+      'write_file',
+      { path: '/tmp/out.txt', content: 'x' },
+      { sessionId: 'sess-taint-1' },
+      { deferReview: true }
+    );
+    expect(r.review).toBe(true);
+    expect(r.approved).toBe(false);
+    expect(r.reason).toContain('flagged this session');
+  });
+
+  it('the rendered ask message carries the reason sentence (taint/app-perm context)', () => {
+    // sendAsk (check.ts) renders via buildReviewMessage — the defer return's
+    // reason must survive into the prompt text, not just the orchestrator result.
+    const msg = buildReviewMessage(
+      '🔒 Node9 App Permission (Review)',
+      undefined,
+      'App permission: "edit_file" requires human approval (workspace policy).'
+    );
+    expect(msg).toContain('edit_file');
+    expect(msg).toContain('human approval');
+    // A rule's own description still wins when present (unchanged v1 behavior).
+    const ruleMsg = buildReviewMessage('label', 'git push sends changes to a shared remote', 'x');
+    expect(ruleMsg).toContain('shared remote');
+  });
+
+  it('PANIC MODE still upgrades review → hard block; defer never sees it (regression)', async () => {
+    writeHome({ cloud: false });
+    const cache = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, '.node9', 'rules-cache.json'), 'utf-8')
+    ) as Record<string, unknown>;
+    cache.panicMode = true;
+    fs.writeFileSync(path.join(tmpHome, '.node9', 'rules-cache.json'), JSON.stringify(cache));
+    _resetConfigCache();
+    _resetCore();
+    const r = await authorizeHeadless('Bash', { command: 'git push origin dev' }, undefined, {
+      deferReview: true,
+    });
+    expect(r.approved).toBe(false);
+    expect(r.review).not.toBe(true); // gate return, not a deferred ask
+    expect(r.blockedByLabel).toContain('Panic mode');
+  });
+});

--- a/src/__tests__/inline-review-count.unit.test.ts
+++ b/src/__tests__/inline-review-count.unit.test.ts
@@ -1,0 +1,72 @@
+// src/__tests__/inline-review-count.unit.test.ts
+// /code-review round-2 fix: an inline-approved tool call writes TWO rows into
+// audit.log — the PostToolUse execution record (source:'inline-review-approved',
+// no eid) and the shippable decision row (checkedBy:'inline-review'). Every
+// local counter must count that call ONCE: readers share NON_DECISION_SOURCES
+// (audit/decision.ts) instead of four hand-copied 'post-hook' filters.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { aggregateReportFromAudit } from '../cli/aggregate/report-audit';
+import { NON_DECISION_SOURCES } from '../audit/decision';
+
+describe('inline-approved call counts once in node9 report', () => {
+  let tmpHome: string;
+  let auditLogPath: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-inlinecount-'));
+    auditLogPath = path.join(tmpHome, '.node9', 'audit.log');
+    vi.spyOn(os, 'homedir').mockReturnValue(tmpHome);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('the execution record + the decision row = ONE counted action', () => {
+    const ts = '2026-06-01T12:00:00.000Z';
+    fs.mkdirSync(path.dirname(auditLogPath), { recursive: true });
+    // Exactly what log.ts writes for one inline-approved `git push`:
+    const rows = [
+      // 1. shippable decision row (has eid, checkedBy 'inline-review', no source)
+      {
+        eid: 'ms0-testeid12345',
+        ts,
+        tool: 'Bash',
+        argsHash: 'abc',
+        decision: 'allow',
+        checkedBy: 'inline-review',
+        ruleName: 'Smart Rule: review-git-push',
+        agent: 'Claude Code',
+        sessionId: 's1',
+      },
+      // 2. the raw PostToolUse execution record (eid-less, source-tagged)
+      {
+        ts,
+        tool: 'Bash',
+        args: { command: 'git push origin main' },
+        decision: 'allowed',
+        source: 'inline-review-approved',
+        agent: 'Claude Code',
+        sessionId: 's1',
+      },
+    ];
+    fs.writeFileSync(auditLogPath, rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+
+    const { data: report } = aggregateReportFromAudit('90d', {
+      now: new Date('2026-06-02T00:00:00.000Z'),
+      auditLogPath,
+    });
+    expect(report.total).toBe(1);
+    expect(report.toolMap.get('Bash')?.calls).toBe(1);
+  });
+
+  it('NON_DECISION_SOURCES covers all three execution/finding source values', () => {
+    expect(NON_DECISION_SOURCES.has('post-hook')).toBe(true);
+    expect(NON_DECISION_SOURCES.has('inline-review-approved')).toBe(true);
+    expect(NON_DECISION_SOURCES.has('response-dlp')).toBe(true);
+  });
+});

--- a/src/__tests__/managed.test.ts
+++ b/src/__tests__/managed.test.ts
@@ -25,7 +25,7 @@ const localEgress = (
   ...over,
 });
 
-const localDlp = (over: Partial<{ enabled: boolean; pii: string }> = {}) => ({
+const localDlp = (over: Partial<{ enabled: boolean; pii: string; reviewAction: string }> = {}) => ({
   enabled: true,
   scanIgnoredTools: true,
   pii: 'off' as string,
@@ -182,6 +182,34 @@ describe('managed dlp (baseline+lock) — M2c', () => {
   it('ignores an unrankable managed pii', () => {
     expect(applyManagedDlp(localDlp({ pii: 'block' }), { pii: 'garbage' }, []).pii).toBe('block');
   });
+
+  // reviewAction (inline-ask v2): floor over review<block — the org's 'block'
+  // can't be loosened locally; a member may tighten a cloud 'review' to block.
+  it('reviewAction: raises review → block (the cloud floor)', () => {
+    expect(applyManagedDlp(localDlp(), { reviewAction: 'block' }, []).reviewAction).toBe('block');
+  });
+
+  it('reviewAction: keeps a stricter local block over a cloud review', () => {
+    expect(
+      applyManagedDlp(localDlp({ reviewAction: 'block' }), { reviewAction: 'review' }, [])
+        .reviewAction
+    ).toBe('block');
+  });
+
+  it('reviewAction: a locked value wins over a stricter local', () => {
+    expect(
+      applyManagedDlp(localDlp({ reviewAction: 'block' }), { reviewAction: 'review' }, [
+        'dlpReviewAction',
+      ]).reviewAction
+    ).toBe('review');
+  });
+
+  it('reviewAction: ignores an unrankable managed value', () => {
+    expect(
+      applyManagedDlp(localDlp({ reviewAction: 'block' }), { reviewAction: 'garbage' }, [])
+        .reviewAction
+    ).toBe('block');
+  });
 });
 
 describe('managed approvers (Preferences)', () => {
@@ -208,6 +236,17 @@ describe('extractManagedConfig — reviewChannel + approvalTimeoutMs (Preference
     });
     expect(out?.reviewChannel).toBe('ask');
     expect(out?.approvalTimeoutMs).toBe(30000);
+  });
+
+  it('keeps dlp.reviewAction only when it is a legal value (inline-ask v2)', () => {
+    const out = extractManagedConfig({
+      managedConfig: { dlp: { reviewAction: 'block' }, locked: [] },
+    });
+    expect(out?.dlp?.reviewAction).toBe('block');
+    const junk = extractManagedConfig({
+      managedConfig: { dlp: { reviewAction: 'nuke-it' }, locked: [] },
+    });
+    expect(junk?.dlp?.reviewAction).toBeUndefined();
   });
 
   it('keeps a valid injectionScan (coerced to known fields)', () => {

--- a/src/__tests__/redactor.test.ts
+++ b/src/__tests__/redactor.test.ts
@@ -42,4 +42,21 @@ describe('redactSecrets', () => {
     const output = redactSecrets(input);
     expect(output).toContain('Bearer ********');
   });
+
+  it('keeps JSON-escaped text PARSEABLE after redaction (audit-gap regression)', () => {
+    // log.ts does JSON.parse(redactSecrets(JSON.stringify(rawInput))). The old
+    // token class included `\\`, so it consumed the escaping backslash of a
+    // trailing `\"` — the parse threw and the ENTIRE audit row was skipped for
+    // any executed call carrying an Authorization header. The round-trip is
+    // the contract, not just the masking.
+    const obj = {
+      command:
+        'curl -H "Authorization: Bearer Xm7Kp3Qn9Bt2Vc6Wr1Ys4Zh8Pq5Nv3M" https://api.example.com',
+    };
+    const output = redactSecrets(JSON.stringify(obj));
+    const parsed = JSON.parse(output) as { command: string }; // must not throw
+    expect(parsed.command).toContain('Bearer ********');
+    expect(parsed.command).toContain('https://api.example.com'); // tail survives
+    expect(output).not.toContain('Xm7Kp3Qn9Bt2Vc6');
+  });
 });

--- a/src/__tests__/review-pending.spec.ts
+++ b/src/__tests__/review-pending.spec.ts
@@ -6,7 +6,12 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { reviewCorrelationKey, recordPendingReview, resolvePendingReview } from '../review-pending';
+import {
+  reviewCorrelationKey,
+  recordPendingReview,
+  resolvePendingReview,
+  discardPendingReview,
+} from '../review-pending';
 
 let store: string;
 beforeEach(() => {
@@ -115,5 +120,24 @@ describe('prune', () => {
     recordPendingReview({ key: 'h:s1|Bash|abc', tool: 'Bash', ts: now - 7 * 60 * 60 * 1000 });
     resolvePendingReview('something-else', now);
     expect(resolvePendingReview('h:s1|Bash|abc', now)).toBeNull();
+  });
+
+  it('an EXPIRED entry never resolves even when matched directly (no prune ran first)', () => {
+    // /code-review fix: findIndex used to match BEFORE pruning, so an expired
+    // marker still resolved if its key was hit first — turning a long-stale
+    // (possibly denied) ask into a shipped "approved inline" row.
+    const now = Date.now();
+    recordPendingReview({ key: 'h:s1|Bash|stale', tool: 'Bash', ts: now - 7 * 60 * 60 * 1000 });
+    expect(resolvePendingReview('h:s1|Bash|stale', now)).toBeNull();
+    recordPendingReview({ key: 'tuid:stale', tool: 'Bash', ts: now - 73 * 60 * 60 * 1000 });
+    expect(resolvePendingReview('tuid:stale', now)).toBeNull();
+  });
+
+  it('discardPendingReview removes ALL entries for a key (decision by another channel supersedes)', () => {
+    const now = Date.now();
+    recordPendingReview({ key: 'h:s1|Bash|x', tool: 'Bash', ts: now - 1000 });
+    recordPendingReview({ key: 'h:s1|Bash|x', tool: 'Bash', ts: now - 500 });
+    discardPendingReview('h:s1|Bash|x');
+    expect(resolvePendingReview('h:s1|Bash|x', now)).toBeNull();
   });
 });

--- a/src/__tests__/review-pending.spec.ts
+++ b/src/__tests__/review-pending.spec.ts
@@ -91,4 +91,29 @@ describe('prune', () => {
     resolvePendingReview('something-else', now);
     expect(resolvePendingReview('old', now)).toBeNull();
   });
+
+  // /code-review fix: per-key TTL. tuid: keys are collision-proof (a
+  // tool_use_id never matches a DIFFERENT call), so an over-a-work-gap approval
+  // (Friday ask → Monday approve, 63h) must survive intervening prunes — losing
+  // the marker silently loses the shipped inline-review outcome row.
+  it('a tuid: marker survives a work-gap (63h) despite intervening prunes', () => {
+    const now = Date.now();
+    recordPendingReview({ key: 'tuid:friday', tool: 'Bash', ts: now - 63 * 60 * 60 * 1000 });
+    resolvePendingReview('something-else', now); // intervening prune-on-miss
+    expect(resolvePendingReview('tuid:friday', now)?.key).toBe('tuid:friday');
+  });
+
+  it('a tuid: marker still expires past 72h', () => {
+    const now = Date.now();
+    recordPendingReview({ key: 'tuid:ancient', tool: 'Bash', ts: now - 73 * 60 * 60 * 1000 });
+    resolvePendingReview('something-else', now);
+    expect(resolvePendingReview('tuid:ancient', now)).toBeNull();
+  });
+
+  it('heuristic (h:) keys keep the tight 6h TTL — bounds Copilot stale-marker misattribution', () => {
+    const now = Date.now();
+    recordPendingReview({ key: 'h:s1|Bash|abc', tool: 'Bash', ts: now - 7 * 60 * 60 * 1000 });
+    resolvePendingReview('something-else', now);
+    expect(resolvePendingReview('h:s1|Bash|abc', now)).toBeNull();
+  });
 });

--- a/src/audit/decision.ts
+++ b/src/audit/decision.ts
@@ -55,6 +55,23 @@ const HUMAN_SOURCES = new Set([
 
 const TIMEOUT_SOURCES = new Set(['timeout']);
 
+/**
+ * `source` values that mark a row as an EXECUTION/finding record, not a
+ * PreToolUse decision. Every local counter (report, TUI, daemon stats) must
+ * drop these or a single tool call counts twice:
+ *   - 'post-hook'              — the PostToolUse execution record
+ *   - 'inline-review-approved' — the SAME record when it resolved an inline
+ *     ask (v2 also writes a separate eid-bearing decision row alongside it)
+ *   - 'response-dlp'           — an output-scan finding, not a call
+ * ONE set shared by all readers (/code-review fix: four hand-copied filters
+ * each knew about two of the three values).
+ */
+export const NON_DECISION_SOURCES = new Set([
+  'post-hook',
+  'inline-review-approved',
+  'response-dlp',
+]);
+
 const has = (s: string, needle: string) => s.includes(needle);
 
 /** The subset of an audit row this needs. Anything row-shaped satisfies it. */

--- a/src/audit/decision.ts
+++ b/src/audit/decision.ts
@@ -43,7 +43,15 @@ export interface DecisionView {
 }
 
 /** checkedBy values meaning a HUMAN made the call (vs a rule firing). */
-const HUMAN_SOURCES = new Set(['daemon', 'cloud', 'local-decision', 'inline-review-approved']);
+// 'inline-review' = the v2 shippable outcome row (log.ts): the dev explicitly
+// approved the agent's inline ask — a human decision, not an auto-allow.
+const HUMAN_SOURCES = new Set([
+  'daemon',
+  'cloud',
+  'local-decision',
+  'inline-review-approved',
+  'inline-review',
+]);
 
 const TIMEOUT_SOURCES = new Set(['timeout']);
 

--- a/src/audit/index.ts
+++ b/src/audit/index.ts
@@ -35,8 +35,14 @@ export function redactSecrets(text: string): string {
   let redacted = text;
 
   // Refined Patterns: Only redact when attached to a known label to avoid masking hashes/paths
+  // NOTE: no backslash in the token class. This runs on JSON-STRINGIFIED text
+  // (log.ts wraps rawInput), where a trailing `\"` is an escape sequence — a
+  // class with `\\` consumed the escaping backslash and produced unparseable
+  // JSON, silently skipping the ENTIRE audit row for any executed call whose
+  // args contained an Authorization header (pre-existing audit gap, found by
+  // the inline-ask v2 /code-review). Real tokens never contain backslashes.
   redacted = redacted.replace(
-    /(authorization:\s*(?:bearer|basic)\s+)[a-zA-Z0-9._\-\/\\=]+/gi,
+    /(authorization:\s*(?:bearer|basic)\s+)[a-zA-Z0-9._\-\/=]+/gi,
     '$1********'
   );
   redacted = redacted.replace(
@@ -187,7 +193,13 @@ export function appendLocalAudit(
   // and redactSecrets' label-based patterns don't cover every credential
   // shape (a bare AWS key leaked through in testing). Gate on checkedBy —
   // intrinsic to every call site — not just the optional dlpPattern meta.
-  const isDlpRow = checkedBy.toLowerCase().includes('dlp') || Boolean(meta?.dlpPattern);
+  // ruleName is checked too (inline-ask v2): an 'inline-review' outcome row
+  // carries the review label as ruleName — a DLP/taint-flagged review means
+  // the args may contain the very credential that triggered it.
+  const isDlpRow =
+    checkedBy.toLowerCase().includes('dlp') ||
+    Boolean(meta?.dlpPattern) ||
+    /dlp|taint/i.test(String(meta?.ruleName ?? ''));
   const preview = auditHashArgsEnabled && !isDlpRow ? buildArgsPreview(args) : undefined;
   const argsField = auditHashArgsEnabled
     ? { argsHash: hashArgs(args), ...(preview ? { argsPreview: preview } : {}) }

--- a/src/auth/orchestrator.ts
+++ b/src/auth/orchestrator.ts
@@ -467,7 +467,11 @@ async function _authorizeHeadlessCore(
       const dlpReason =
         `🚨 DATA LOSS PREVENTION: ${dlpMatch.patternName} detected in ` +
         `field "${dlpMatch.fieldPath}" (${dlpMatch.redactedSample})`;
-      if (dlpMatch.severity === 'block') {
+      // reviewAction:'block' (review-ask-inline-v2-spec.md): the admin's "if
+      // DLP matters, set it to block" lever — review-severity matches take the
+      // same hard-block path as block-severity ones. Default 'review' keeps
+      // today's behavior (fall through to the review path below).
+      if (dlpMatch.severity === 'block' || config.policy.dlp.reviewAction === 'block') {
         // Always hash args on DLP blocks — the secret must never appear in
         // the audit log. The pattern + redacted sample ride on the local row;
         // the outbox shipper carries them to the SaaS (no decision-time
@@ -1072,30 +1076,31 @@ async function _authorizeHeadlessCore(
   // /intercept pending entry is ever created (which would orphan in the
   // dashboard/Slack). The caller turns this result into the agent's native
   // `permissionDecision:"ask"` prompt.
-  //   - Excludes taint/exfil reviews (must use the routed approver — self-approval
-  //     is weakest exactly where exfiltration risk is highest).
-  //   - Excludes a DOWNGRADED HARD BLOCK (F1d): an intrinsic block (pipe-chain
-  //     exfil / eval-remote, ruleName-less) softened to review here must use the
-  //     out-of-band approver like taint — same risk class, and the agent's own
-  //     inline prompt is the weakest surface exactly where it matters most.
-  //     `ask` DOES reach a human (so this is hardening, not a fail-open fix), but
-  //     the routed approver is the channel node9 controls and the agent can't spoof.
-  //   - Excludes cloud-enforced setups (safe-by-construction): never bypass the
-  //     SaaS org-policy / routed approval; those keep the handshake + race below.
-  // Set by check.ts (`deferReview: askMode`) for ask-capable agents (Claude Code /
-  // Copilot), default-on for cloud-less setups.
-  const cloudEnforcedForDefer = approvers.cloud && !!creds?.apiKey;
-  if (
-    options?.deferReview &&
-    !hardBlockDowngraded &&
-    !taintWarning &&
-    !appPermReview &&
-    !cloudEnforcedForDefer
-  ) {
+  //
+  // v2 (review-ask-inline-v2-spec.md): block = stop, review = THE DEV DECIDES,
+  // inline is the dev's seat. Every review verdict defers — smart-rule, taint,
+  // DLP credential-review, app-permission — with EXACTLY ONE exclusion:
+  //   - a DOWNGRADED HARD BLOCK (F1d): an intrinsic block (pipe-chain exfil /
+  //     eval-remote) softened to review only because a human is reachable is
+  //     NOT an admin-chosen review verdict — "block = stop" keeps it on the
+  //     routed approver, the channel node9 controls and the agent can't spoof.
+  // The v1 cloud-enforced carve-out is deleted: cloud is the RECORD, not a
+  // gate — the inline outcome ships to the SaaS as audit (checkedBy
+  // 'inline-review' via log.ts); an admin who wants routed approvals sets
+  // managed reviewChannel:'approver' (workspace, one click).
+  // Set by check.ts (`deferReview: askMode`) for ask-capable agents (Claude
+  // Code / Copilot), default-on.
+  if (options?.deferReview && !hardBlockDowngraded) {
     return {
       approved: false,
       review: true,
-      reason: explainableLabel || 'Node9 flagged this action for review.',
+      // The prompt must say WHY: the taint / app-permission sentence beats the
+      // bare label so the dev sees the actual risk context inline.
+      reason:
+        taintWarning ||
+        appPermReview ||
+        explainableLabel ||
+        'Node9 flagged this action for review.',
       ruleDescription: policyRuleDescription,
       blockedByLabel: explainableLabel,
     };

--- a/src/auth/orchestrator.ts
+++ b/src/auth/orchestrator.ts
@@ -1079,7 +1079,10 @@ async function _authorizeHeadlessCore(
   //
   // v2 (review-ask-inline-v2-spec.md): block = stop, review = THE DEV DECIDES,
   // inline is the dev's seat. Every review verdict defers — smart-rule, taint,
-  // DLP credential-review, app-permission — with EXACTLY ONE exclusion:
+  // DLP credential-review — with EXACTLY ONE exclusion. (App-permission
+  // reviews are inline-eligible in PRINCIPLE only: serverKey comes solely from
+  // the mcp-gateway, which passes no deferReview — JSON-RPC has no ask channel
+  // — so in production they always take the race below.)
   //   - a DOWNGRADED HARD BLOCK (F1d): an intrinsic block (pipe-chain exfil /
   //     eval-remote) softened to review only because a human is reachable is
   //     NOT an admin-chosen review verdict — "block = stop" keeps it on the
@@ -1094,13 +1097,10 @@ async function _authorizeHeadlessCore(
     return {
       approved: false,
       review: true,
-      // The prompt must say WHY: the taint / app-permission sentence beats the
-      // bare label so the dev sees the actual risk context inline.
-      reason:
-        taintWarning ||
-        appPermReview ||
-        explainableLabel ||
-        'Node9 flagged this action for review.',
+      // The prompt must say WHY: the taint sentence beats the bare label so
+      // the dev sees the actual risk context inline. (No appPermReview term:
+      // deferReview and serverKey never co-occur in production — see above.)
+      reason: taintWarning || explainableLabel || 'Node9 flagged this action for review.',
       ruleDescription: policyRuleDescription,
       blockedByLabel: explainableLabel,
     };

--- a/src/cli/aggregate/report-audit.ts
+++ b/src/cli/aggregate/report-audit.ts
@@ -24,7 +24,7 @@ import { decodeProjectDirName } from '../../costSync';
 import { pricingFor, normalizeModel } from '../../pricing/litellm';
 import { codexSessionCost } from '../../cost-codex';
 import type { BuildReportJsonInput, ReportPeriod } from '../render/report-json';
-import { classifyDecision } from '../../audit/decision';
+import { classifyDecision, NON_DECISION_SOURCES } from '../../audit/decision';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1105,8 +1105,7 @@ export function aggregateReportFromAudit(
   // scored a higher block RATE in the past than in the present purely by which
   // rows each filter let through.
   const priorEntries = allEntries.filter((e) => {
-    if (e.source === 'post-hook') return false;
-    if (e.source === 'response-dlp') return false;
+    if (typeof e.source === 'string' && NON_DECISION_SOURCES.has(e.source)) return false;
     if (typeof e.decision !== 'string') return false;
     const ts = new Date(e.ts);
     return ts >= priorStart && ts <= priorEnd;
@@ -1119,8 +1118,7 @@ export function aggregateReportFromAudit(
   const testTs = excludeTests ? buildTestTimestamps(allEntries) : new Set<number>();
   let excludedTests = 0;
   const entries = allEntries.filter((e) => {
-    if (e.source === 'post-hook') return false;
-    if (e.source === 'response-dlp') return false;
+    if (typeof e.source === 'string' && NON_DECISION_SOURCES.has(e.source)) return false;
     // Event rows (e.g. {"event":"shield-create"}) carry no decision and are
     // not PreToolUse tool calls — dropping them keeps isAllow(decision) and
     // the bucket loop total-safe on a real, mixed audit log.

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -23,7 +23,11 @@ import {
 import { defaultSkillRoots, resolveUserSkillRoot, verifyAndPinRoots } from '../../skill-pin';
 import { scanArgs } from '../../dlp';
 import { appendLocalAudit } from '../../audit';
-import { reviewCorrelationKey, recordPendingReview } from '../../review-pending';
+import {
+  reviewCorrelationKey,
+  recordPendingReview,
+  discardPendingReview,
+} from '../../review-pending';
 import {
   extractToolName,
   extractToolInput,
@@ -165,12 +169,19 @@ function agentSupportsAsk(agent: string): boolean {
 // prompt (true) vs. node9's own approver (false). Precedence (v2 — the cloud
 // carve-out is deleted, see review-ask-inline-v2-spec.md: cloud is the record,
 // not a gate; admins force routed approval via managed reviewChannel):
-//   1. agent not ask-capable          → approver (false)
-//   2. --ask / --no-ask flag           → wins
-//   3. settings.reviewChannel          → 'ask' | 'approver'
-//   4. default                         → ASK
+//   1. agent not ask-capable            → approver (false)
+//   2. ADMIN-SET (managed) reviewChannel → wins — the org's routing lever (and
+//      the documented v2 rollback) must not be defeatable by a --ask flag in a
+//      per-machine hook registration (/code-review fix)
+//   3. --ask / --no-ask flag             → wins (local/debug override)
+//   4. local settings.reviewChannel      → 'ask' | 'approver'
+//   5. default                           → ASK
 function resolveAskMode(agent: string, opts: { ask?: boolean }, config: Config): boolean {
   if (!agentSupportsAsk(agent)) return false;
+  if (config.settings.reviewChannelManaged === true) {
+    if (config.settings.reviewChannel === 'ask') return true;
+    if (config.settings.reviewChannel === 'approver') return false;
+  }
   if (opts.ask === true) return true;
   if (opts.ask === false) return false;
   if (config.settings.reviewChannel === 'ask') return true;
@@ -877,6 +888,22 @@ export function registerCheckCommand(program: Command): void {
             cwd: safeCwdForAuth,
             deferReview: askMode,
           });
+
+          // A decision by any channel OTHER than an inline defer supersedes any
+          // stale pending-ask marker for this correlation key (/code-review
+          // fix): without this, a Copilot command denied at an earlier inline
+          // ask and later allowed on the ordinary path (taint expired, rule
+          // changed) resolves the old marker in PostToolUse and ships a
+          // fabricated "dev approved inline" row. Claude Code's tuid keys are
+          // per-call unique, so this is a no-op there. Best-effort.
+          if (!result.review) {
+            try {
+              const key = reviewCorrelationKey(payload as Record<string, unknown>);
+              if (key) discardPendingReview(key);
+            } catch {
+              /* marker hygiene must never affect the decision */
+            }
+          }
 
           if (result.approved) {
             // Only write to stderr in debug mode — Claude Code treats any stderr

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -162,16 +162,15 @@ function agentSupportsAsk(agent: string): boolean {
 }
 
 // Whether a `review` verdict for this call is deferred to the agent's inline
-// prompt (true) vs. node9's own approver (false). Precedence:
+// prompt (true) vs. node9's own approver (false). Precedence (v2 — the cloud
+// carve-out is deleted, see review-ask-inline-v2-spec.md: cloud is the record,
+// not a gate; admins force routed approval via managed reviewChannel):
 //   1. agent not ask-capable          → approver (false)
-//   2. cloud approver configured       → approver (v1: never bypass SaaS
-//      org-policy / second-party approval; matches the orchestrator defer guard)
-//   3. --ask / --no-ask flag           → wins
-//   4. settings.reviewChannel          → 'ask' | 'approver'
-//   5. default                         → ASK (cloud already excluded at step 2)
+//   2. --ask / --no-ask flag           → wins
+//   3. settings.reviewChannel          → 'ask' | 'approver'
+//   4. default                         → ASK
 function resolveAskMode(agent: string, opts: { ask?: boolean }, config: Config): boolean {
   if (!agentSupportsAsk(agent)) return false;
-  if (config.settings.approvers.cloud === true) return false;
   if (opts.ask === true) return true;
   if (opts.ask === false) return false;
   if (config.settings.reviewChannel === 'ask') return true;
@@ -625,8 +624,16 @@ export function registerCheckCommand(program: Command): void {
           // Inline-ask: route a `review` verdict to the agent's native approve/deny
           // prompt instead of node9's own approver. Only reached for ask-capable
           // agents (Claude Code / GitHub Copilot) — see resolveAskMode/agentSupportsAsk.
-          const sendAsk = (result: { blockedByLabel?: string; ruleDescription?: string }) => {
-            const msg = buildReviewMessage(result.blockedByLabel, result.ruleDescription);
+          const sendAsk = (result: {
+            blockedByLabel?: string;
+            ruleDescription?: string;
+            reason?: string;
+          }) => {
+            const msg = buildReviewMessage(
+              result.blockedByLabel,
+              result.ruleDescription,
+              result.reason
+            );
             // Phase 4: record a pending-review marker so the matching PostToolUse can
             // capture the approve outcome. Best-effort — never block the ask emit.
             try {
@@ -880,8 +887,9 @@ export function registerCheckCommand(program: Command): void {
           }
 
           // Inline-ask: a deferred review → hand the approve/deny prompt to the
-          // agent (only set when askMode + ask-capable agent; orchestrator excludes
-          // taint/cloud paths by construction). Must precede the block path below.
+          // agent (only set when askMode + ask-capable agent; v2 defers every
+          // review verdict except a downgraded hard block — see the orchestrator
+          // defer guard). Must precede the block path below.
           if (result.review) {
             sendAsk(result);
             return;

--- a/src/cli/commands/log.ts
+++ b/src/cli/commands/log.ts
@@ -5,7 +5,13 @@ import type { Command } from 'commander';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { redactSecrets, appendToLog, LOCAL_AUDIT_LOG } from '../../audit';
+import {
+  redactSecrets,
+  appendToLog,
+  appendLocalAudit,
+  LOCAL_AUDIT_LOG,
+  HOOK_DEBUG_LOG,
+} from '../../audit';
 import { getConfig } from '../../config';
 import { reviewCorrelationKey, resolvePendingReview } from '../../review-pending';
 import { createShadowSnapshot, getSnapshotHistory } from '../../undo';
@@ -169,10 +175,14 @@ export function registerLogCommand(program: Command): void {
 
           // Phase 4: if this execution resolves a deferred inline-ask review, the
           // user APPROVED it. Best-effort — must never skip/abort the audit write.
+          // v2: the resolved marker (with its review label) is kept so a SHIPPABLE
+          // decision row can be written after the config load below.
           let reviewApproved = false;
+          let resolvedReview: ReturnType<typeof resolvePendingReview> = null;
           try {
             const key = reviewCorrelationKey(payload as Record<string, unknown>);
-            if (key && resolvePendingReview(key)) reviewApproved = true;
+            if (key) resolvedReview = resolvePendingReview(key);
+            if (resolvedReview) reviewApproved = true;
           } catch {
             /* outcome capture is best-effort */
           }
@@ -285,6 +295,39 @@ export function registerLogCommand(program: Command): void {
           // non-fatal and must not retroactively gap the audit trail above. It is
           // hoisted above the gap1 block (below) so injectionScan can read its flag.
           const config = getConfig(safeCwd);
+
+          // v2 (review-ask-inline-v2-spec.md): the dev's inline approve is a real
+          // DECISION and must reach the dashboard — the post-hook row above has no
+          // eid (deliberately unshipped), so write a standard decision row the
+          // outbox shipper picks up. The defer-time review label rides as ruleName
+          // so the SaaS says WHICH review was approved inline. Denials stay
+          // unobservable (no hook fires) — approve-only telemetry, by design.
+          if (resolvedReview) {
+            try {
+              appendLocalAudit(
+                tool,
+                rawInput,
+                'allow',
+                'inline-review',
+                {
+                  agent,
+                  ruleName: resolvedReview.label || 'inline-review',
+                  ...(rawToolName !== tool ? { agentToolName: rawToolName } : {}),
+                  ...(typeof payloadSessionId === 'string' ? { sessionId: payloadSessionId } : {}),
+                  ...(safeCwd ? { workingDir: safeCwd } : {}),
+                },
+                config.settings.auditHashArgs === true
+              );
+            } catch (err) {
+              // Audit-trail guard: never silent (creates a SaaS-visibility gap).
+              appendToLog(HOOK_DEBUG_LOG, {
+                ts: new Date().toISOString(),
+                event: 'inline-review-ship-row-fail',
+                tool,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
+          }
 
           // ── gap1: response-channel DLP — scan what the tool RETURNED ─────────
           // The output is about to enter (or, on observe-only agents, has just

--- a/src/cli/commands/log.ts
+++ b/src/cli/commands/log.ts
@@ -304,6 +304,13 @@ export function registerLogCommand(program: Command): void {
           // unobservable (no hook fires) — approve-only telemetry, by design.
           if (resolvedReview) {
             try {
+              const reviewLabel = resolvedReview.label || 'inline-review';
+              // /code-review HIGH fix: a DLP/taint-flagged review means the
+              // args likely CONTAIN the flagged credential — force-hash the
+              // row regardless of auditHashArgs (same stance as the DLP block
+              // path, which always hashes). The isDlpRow guard in
+              // appendLocalAudit suppresses the preview via ruleName.
+              const sensitiveReview = /dlp|taint/i.test(reviewLabel);
               appendLocalAudit(
                 tool,
                 rawInput,
@@ -311,12 +318,12 @@ export function registerLogCommand(program: Command): void {
                 'inline-review',
                 {
                   agent,
-                  ruleName: resolvedReview.label || 'inline-review',
+                  ruleName: reviewLabel,
                   ...(rawToolName !== tool ? { agentToolName: rawToolName } : {}),
                   ...(typeof payloadSessionId === 'string' ? { sessionId: payloadSessionId } : {}),
                   ...(safeCwd ? { workingDir: safeCwd } : {}),
                 },
-                config.settings.auditHashArgs === true
+                sensitiveReview || config.settings.auditHashArgs === true
               );
             } catch (err) {
               // Audit-trail guard: never silent (creates a SaaS-visibility gap).

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -100,8 +100,10 @@ export const ConfigFileSchema = z
         agentPolicy: z.enum(['require_approval', 'block_on_rules']).optional(),
         // Where a `review` verdict's prompt is rendered: 'ask' = the agent's own
         // inline approve/deny prompt (Claude Code / GitHub Copilot); 'approver' =
-        // node9's own approver (terminal/native/cloud). Unset → smart default
-        // (ask for ask-capable agents unless a cloud approver is configured).
+        // node9's own approver (terminal/native/cloud). Unset → default ASK for
+        // ask-capable agents (v2: cloud no longer disables inline — the outcome
+        // ships to the dashboard as audit; admins force routing via managed
+        // reviewChannel, which outranks the local --ask flag).
         reviewChannel: z.enum(['ask', 'approver']).optional(),
         // When true, agents may call WEAKENING node9 MCP tools (shield_disable,
         // approver_set). Default (unset/false): those tools refuse over MCP — a human

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -147,6 +147,7 @@ export const ConfigFileSchema = z
             enabled: z.boolean().optional(),
             scanIgnoredTools: z.boolean().optional(),
             pii: z.enum(['off', 'block']).optional(),
+            reviewAction: z.enum(['review', 'block']).optional(),
           })
           .optional(),
         egress: z

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -93,6 +93,11 @@ export interface Config {
       // Opt-in by design — defaulting to 'off' changes no existing behaviour and
       // avoids false-positive blocks for orgs that legitimately handle PII.
       pii?: 'off' | 'block';
+      // What a REVIEW-severity DLP match does (review-ask-inline-v2-spec.md):
+      // 'review' (default): flag for human review (v2: inline ask by default).
+      // 'block': upgrade to a hard block at the DLP gate — the admin's "if DLP
+      // matters, set it to block" lever. Block-severity patterns always block.
+      reviewAction?: 'review' | 'block';
     };
     // Egress / destination control (GAP-5). Gates WHERE network tools send data
     // (curl/wget/scp/ssh/nc). Opt-in: enabled=false by default. `mode` is the
@@ -801,6 +806,7 @@ export function getConfig(cwd?: string): Config {
       if (d.enabled !== undefined) mergedPolicy.dlp.enabled = d.enabled;
       if (d.scanIgnoredTools !== undefined) mergedPolicy.dlp.scanIgnoredTools = d.scanIgnoredTools;
       if (d.pii !== undefined) mergedPolicy.dlp.pii = d.pii;
+      if (d.reviewAction !== undefined) mergedPolicy.dlp.reviewAction = d.reviewAction;
     }
     if (p.egress) {
       const e = p.egress as Partial<Config['policy']['egress']>;
@@ -913,7 +919,7 @@ export function getConfig(cwd?: string): Config {
             deny?: unknown;
             allowPrivate?: unknown;
           };
-          dlp?: { enabled?: unknown; pii?: unknown };
+          dlp?: { enabled?: unknown; pii?: unknown; reviewAction?: unknown };
           approvers?: {
             native?: unknown;
             browser?: unknown;
@@ -972,13 +978,18 @@ export function getConfig(cwd?: string): Config {
             locked
           );
         }
-        // M2c: policy.dlp. enabled force-on; pii floor over off<block.
+        // M2c: policy.dlp. enabled force-on; pii floor over off<block;
+        // reviewAction floor over review<block (inline-ask v2).
         if (mc.dlp && typeof mc.dlp === 'object') {
           mergedPolicy.dlp = applyManagedDlp(
             mergedPolicy.dlp,
             {
               enabled: typeof mc.dlp.enabled === 'boolean' ? mc.dlp.enabled : undefined,
               pii: typeof mc.dlp.pii === 'string' ? mc.dlp.pii : undefined,
+              reviewAction:
+                mc.dlp.reviewAction === 'review' || mc.dlp.reviewAction === 'block'
+                  ? mc.dlp.reviewAction
+                  : undefined,
             },
             locked
           );

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -48,6 +48,10 @@ export interface Config {
     /** Review-prompt delivery: 'ask' = agent's inline prompt, 'approver' = node9's
      *  own approver. Unset → smart default (see resolveAskMode in check.ts). */
     reviewChannel?: 'ask' | 'approver';
+    /** True when reviewChannel came from the org's managed config (cloud sync).
+     *  An admin-set value outranks the local --ask/--no-ask hook flag in
+     *  resolveAskMode — the org lever must not be defeatable per-machine. */
+    reviewChannelManaged?: boolean;
     /** When true, agents may call weakening MCP tools (shield_disable, approver_set).
      *  Default (unset): those tools refuse over MCP — a human runs them from the CLI. */
     mcpAllowWeakening?: boolean;
@@ -1008,8 +1012,13 @@ export function getConfig(cwd?: string): Config {
         }
         // Preferences v2: reviewChannel + approvalTimeoutMs — plain scalars, the
         // org's value replaces local when set (admin owns these approval knobs).
+        // reviewChannelManaged marks the value as ADMIN-SET so resolveAskMode
+        // ranks it above the local --ask/--no-ask hook flag (/code-review fix:
+        // the org's routing lever — and the documented v2 rollback — must not
+        // be defeatable by editing the hook registration on one machine).
         if (mc.reviewChannel === 'ask' || mc.reviewChannel === 'approver') {
           mergedSettings.reviewChannel = mc.reviewChannel;
+          mergedSettings.reviewChannelManaged = true;
         }
         // Require a POSITIVE timeout. 0 is rejected (not "wait forever"): the
         // daemon's pending-card timer is `setTimeout(deny, ms ?? DEFAULT)`, so a

--- a/src/config/managed.ts
+++ b/src/config/managed.ts
@@ -108,23 +108,26 @@ export function applyManagedEgress<
 
 // Managed DLP fields (M2c). `enabled` is force-on; `pii` gates SSN/credit-card in
 // tool args (off = detect-only, block = deny in realtime), ordered off<block.
+// `reviewAction` (inline-ask v2) upgrades review-severity matches to a hard
+// block, ordered review<block — a floor, so a member may tighten but the org's
+// 'block' can never be loosened locally.
 export const DLP_PII_ORDER = ['off', 'block'] as const;
+export const DLP_REVIEW_ACTION_ORDER = ['review', 'block'] as const;
 export interface ManagedDlp {
   enabled?: boolean;
   pii?: string;
+  reviewAction?: string;
 }
 
 /**
  * Apply managed DLP to the machine's local dlp object (baseline+lock), same
- * model as egress: `enabled` force-on, `pii` a floor over off<block. Generic so
- * the precise caller type is preserved; untouched fields (scanIgnoredTools)
- * carry through.
+ * model as egress: `enabled` force-on, `pii` a floor over off<block,
+ * `reviewAction` a floor over review<block. Generic so the precise caller type
+ * is preserved; untouched fields (scanIgnoredTools) carry through.
  */
-export function applyManagedDlp<T extends { enabled: boolean; pii?: string }>(
-  local: T,
-  managed: ManagedDlp,
-  locked: string[]
-): T {
+export function applyManagedDlp<
+  T extends { enabled: boolean; pii?: string; reviewAction?: string },
+>(local: T, managed: ManagedDlp, locked: string[]): T {
   const next: T = { ...local };
   if (typeof managed.enabled === 'boolean') {
     next.enabled = locked.includes('dlpEnabled')
@@ -138,6 +141,14 @@ export function applyManagedDlp<T extends { enabled: boolean; pii?: string }>(
       managed.pii,
       locked.includes('dlpPii')
     ) as T['pii'];
+  }
+  if (typeof managed.reviewAction === 'string') {
+    next.reviewAction = resolveByOrder(
+      DLP_REVIEW_ACTION_ORDER,
+      local.reviewAction ?? 'review',
+      managed.reviewAction,
+      locked.includes('dlpReviewAction')
+    ) as T['reviewAction'];
   }
   return next;
 }

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -73,7 +73,7 @@ import { extractCommandPattern } from '../auth/state.js';
 import { startCostSync } from '../costSync.js';
 import { startCloudSync, startForensicBroadcast } from './sync.js';
 import { startAuditShipper } from './audit-shipper.js';
-import { classifyDecision } from '../audit/decision.js';
+import { classifyDecision, NON_DECISION_SOURCES } from '../audit/decision.js';
 import { startDlpScanner } from './dlp-scanner.js';
 import { startMcpReconciler } from './mcp-reconciler.js';
 import { startHookHeal } from './hook-heal.js';
@@ -113,7 +113,7 @@ export function buildDaemonReport(
   else if (period === 'month') start = new Date(now.getFullYear(), now.getMonth(), 1);
 
   const entries = allEntries.filter((e) => {
-    if (e.source === 'post-hook' || e.source === 'response-dlp') return false;
+    if (typeof e.source === 'string' && NON_DECISION_SOURCES.has(e.source)) return false;
     return new Date(e.ts as string) >= start;
   });
 

--- a/src/daemon/sync.ts
+++ b/src/daemon/sync.ts
@@ -168,7 +168,7 @@ export interface ManagedConfigCache {
     deny?: string[];
     allowPrivate?: boolean;
   };
-  dlp?: { enabled?: boolean; pii?: string };
+  dlp?: { enabled?: boolean; pii?: string; reviewAction?: string };
   approvers?: { native?: boolean; browser?: boolean; cloud?: boolean; terminal?: boolean };
   reviewChannel?: string;
   approvalTimeoutMs?: number;
@@ -204,7 +204,7 @@ interface CloudPolicyBody {
       deny?: unknown;
       allowPrivate?: unknown;
     };
-    dlp?: { enabled?: unknown; pii?: unknown };
+    dlp?: { enabled?: unknown; pii?: unknown; reviewAction?: unknown };
     approvers?: { native?: unknown; browser?: unknown; cloud?: unknown; terminal?: unknown };
     reviewChannel?: unknown;
     approvalTimeoutMs?: unknown;
@@ -567,12 +567,15 @@ export function extractManagedConfig(body: CloudPolicyBody): ManagedConfigCache 
       out.egress = e;
     }
   }
-  // M2c: dlp.enabled (bool) + dlp.pii (string).
+  // M2c: dlp.enabled (bool) + dlp.pii (string) + dlp.reviewAction (enum,
+  // inline-ask v2 — validated to the two legal values, junk dropped).
   if (mc.dlp && typeof mc.dlp === 'object') {
-    const d: { enabled?: boolean; pii?: string } = {};
+    const d: { enabled?: boolean; pii?: string; reviewAction?: string } = {};
     if (typeof mc.dlp.enabled === 'boolean') d.enabled = mc.dlp.enabled;
     if (typeof mc.dlp.pii === 'string') d.pii = mc.dlp.pii;
-    if (d.enabled !== undefined || d.pii !== undefined) out.dlp = d;
+    if (mc.dlp.reviewAction === 'review' || mc.dlp.reviewAction === 'block')
+      d.reviewAction = mc.dlp.reviewAction;
+    if (d.enabled !== undefined || d.pii !== undefined || d.reviewAction !== undefined) out.dlp = d;
   }
   // Preferences: approvers (4 bools — where approvals may happen).
   if (mc.approvers && typeof mc.approvers === 'object') {

--- a/src/policy/index.ts
+++ b/src/policy/index.ts
@@ -266,13 +266,17 @@ async function deriveExplainTrace(toolName: string, args?: unknown): Promise<Exp
     const dlpMatch =
       (filePathE ? scanFilePath(filePathE) : null) ?? (args !== undefined ? scanArgs(args) : null);
     if (dlpMatch) {
+      // Mirror the real gate (orchestrator DLP section): reviewAction:'block'
+      // upgrades review-severity matches — explain must not say 'review'
+      // where the gate would block.
+      const dlpBlocks = dlpMatch.severity === 'block' || config.policy.dlp.reviewAction === 'block';
       steps.push({
         name: 'DLP Content Scanner',
-        outcome: dlpMatch.severity === 'block' ? 'block' : 'review',
+        outcome: dlpBlocks ? 'block' : 'review',
         detail: `🚨 ${dlpMatch.patternName} detected in ${dlpMatch.fieldPath} — sample: ${dlpMatch.redactedSample}`,
-        isFinal: dlpMatch.severity === 'block',
+        isFinal: dlpBlocks,
       });
-      if (dlpMatch.severity === 'block') {
+      if (dlpBlocks) {
         return { tool: toolName, args, waterfall, steps, decision: 'block' };
       }
     } else {

--- a/src/policy/negotiation.ts
+++ b/src/policy/negotiation.ts
@@ -93,7 +93,18 @@ INSTRUCTIONS:
 // REQUEST-framed, not block-framed: node9 is asking the user to approve, not
 // telling the agent it was blocked. Keep it short — it renders inside the
 // agent's permission prompt.
-export function buildReviewMessage(blockedByLabel?: string, ruleDescription?: string): string {
-  const why = ruleDescription || blockedByLabel || 'this action needs your review';
+export function buildReviewMessage(
+  blockedByLabel?: string,
+  ruleDescription?: string,
+  reason?: string
+): string {
+  // Priority: the rule's own description (most specific), then the verdict's
+  // human sentence (v2: taint / app-permission context — the dev must see WHY
+  // in the inline prompt, not just a label), then the bare label.
+  const why =
+    ruleDescription ||
+    (reason && reason !== blockedByLabel ? reason : undefined) ||
+    blockedByLabel ||
+    'this action needs your review';
   return `Node9 flagged this for your review: ${why}. Approve to proceed, or deny to cancel.`;
 }

--- a/src/review-pending.ts
+++ b/src/review-pending.ts
@@ -18,7 +18,16 @@ function storePath(): string {
     process.env.NODE9_PENDING_STORE || path.join(os.homedir(), '.node9', 'pending-reviews.json')
   );
 }
-const TTL_MS = 6 * 60 * 60 * 1000; // 6h — a review older than this is treated as abandoned
+// Per-key TTL (/code-review fix): an over-a-work-gap approval (Friday ask →
+// Monday approve) used to lose its shipped outcome row because ANY intervening
+// marker operation pruned the 6h-old entry.
+//   - `tuid:` keys (Claude Code) are collision-proof — a tool_use_id can never
+//     falsely match a DIFFERENT call — so a long TTL is safe: 72h.
+//   - `h:` heuristic keys (Copilot: session|tool|args-hash) CAN falsely match a
+//     later identical command decided by another channel; keep 6h to bound that
+//     misattribution window.
+const TTL_TUID_MS = 72 * 60 * 60 * 1000;
+const TTL_MS = 6 * 60 * 60 * 1000; // heuristic keys — abandoned after this
 const MAX_ENTRIES = 500; // hard cap so the file can't grow unbounded without a deny-sweep
 
 export interface PendingReview {
@@ -78,9 +87,11 @@ function write(store: Store): void {
   }
 }
 
-/** Drop expired entries, then cap to the most-recent MAX_ENTRIES. */
+/** Drop expired entries (per-key TTL), then cap to the most-recent MAX_ENTRIES. */
 function prune(entries: PendingReview[], now: number): PendingReview[] {
-  const fresh = entries.filter((e) => now - e.ts < TTL_MS);
+  const fresh = entries.filter(
+    (e) => now - e.ts < (e.key.startsWith('tuid:') ? TTL_TUID_MS : TTL_MS)
+  );
   return fresh.length > MAX_ENTRIES ? fresh.slice(fresh.length - MAX_ENTRIES) : fresh;
 }
 

--- a/src/review-pending.ts
+++ b/src/review-pending.ts
@@ -114,17 +114,40 @@ export function recordPendingReview(entry: PendingReview): void {
  */
 export function resolvePendingReview(key: string, now: number = Date.now()): PendingReview | null {
   try {
+    // Prune FIRST (/code-review fix): findIndex used to match before pruning,
+    // so an expired marker still resolved when its key was hit directly —
+    // turning a long-stale (possibly denied) ask into a false approval record.
     const store = read();
-    const idx = store.entries.findIndex((e) => e.key === key);
+    const live = prune(store.entries, now);
+    const idx = live.findIndex((e) => e.key === key);
     if (idx === -1) {
-      const pruned = prune(store.entries, now);
-      if (pruned.length !== store.entries.length) write({ entries: pruned });
+      if (live.length !== store.entries.length) write({ entries: live });
       return null;
     }
-    const [match] = store.entries.splice(idx, 1);
-    write({ entries: prune(store.entries, now) });
+    const [match] = live.splice(idx, 1);
+    write({ entries: live });
     return match;
   } catch {
     return null;
+  }
+}
+
+/**
+ * Remove ALL pending markers for a key. Called by check.ts when a call is
+ * decided by any channel OTHER than an inline defer (/code-review fix): a
+ * later identical Copilot command allowed on the ordinary path must not
+ * resolve a stale marker from an earlier (possibly DENIED) ask — that would
+ * ship a fabricated "dev approved inline" row. Best-effort, never throws.
+ */
+export function discardPendingReview(key: string, now: number = Date.now()): void {
+  try {
+    const store = read();
+    const kept = prune(
+      store.entries.filter((e) => e.key !== key),
+      now
+    );
+    if (kept.length !== store.entries.length) write({ entries: kept });
+  } catch {
+    /* best-effort */
   }
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -150,7 +150,7 @@ function printInlineAskNotice(): void {
   console.log(
     chalk.gray(
       '      Prefer node9’s own approver? Set "reviewChannel": "approver" in config, or add --no-ask to the hook.\n' +
-        '      (Inline prompts are auto-disabled when a cloud approver is configured.)'
+        '      (Inline is the default for every review; with a cloud workspace the outcome ships to the dashboard as audit.)'
     )
   );
 }

--- a/src/tui/dashboard/data.ts
+++ b/src/tui/dashboard/data.ts
@@ -16,6 +16,7 @@ import { runBlast } from '../../cli/commands/blast.js';
 import { DAEMON_HOST, DAEMON_PORT, getInternalToken } from '../../auth/daemon.js';
 import { parseJSONLFile, type DailyEntry } from '../../costSync.js';
 import { SHIELDS, readActiveShields } from '../../shields.js';
+import { NON_DECISION_SOURCES } from '../../audit/decision.js';
 import { extractFindingsFromLine } from '../../daemon/scan-watermark.js';
 import {
   aggregateReportFromAudit,
@@ -167,7 +168,7 @@ export function aggregateAudit(
   endMs: number = Date.now()
 ): AuditAggregates {
   const inWindow = entries.filter((e) => {
-    if (e.source === 'post-hook' || e.source === 'response-dlp') return false;
+    if (typeof e.source === 'string' && NON_DECISION_SOURCES.has(e.source)) return false;
     const t = Date.parse(e.ts);
     return t >= startMs && t <= endMs;
   });
@@ -367,7 +368,7 @@ export function compactPathsInCommand(cmd: string): string {
 export function buildLiveBackfill(n: number): ActivityEvent[] {
   if (n <= 0) return [];
   const all = readAuditEntries().filter(
-    (e) => e.source !== 'post-hook' && e.source !== 'response-dlp'
+    (e) => !(typeof e.source === 'string' && NON_DECISION_SOURCES.has(e.source))
   );
   const tail = all.slice(-n);
   return tail.map((e, i) => auditEntryToActivityEvent(e, i));


### PR DESCRIPTION
## What

Four commits closing the approvals-waterfall task (12·1/9):

- **8ba5da7 — inline-ask v2**: block = stop, review = the dev decides, inline is the dev's seat. The defer guard collapses to ONE exclusion (`!hardBlockDowngraded`, F1d); the v1 cloud/taint/app-perm carve-outs are deleted. Cloud becomes the record, not a gate: a resolved inline review ships an eid-bearing decision row (`checkedBy:'inline-review'`, review label as ruleName). New precedence: not-capable → **admin-managed reviewChannel** → --ask/--no-ask → local reviewChannel → default ASK.
- **105d8c2 — policy.dlp.reviewAction**: the admin's "if DLP matters, set it to block" lever. `'block'` upgrades review-severity DLP matches at the gate; managed floor over review<block; block-severity patterns untouched.
- **324a0cc + 491476d — /code-review rounds 1+2** (25 raw findings → 10 confirmed → all fixed, 15 refuted): HIGH secret-leak in the inline-review row (force-hash + no preview); pre-existing audit-gap bug (redactSecrets broke JSON.parse on Authorization-header payloads — whole PostToolUse row silently skipped); managed reviewChannel outranks a local --ask flag (org lever not defeatable per-machine); stale-marker fabrication closed (TTL-on-match + PRE-side discard — a denied Copilot ask can never ship later as approved); local double-count fixed via shared NON_DECISION_SOURCES; engine + explain honor dlp.reviewAction; per-key marker TTL (tuid 72h / heuristic 6h); app-perm defer tests rewritten to the real gateway shape.

## Verification

- 3751 tests green, typecheck/lint/format clean, failing-first tests at the real gate for every behavior change.
- Live E2E witnessed: a real `python3 -c` review → inline ask → human approve → attributed `inline-review` row in audit.log, shipper caught up.
- Rollback: managed `reviewChannel:'approver'` restores routed behavior exactly — one admin click, no release.

Spec: doc/roadmap/active/review-ask-inline-v2-spec.md (private).

🤖 Generated with [Claude Code](https://claude.com/claude-code)