### PR TITLE
fix(config): admin commandChecks value must apply when the device has no local opinion (1.67.1)

### DIFF
--- a/src/__tests__/managed.test.ts
+++ b/src/__tests__/managed.test.ts
@@ -362,6 +362,33 @@ describe('managed commandChecks (floor + per-key locks)', () => {
     expect(out.chmod).toBeUndefined();
   });
 
+  // Founder QA 2026-07-26: the dashboard said inlineExec=off, the gate stayed
+  // at review. The floor compared the admin value against the DEFAULT ('review')
+  // as if the dev had chosen it, and off < review, so every admin 'off' was
+  // silently discarded. An absent local opinion must not out-rank the org.
+  it("an admin 'off' APPLIES when the device has no local opinion", () => {
+    const out = applyManagedCommandChecks({} as ManagedCommandChecks, { inlineExec: 'off' }, []);
+    expect(out.inlineExec).toBe('off');
+  });
+
+  it("an explicit local 'review' still out-ranks an admin 'off' (real floor)", () => {
+    const out = applyManagedCommandChecks(
+      { inlineExec: 'review' } as ManagedCommandChecks,
+      { inlineExec: 'off' },
+      []
+    );
+    expect(out.inlineExec).toBe('review');
+  });
+
+  it("a LOCKED admin 'off' beats even an explicit local 'review'", () => {
+    const out = applyManagedCommandChecks(
+      { inlineExec: 'review' } as ManagedCommandChecks,
+      { inlineExec: 'off' },
+      ['commandChecksInlineExec']
+    );
+    expect(out.inlineExec).toBe('off');
+  });
+
   it("keeps a stricter local 'block' over a cloud 'review'", () => {
     const out = applyManagedCommandChecks({ sqlDdl: 'block' }, { sqlDdl: 'review' }, []);
     expect(out.sqlDdl).toBe('block');

--- a/src/config/managed.ts
+++ b/src/config/managed.ts
@@ -180,12 +180,23 @@ export function applyManagedCommandChecks<T extends Partial<Record<CommandCheckK
     const m = managed[key];
     if (typeof m !== 'string') continue;
     const lockKey = `commandChecks${key[0].toUpperCase()}${key.slice(1)}`;
-    const resolved = resolveByOrder(
-      COMMAND_CHECK_ORDER as unknown as string[],
-      local[key] ?? 'review',
-      m,
-      locked.includes(lockKey)
-    );
+    const localValue = local[key];
+    // NO local opinion → the org's value applies verbatim. The floor compares
+    // an admin value against a DEV'S CHOICE; treating an absent choice as the
+    // default 'review' made the default masquerade as a deliberate local
+    // setting, and since off < review the floor silently discarded every
+    // admin 'off' (founder QA 2026-07-26: dashboard said off, gate stayed
+    // review). Only dlp.pii escaped this because its default is the WEAKEST
+    // value, so an absent local could never out-rank the managed one.
+    const resolved =
+      localValue === undefined
+        ? m
+        : resolveByOrder(
+            COMMAND_CHECK_ORDER as unknown as string[],
+            localValue,
+            m,
+            locked.includes(lockKey)
+          );
     // Class-B safety: never store 'off' for tighten-only keys even if a
     // hostile/buggy cloud value slips past upstream validation.
     if ((key === 'evalDynamic' || key === 'pipeChainHigh') && resolved === 'off') continue;


### PR DESCRIPTION
Patch release for a bug shipped in **1.67.0**.

## The bug

An admin sets a command check to `off` in the dashboard. The device syncs it, caches it — and the effective config resolves to `review`. The setting is silently ignored.

`applyManagedCommandChecks` passed the floor `local[key] ?? 'review'`, so an **absent** local choice masqueraded as a deliberate one. Since `off < review` in the strictness order, the "a member may be stricter, never weaker" rule concluded the device out-ranked the admin and discarded the value.

`dlp.pii` escaped this class only by luck — its default is the *weakest* value, so an absent local could never out-rank the managed one. Any knob whose default sits mid-order is affected, which is all four Class-C command checks.

## Fix

- No local opinion → the org's value applies verbatim
- Explicit local value → still floors (a dev may be stricter)
- Lock → still forces the exact value

Three tests pin all three cases, red-verified before the fix.

## Impact

`1.67.0` users: admin `off`/weaker command-check values are ignored on devices. Stricter values and unset defaults are unaffected — no one is *less* protected than intended, but admins cannot dial a check down. This cuts **1.67.1**.

## Verification

Suite 3796 green, typecheck clean. Verified on a real machine: effective config went from `{"inlineExec":"review"}` to `{"inlineExec":"off"}` after rebuild, and the gate agrees — a real `python3 -c` logs `checkedBy: local-policy` with no review row.

Found by founder QA ("did you check the local policy?") — the dashboard, the sync cache and the gate disagreed, and only reading the *effective merged* config exposed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)