### PR TITLE
fix(jail): cover every reader, not fourteen

### DIFF
--- a/packages/policy-engine/src/policy/env-reader-coverage.spec.ts
+++ b/packages/policy-engine/src/policy/env-reader-coverage.spec.ts
@@ -1,0 +1,189 @@
+// The credential jail must cover every command that READS, not the fourteen
+// someone happened to list.
+//
+// HOW THIS WAS FOUND, because the shape recurs. `shield:project-jail:block-read-env`
+// exists twice under ONE name: as a regex rule in project-jail.json naming 36
+// reader commands, and as `SENSITIVE_PATH_RULES` inside `analyzeFsOperation`
+// knowing 14. The regex rule is additionally suppressed for bash
+// (`AST_FS_REGEX_RULES`), so for every AI agent the AST tier is the only gate
+// and the 22-reader delta was ungated:
+//
+//   grep egrep fgrep rg ag ack awk gawk sed cut tr jq yq
+//   od xxd hexdump strings sort uniq tac nl dd
+//
+// Measured before this change, all `allow`: `strings .env`, `xxd .env`,
+// `grep -i secret .env`, `sed -n 1,10p .env`, `jq . .env`, `sort .env`.
+// A reviewer who greps the rule NAME sees a rule that exists and moves on —
+// a shared name is not a shared implementation.
+//
+// Second defect, same cause: the AST rule's suffix list is hand-written and
+// anchored with `$`, so `.env.prod` and `.env.ci` were never covered either.
+//
+// Rows assert at `evaluatePolicy` — the layer that actually gates. Asserting at
+// `evaluateSmartConditions` would test a layer that is suppressed downstream.
+
+import { describe, it, expect } from 'vitest';
+import { evaluatePolicy, type PolicyConfig } from './index';
+import projectJail from '../shields/builtin/project-jail.json';
+import type { SmartRule } from '../types';
+
+const config: PolicyConfig = {
+  policy: {
+    sandboxPaths: [],
+    dangerousWords: [],
+    ignoredTools: [],
+    smartRules: projectJail.smartRules as SmartRule[],
+    toolInspection: { bash: 'command', shell: 'command', run_shell_command: 'command' },
+    dlp: { enabled: false, scanIgnoredTools: false },
+  },
+  settings: { mode: 'standard' },
+} as unknown as PolicyConfig;
+
+async function G(command: string): Promise<string> {
+  const v = await evaluatePolicy(config, 'Bash', { command }, { agent: 'claude' }, {});
+  return String(v.decision);
+}
+
+// The 22 readers the AST tier did not know. Each is a real way to read a file:
+// `strings` and `xxd` dump contents, `jq`/`yq` parse them, `sort`/`uniq`/`tac`/
+// `nl` echo them, `sed`/`awk`/`cut`/`tr` transform them to stdout.
+const UNGATED_READERS = [
+  ['grep', 'grep -i secret .env'],
+  ['egrep', 'egrep KEY .env'],
+  ['fgrep', 'fgrep KEY .env'],
+  ['rg', 'rg API_KEY .env'],
+  ['ag', 'ag KEY .env'],
+  ['ack', 'ack KEY .env'],
+  ['awk', "awk '{print}' .env"],
+  ['gawk', "gawk '{print}' .env"],
+  ['sed', 'sed -n 1,10p .env'],
+  ['cut', 'cut -d= -f2 .env'],
+  ['tr', 'tr a b .env'],
+  ['jq', 'jq . .env'],
+  ['yq', 'yq . .env'],
+  ['od', 'od -c .env'],
+  ['xxd', 'xxd .env'],
+  ['hexdump', 'hexdump -C .env'],
+  ['strings', 'strings .env'],
+  ['sort', 'sort .env'],
+  ['uniq', 'uniq .env'],
+  ['tac', 'tac .env'],
+  ['nl', 'nl .env'],
+] as const;
+
+describe('every reader the shield claims to cover is actually gated', () => {
+  it.each(UNGATED_READERS)('blocks `%s` reading a .env', async (_name, command) => {
+    expect(await G(command)).toBe('block');
+  });
+
+  it('covers the same readers for .ssh and .aws, not only .env', async () => {
+    // The reader set is shared by all SENSITIVE_PATH_RULES, so widening it must
+    // widen every rule that depends on it — not just the one under repair.
+    expect(await G('strings ~/.ssh/id_rsa')).toBe('block');
+    expect(await G('xxd ~/.aws/credentials')).toBe('block');
+    expect(await G('strings ~/.npmrc')).toBe('review');
+  });
+});
+
+describe('the suffix list was hand-written, so it was incomplete', () => {
+  it.each([
+    ['.env.prod', 'cat .env.prod'],
+    ['.env.ci', 'cat .env.ci'],
+    ['.env.test.local', 'cat .env.test.local'],
+    ['.env.local.bak', 'cat .env.local.bak'],
+    ['already-listed .env.local', 'cat .env.local'],
+    ['already-listed .env.production.local', 'cat .env.production.local'],
+  ])('blocks %s', async (_name, command) => {
+    expect(await G(command)).toBe('block');
+  });
+
+  it('an unlisted suffix is caught through a NEWLY covered reader too', async () => {
+    // Crosses both defects at once: a reader from the 22-delta reading a suffix
+    // from outside the hand-written list. Passing either fix alone leaves this
+    // red, so it cannot go green for half a reason.
+    expect(await G('strings .env.prod')).toBe('block');
+  });
+});
+
+describe('the documented non-matches stay allowed', () => {
+  // shell/index.ts states these as INTENTIONAL non-matches and
+  // shields.test.ts:983-995 pins them. Widening the suffix match is exactly the
+  // change that would quietly eat them, so they are re-asserted at the gate.
+  it.each([
+    ['.env.example', 'cat .env.example'],
+    ['.env.sample', 'cat .env.sample'],
+    ['.env.template', 'cat .env.template'],
+    ['.env.test', 'cat .env.test'],
+    ['.envrc', 'cat .envrc'],
+  ])('allows %s (committed fixture, not a secret)', async (_name, command) => {
+    expect(await G(command)).toBe('allow');
+  });
+
+  it('a template read through a newly covered reader is still allowed', async () => {
+    expect(await G('grep DATABASE_URL .env.example')).toBe('allow');
+  });
+});
+
+describe('widening the reader set must not invent false positives', () => {
+  it.each([
+    ['.environment is not .env', 'cat .environment'],
+    ['a name that merely starts with env', 'cat env.js'],
+    ['vite-env.d.ts — hyphen, not dot', 'cat src/vite-env.d.ts'],
+    ['next-env.d.ts', 'cat next-env.d.ts'],
+    ['a directory called environments', 'cat config/environments/prod.yml'],
+    ['printenv is not a file read', 'printenv'],
+    ['env as a command, not a path', 'env | grep PATH'],
+    ['listing is not reading', 'ls -la .env'],
+    ['echoing the name is not reading', 'echo .env'],
+    ['docker consumes it, the agent never sees it', 'docker run --env-file .env img'],
+    ['git add is not a read', 'git add .env'],
+    ['npm add, where `dd` hides inside `add`', 'npm add dotenv'],
+    ['excluding it is the opposite of reading it', 'grep -r TODO --exclude=.env .'],
+  ])('allows: %s', async (_name, command) => {
+    expect(await G(command)).toBe('allow');
+  });
+
+  it('a .env named inside a commit message is data, not a read', async () => {
+    expect(await G('git commit -m "update .env handling"')).toBe('allow');
+    expect(await G('git commit -m "run cat .env to see"')).toBe('allow');
+  });
+
+  it('a .env named inside a JSON string argument is data, not a read', async () => {
+    // The exact false positive AST_FS_REGEX_RULES suppression exists to kill.
+    // If someone "fixes" this by un-suppressing the regex rule, this goes red.
+    expect(await G('echo \'{"command":"cat .env"}\'')).toBe('allow');
+  });
+
+  it('a read of an unrelated file does not become a read of .env', async () => {
+    // `.*?` in the regex rule spans command boundaries; the AST tier resolves
+    // per call, and must keep doing so as the reader set grows.
+    expect(await G('cat README.md; echo .env')).toBe('allow');
+    expect(await G('head -5 CHANGELOG.md; touch .env.bak')).toBe('allow');
+  });
+
+  it('the newly added readers stay silent on ordinary work', async () => {
+    // 22 new reader names is 22 new chances to fire on a normal command.
+    expect(await G('grep -rn TODO src/')).toBe('allow');
+    expect(await G('sort package.json')).toBe('allow');
+    expect(await G('jq .version package.json')).toBe('allow');
+    expect(await G('strings dist/cli.js')).toBe('allow');
+    expect(await G('sed -i s/a/b/ README.md')).toBe('allow');
+    expect(await G('git log | head -20')).toBe('allow');
+    expect(await G('npm run type-check')).toBe('allow');
+  });
+});
+
+describe('the prescreen and the reader set are one list, not two', () => {
+  it('every reader passes the prescreen that guards the AST tier', async () => {
+    // ⭐ The half-applied widening this repo keeps shipping: FS_OP_PRESCREEN_RE
+    // is a fast-path that returns BEFORE the AST parse. Adding a reader to
+    // FS_READ_TOOLS while leaving the prescreen at fourteen names produces a
+    // diff that looks complete and changes nothing. The only durable fix is for
+    // the prescreen to be DERIVED from the set; this row is what proves it,
+    // by driving every reader through the real gate rather than inspecting
+    // either list.
+    for (const [name, command] of UNGATED_READERS) {
+      expect(await G(command), `${name} did not survive the prescreen`).toBe('block');
+    }
+  });
+});

--- a/packages/policy-engine/src/scan/canonical.ts
+++ b/packages/policy-engine/src/scan/canonical.ts
@@ -222,7 +222,24 @@ export const LONG_OUTPUT_THRESHOLD_BYTES = 100 * 1024;
 // hashed source set in the same change: canonical.ts runs
 // evaluateSmartConditions, so a matcher change alters scan output, and the
 // old three-file set would have let this through with no bump.
-export const CANONICAL_EXTRACTOR_VERSION = 'canonical-v8';
+//
+// v9 (2026-08-20): FS_READ_TOOLS grew from 14 reader commands to 36, and the
+// `.env` matcher became structural instead of a seven-suffix list. Both change
+// what `ast-fs-op` emits on history that was already scanned — measured before
+// bumping rather than assumed, because a bump costs every daemon in the fleet a
+// full re-scan:
+//
+//   command                   v8        v9
+//   strings .env              (none) →  ast-fs-op block/high
+//   grep -i secret .env       (none) →  ast-fs-op block/high
+//   xxd ~/.aws/credentials    (none) →  ast-fs-op block/critical
+//   cat .env.prod             (none) →  ast-fs-op block/high
+//   cat .env                  block  →  block            (control, unmoved)
+//   cat .env.example          (none) →  (none)           (fixture, still clean)
+//
+// The re-scan is the point: those reads happened on real machines and produced
+// no finding at all, so the history a user sees today under-reports them.
+export const CANONICAL_EXTRACTOR_VERSION = 'canonical-v9';
 
 /**
  * SHA-256 prefix of the detector-source files
@@ -234,7 +251,7 @@ export const CANONICAL_EXTRACTOR_VERSION = 'canonical-v8';
  * files changed, this hash must change too, and you must consciously
  * decide whether to bump CANONICAL_EXTRACTOR_VERSION."
  */
-export const CANONICAL_EXTRACTOR_HASH = '80f40f974263b281';
+export const CANONICAL_EXTRACTOR_HASH = '4ebf40dfe1d7c0a1';
 
 // Dedupe key length cap — match what scan.ts:502 uses today.
 const DEDUPE_PREVIEW_LEN = 120;

--- a/packages/policy-engine/src/shell/index.ts
+++ b/packages/policy-engine/src/shell/index.ts
@@ -411,6 +411,19 @@ export const detectDangerousEval = detectDangerousShellExec;
 //   - $HOME root (with allow-list for tool-managed cache paths)
 // returning a structured verdict per call.
 
+// Every command that puts a file's CONTENTS where the agent can see them.
+//
+// This set had 14 entries while the project-jail shield's regex rule named 36,
+// and since that rule is suppressed for bash (AST_FS_REGEX_RULES) this set was
+// the only gate — so the 22-name delta was ungated for every AI agent and
+// `strings .env` read a credential file with no verdict at all.
+//
+// The membership test is "does it emit file contents", not "is it a pager":
+// `strings`/`xxd`/`od`/`hexdump` dump bytes, `jq`/`yq` parse and print,
+// `sort`/`uniq`/`tac`/`nl` echo lines, `sed`/`awk`/`cut`/`tr` transform to
+// stdout, and the grep family prints matching lines — which is all an
+// exfiltrator needs. Adding a name here widens EVERY SENSITIVE_PATH_RULES entry
+// (.ssh, .aws, .env, credentials), not just the one being repaired.
 const FS_READ_TOOLS = new Set([
   'cat',
   'less',
@@ -426,6 +439,29 @@ const FS_READ_TOOLS = new Set([
   'emacs',
   'code',
   'type',
+  // — the 22 that were missing —
+  'grep',
+  'egrep',
+  'fgrep',
+  'rg',
+  'ag',
+  'ack',
+  'awk',
+  'gawk',
+  'sed',
+  'cut',
+  'tr',
+  'jq',
+  'yq',
+  'od',
+  'xxd',
+  'hexdump',
+  'strings',
+  'sort',
+  'uniq',
+  'tac',
+  'nl',
+  'dd',
 ]);
 
 // Fast-path screen: the AST detector only fires when one of these tools is
@@ -437,8 +473,24 @@ const FS_READ_TOOLS = new Set([
 // argument string / hyphenated token / commit message" wasted parses
 // (e.g. `git log | head -20` still matches; `npm run type-check` no longer
 // passes prescreen because `type` is mid-token, never a CallExpr name).
-const FS_OP_PRESCREEN_RE =
-  /(?:^|[\s|;&(`\n])(?:rm|cat|less|head|tail|bat|more|open|print|nano|vim|vi|emacs|code|type)\b/;
+//
+// DERIVED from FS_READ_TOOLS, never hand-written beside it. It used to be a
+// second copy of the same fourteen names, and two lists that must agree but are
+// maintained separately is how a widening ships half-applied: adding a reader to
+// the Set alone changes nothing, because this prescreen returns before the AST
+// is ever parsed — the diff looks complete and the gate stays open. Deriving it
+// makes that failure unrepresentable.
+//
+// `rm` is joined in because the detector also handles deletion; it is not a
+// reader and deliberately does not live in FS_READ_TOOLS.
+const FS_OP_PRESCREEN_RE = new RegExp(
+  `(?:^|[\\s|;&(\`\\n])(?:rm|${[...FS_READ_TOOLS]
+    // Escape defensively: every current name is bare word characters, but a
+    // future addition with a `.` or `+` would otherwise become a wildcard and
+    // silently widen the prescreen.
+    .map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|')})\\b`
+);
 
 // Cache directories under $HOME that are tool-managed. Deleting them is safe
 // (the tool re-populates), so `rm -rf` of these paths must not block.
@@ -492,10 +544,38 @@ const SENSITIVE_PATH_RULES: Array<{
     // for the canonical test-asserted contract.
     rule: 'shield:project-jail:block-read-env',
     reason: 'Reading .env files is blocked by project-jail shield',
+    // Structural, not a list. The previous form enumerated seven suffixes and
+    // anchored on `$`, so `.env.prod`, `.env.ci` and `.env.local.bak` — all
+    // gitignored, all routinely holding real secrets — were never covered. A
+    // hand-written list of what to protect is only ever as complete as the day
+    // it was typed; this says "`.env` plus any suffix chain" and then names the
+    // exceptions, which is the direction that fails safe.
+    //
+    //   \.env          the segment itself
+    //   (?![\w-])      a boundary, so `.environment` and `.envrc` are NOT .env
+    //                  files. Without it a flat suffix class swallows both.
+    //   (?![\w-])      a boundary, so `.environment` and `.envrc` are NOT .env
+    //   [\w.-]*$       any suffix chain. Flat class, no nested quantifier —
+    //                  `(\.[\w-]+)*` reads the same but is rejected by
+    //                  safe-regex2, and this pattern runs on the hook hot path.
+    //
+    // The two exclusions are NOT the same shape, because the words do not mean
+    // the same thing:
+    //
+    //   (?!\.(?:example|sample|template)\b)  — "this file is a fixture", and it
+    //     stays a fixture whatever follows, so `.env.example.md` is allowed too.
+    //     These are checked into git by convention: already public, so blocking
+    //     them buys nothing and costs the most common legitimate agent read.
+    //
+    //   (?!\.test$)  — anchored, because `test` names an ENVIRONMENT, not a
+    //     fixture. `.env.test` is the committed template and stays allowed, but
+    //     `.env.test.local` is gitignored by the `.env*.local` convention and
+    //     holds real values, so it must block. Using `\b` here — the obvious
+    //     symmetry — silently exempts every `.env.test.*` file.
+    //
+    // shields.test.ts:983-995 is the canonical contract; keep both in step.
     match: (p) =>
-      /(?:^|[\\/])\.env(?:\.(?:local|production|staging|development|production\.local|staging\.local|development\.local))?$/i.test(
-        p
-      ),
+      /(?:^|[\\/])\.env(?![\w-])(?!\.(?:example|sample|template)\b)(?!\.test$)[\w.-]*$/i.test(p),
   },
   {
     // verdict: 'review' (not 'block') is a deliberate design choice


### PR DESCRIPTION
One commit. Push to `main` triggers semantic-release, so **this merge publishes to npm**. CI green on `dev` (Ubuntu + Windows, Node 20 + 22).

## What it closes

`shield:project-jail:block-read-env` exists twice under one name — a regex rule naming 36 readers, and `SENSITIVE_PATH_RULES` inside `analyzeFsOperation` knowing 14. The regex rule is suppressed for bash, so the AST tier was the only gate and the 22-name delta was ungated for every AI agent. Measured `allow` before this change: `strings .env`, `xxd ~/.aws/credentials`, `grep -i secret .env`, `sed -n 1,10p .env`, `jq . .env`, `sort .env`.

Also structural now: the `.env` matcher was a hand-written list of seven suffixes anchored on `$`, so `.env.prod` / `.env.ci` / `.env.local.bak` — gitignored, routinely holding real secrets — were never covered.

And the durable part: `FS_OP_PRESCREEN_RE` is DERIVED from `FS_READ_TOOLS` instead of being a second hand-written copy. Adding a reader to the Set alone used to change nothing, because the prescreen returns before the AST is parsed — a diff that looks complete while the gate stays open.

## Operational note for whoever is watching telemetry

`CANONICAL_EXTRACTOR_VERSION` v8 → v9. Every daemon re-scans its history on next start — a one-time SaaS payload spike, fleet-wide, shortly after v1.67.2 went out. That is intended: 4 of 6 probe commands move from no finding at all to a real `ast-fs-op`, so the history users see today under-reports real credential reads. Measured before bumping, with `cat .env` unmoved as a control.

## Known and not claimed

Redirect targets (`grep KEY < .env` resolves to `paths=["KEY"]`), `dd if=.env` operand splitting, and Windows separator readings (`analyzeFsOperation` calls `normalizeCommandForPolicy` only, never `commandReadings`, so `cat C:\app\.env` still misses). Tracked as follow-ups, not fixed here.