### PR TITLE
fix(config): admin commandChecks value must apply when the device has no local opinion

### DIFF
--- a/src/__tests__/managed.test.ts
+++ b/src/__tests__/managed.test.ts
@@ -362,6 +362,33 @@ describe('managed commandChecks (floor + per-key locks)', () => {
     expect(out.chmod).toBeUndefined();
   });
 
+  // Founder QA 2026-07-26: the dashboard said inlineExec=off, the gate stayed
+  // at review. The floor compared the admin value against the DEFAULT ('review')
+  // as if the dev had chosen it, and off < review, so every admin 'off' was
+  // silently discarded. An absent local opinion must not out-rank the org.
+  it("an admin 'off' APPLIES when the device has no local opinion", () => {
+    const out = applyManagedCommandChecks({} as ManagedCommandChecks, { inlineExec: 'off' }, []);
+    expect(out.inlineExec).toBe('off');
+  });
+
+  it("an explicit local 'review' still out-ranks an admin 'off' (real floor)", () => {
+    const out = applyManagedCommandChecks(
+      { inlineExec: 'review' } as ManagedCommandChecks,
+      { inlineExec: 'off' },
+      []
+    );
+    expect(out.inlineExec).toBe('review');
+  });
+
+  it("a LOCKED admin 'off' beats even an explicit local 'review'", () => {
+    const out = applyManagedCommandChecks(
+      { inlineExec: 'review' } as ManagedCommandChecks,
+      { inlineExec: 'off' },
+      ['commandChecksInlineExec']
+    );
+    expect(out.inlineExec).toBe('off');
+  });
+
   it("keeps a stricter local 'block' over a cloud 'review'", () => {
     const out = applyManagedCommandChecks({ sqlDdl: 'block' }, { sqlDdl: 'review' }, []);
     expect(out.sqlDdl).toBe('block');

--- a/src/config/managed.ts
+++ b/src/config/managed.ts
@@ -180,12 +180,23 @@ export function applyManagedCommandChecks<T extends Partial<Record<CommandCheckK
     const m = managed[key];
     if (typeof m !== 'string') continue;
     const lockKey = `commandChecks${key[0].toUpperCase()}${key.slice(1)}`;
-    const resolved = resolveByOrder(
-      COMMAND_CHECK_ORDER as unknown as string[],
-      local[key] ?? 'review',
-      m,
-      locked.includes(lockKey)
-    );
+    const localValue = local[key];
+    // NO local opinion → the org's value applies verbatim. The floor compares
+    // an admin value against a DEV'S CHOICE; treating an absent choice as the
+    // default 'review' made the default masquerade as a deliberate local
+    // setting, and since off < review the floor silently discarded every
+    // admin 'off' (founder QA 2026-07-26: dashboard said off, gate stayed
+    // review). Only dlp.pii escaped this because its default is the WEAKEST
+    // value, so an absent local could never out-rank the managed one.
+    const resolved =
+      localValue === undefined
+        ? m
+        : resolveByOrder(
+            COMMAND_CHECK_ORDER as unknown as string[],
+            localValue,
+            m,
+            locked.includes(lockKey)
+          );
     // Class-B safety: never store 'off' for tighten-only keys even if a
     // hostile/buggy cloud value slips past upstream validation.
     if ((key === 'evalDynamic' || key === 'pipeChainHigh') && resolved === 'off') continue;


### PR DESCRIPTION
## The bug (founder QA: *"did you check the local policy?"*)

Dashboard said `inlineExec: off`. Device cache said `off`. **Effective config resolved to `review`.**

`applyManagedCommandChecks` passed the floor `local[key] ?? 'review'` — so an **absent** local choice masqueraded as a deliberate one. Since `off < review` in the strictness order, the "a member may be stricter, never weaker" rule concluded the device out-ranked the admin and silently discarded every admin `off`.

`dlp.pii` escaped this class only by luck: its default is the *weakest* value, so an absent local could never out-rank the managed one. Any knob whose default sits mid-order has the bug.

## Fix

- No local opinion → the org's value applies verbatim
- Explicit local value → still floors (dev may be stricter)
- Lock → still forces the exact value

Three tests pin all three cases, red-verified before the fix.

## Impact

**npm `1.67.0` shipped with this bug.** Admin `off`/weaker values for commandChecks are ignored on devices; stricter values and unset defaults are unaffected. This merge cuts **1.67.1**.

## Verification

Suite 3796 green, typecheck 0 errors, prettier clean on both files. Effective config on the founder's machine re-read after rebuild: `{"inlineExec":"off"}` (was `"review"`), and the gate confirms it — a real `python3 -c` now logs `checkedBy: local-policy` with no review row.

Branch-not-dev: local `dev` carries two unpushed commits from a concurrent session, so this is cherry-picked onto a clean branch rather than rebasing someone else's in-flight work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)