### PR TITLE
B0: verified machine onboarding + honest connect failures

### DIFF
--- a/src/__tests__/__snapshots__/scan-render.snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/scan-render.snapshot.test.ts.snap
@@ -5,7 +5,7 @@ exports[`N6 — state-aware phrasing (enabledShields injected) > chalk panel: an
   │ 🚨 2 credential leaks in tool input  (latest: 2d ago, GitHub Token)      │
   │ 🛑 2 ops node9 would have blocked  (block-read-ssh, block-eval-remote)   │
   │ 🔁 1 agent loops detected  (Edit dominates, 125 wasted calls · 1% of calls) │
-  │ 🔭 5 secrets reachable on disk  → agent reads blocked in-path (project-jail ✓) │
+  │ 🔭 5 secrets reachable on disk  → project-jail ✓ enabled                 │
   ╰──────────────────────────────────────────────────────────────────────────╯
 
   ╭─ LEAKS  ·  2 secrets in plain text ──────────────────────────────────────╮
@@ -40,7 +40,7 @@ exports[`N6 — state-aware phrasing (enabledShields injected) > chalk panel: an
   ╰──────────────────────────────────────────────────────────────────────────╯
 
   ╭─ SHIELDS  ·  your coverage vs what we found ─────────────────────────────╮
-  │ 🛡️  project-jail  catches 4 ops         ✓ enabled — enforcing in-path    │
+  │ 🛡️  project-jail  catches 4 ops         ✓ enabled                        │
   │       review-read-credentials ×3, block-read-ssh                         │
   │ ☐   bash-safe     catches 1 op                                           │
   │       block-eval-remote                                                  │
@@ -72,7 +72,7 @@ exports[`N6 — state-aware phrasing (enabledShields injected) > ink scorecard: 
 │ CREDENTIAL LEAKS                         │ │ WOULD HAVE BLOCKED                       │
 │   2d GitHub Token   [Bash]        claude │ │ ✗ block-read-ssh    ×1  ✓ shield:projec… │
 │  19d GCP API Key    [user-prompt] gemini │ │ ✗ block-eval-remote ×1  needs shield:ba… │
-│ → DLP · node9 mask (runtime + cleanup)   │ │ → ✓ rules are enforced in-path · enable… │
+│ → DLP · node9 mask (runtime + cleanup)   │ │ → ✓ marks rules from enabled shields · … │
 ╰──────────────────────────────────────────╯ ╰──────────────────────────────────────────╯
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ High (5 paths reachable) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ╭────────────────────────────────────────────────────────────────────────────────────────╮
@@ -94,7 +94,7 @@ exports[`N6 — state-aware phrasing (enabledShields injected) > ink scorecard: 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Recommended action ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ╭────────────────────────────────────────────────────────────────────────────────────────╮
 │ SHIELDS                                                                                │
-│ project-jail    catches 4 ops       ✓ enabled — enforcing in-path                      │
+│ project-jail    catches 4 ops       ✓ enabled                                          │
 │ bash-safe       catches 1 op                                                           │
 │ ✓ active: postgres  (no hits in this history)                                          │
 │ aws · docker · filesystem · github · k8s · mongodb · redis  (no hits — install proact… │

--- a/src/__tests__/__snapshots__/scan-render.snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/scan-render.snapshot.test.ts.snap
@@ -200,7 +200,7 @@ $9025.15 AI spend  ·  4 risky operations
 
 🔑  4   credential leak     (GitHub Token ×2, AWS Access Key, JWT)
 🛑  8   would have blocked  (force-push ×5, eval-remote)
-🔁  1   agent loops         (1% wasted  ·  ~$0.2460)
+🔁  1   agent loops         (125 wasted calls (1% of all calls)  ·  ~$0.2460)
 📂  1   long iterations     (deep work — not waste)
 👁  56  flagged for review  (rm)
 
@@ -235,7 +235,7 @@ exports[`renderNarrativeScorecard — output snapshots > rich fixture (critical 
      • 5 credential files reachable on disk
 
   🟢  MEDIUM     3 findings
-     • 2 agent loops (2% of calls, ~$0.2460 wasted)
+     • 2 agent loops (225 wasted calls, 2% of calls, ~$0.2460 wasted)
      • rm calls
 
 →  npx node9-ai scan       run this on your machine
@@ -256,7 +256,7 @@ exports[`renderPanelScorecard — output snapshots > panel fixture (critical sco
 "  ╭─ TOP FINDINGS ───────────────────────────────────────────────────────────╮
   │ 🚨 2 credential leaks in tool input  (latest: 2d ago, GitHub Token)      │
   │ 🛑 2 ops node9 would have blocked  (block-read-ssh, block-eval-remote)   │
-  │ 🔁 1 agent loops detected  (Edit dominates, 1% wasted)                   │
+  │ 🔁 1 agent loops detected  (Edit dominates, 125 wasted calls · 1% of calls) │
   │ 🔭 5 secrets reachable on disk  → enable project-jail (+53 pts)          │
   ╰──────────────────────────────────────────────────────────────────────────╯
 
@@ -276,7 +276,7 @@ exports[`renderPanelScorecard — output snapshots > panel fixture (critical sco
   │ 👁️  review-read-credentials  ×3    needs shield:project-jail             │
   ╰──────────────────────────────────────────────────────────────────────────╯
 
-  ╭─ AGENT LOOPS  ·  1 repeated patterns  ·  1% wasted ──────────────────────╮
+  ╭─ AGENT LOOPS  ·  1 pattern  ·  125 wasted calls (1% of all calls) ───────╮
   │ Edit      ×125 repeats    (100%)                                         │
   │                                                                          │
   │ Top stuck patterns:                                                      │
@@ -336,23 +336,23 @@ exports[`renderScanScorecardInk — output snapshots > panel fixture (critical s
 │                                          │ │ Tools / session ~385                     │
 │                                          │ │ Cost / session  ~$372                    │
 ╰──────────────────────────────────────────╯ ╰──────────────────────────────────────────╯
-━━━━━━━━━━━━━━━━━━━━━━ Critical (2 secrets leaked + 2 ops blocked) ━━━━━━━━━━━━━━━━━━━━━━━
+━━━━━━━━━━━━━━━━━━ Critical (2 secrets leaked + 2 ops would be blocked) ━━━━━━━━━━━━━━━━━━
 ╭──────────────────────────────────────────╮ ╭──────────────────────────────────────────╮
 │ CREDENTIAL LEAKS                         │ │ WOULD HAVE BLOCKED                       │
 │   2d GitHub Token   [Bash]        claude │ │ ✗ block-read-ssh   ×1 needs shield:proj… │
 │  19d GCP API Key    [user-prompt] gemini │ │ ✗ block-eval-remote ×1  needs shield:ba… │
 │ → DLP · node9 mask (runtime + cleanup)   │ │ → install node9 + enable shields above   │
 ╰──────────────────────────────────────────╯ ╰──────────────────────────────────────────╯
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━ High (5 paths reachable on disk) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ High (5 paths reachable) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ╭────────────────────────────────────────────────────────────────────────────────────────╮
-│ BLAST RADIUS                                                                           │
+│ BLAST RADIUS · top 4 of 5                                                              │
 │ ✗  ~/.ssh/id_rsa                       RSA private key                                 │
 │ ✗  ~/.ssh/id_ed25519                   Ed25519 private key                             │
 │ ✗  ~/.config/gcloud/credentials.db     GCP credentials                                 │
 │ ✗  ~/.npmrc                            npm auth token                                  │
 │ → project-jail shield blocks agent reads of these paths                                │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
-━━━━━━━━━━━━━━━━━━━━━━ Medium (37 ops flagged · 1 loop · 1% wasted) ━━━━━━━━━━━━━━━━━━━━━━
+━━━━━━━━━ Medium (37 ops flagged · 1 loop · 125 wasted calls (1% of all calls)) ━━━━━━━━━━
 ╭──────────────────────────────────────────╮ ╭──────────────────────────────────────────╮
 │ REVIEW QUEUE                             │ │ AGENT LOOPS                              │
 │ review-git-destructive×22   default      │ │ Edit      ×125          100%             │

--- a/src/__tests__/__snapshots__/scan-render.snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/scan-render.snapshot.test.ts.snap
@@ -1,5 +1,107 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`N6 — state-aware phrasing (enabledShields injected) > chalk panel: an enabled shield is never recommended, tags flip to ✓ 1`] = `
+"  ╭─ TOP FINDINGS ───────────────────────────────────────────────────────────╮
+  │ 🚨 2 credential leaks in tool input  (latest: 2d ago, GitHub Token)      │
+  │ 🛑 2 ops node9 would have blocked  (block-read-ssh, block-eval-remote)   │
+  │ 🔁 1 agent loops detected  (Edit dominates, 125 wasted calls · 1% of calls) │
+  │ 🔭 5 secrets reachable on disk  → agent reads blocked in-path (project-jail ✓) │
+  ╰──────────────────────────────────────────────────────────────────────────╯
+
+  ╭─ LEAKS  ·  2 secrets in plain text ──────────────────────────────────────╮
+  │   2d  GitHub Token   ghp_****7iD8         [Bash]          claude         │
+  │  19d  GCP API Key    AIza****4its         [user-prompt]   gemini         │
+  ╰──────────────────────────────────────────────────────────────────────────╯
+
+  ╭─ BLOCKED  ·  2 ops node9 would have stopped ─────────────────────────────╮
+  │ ✗ block-read-ssh           ×1    ✓ shield:project-jail                   │
+  │ ✗ block-eval-remote        ×1    needs shield:bash-safe                  │
+  ╰──────────────────────────────────────────────────────────────────────────╯
+
+  ╭─ REVIEW QUEUE  ·  37 ops flagged for approval ───────────────────────────╮
+  │ 👁️  review-git-destructive   ×22   default                               │
+  │ 👁️  review-sudo              ×12   default                               │
+  │ 👁️  review-read-credentials  ×3    ✓ shield:project-jail                 │
+  ╰──────────────────────────────────────────────────────────────────────────╯
+
+  ╭─ AGENT LOOPS  ·  1 pattern  ·  125 wasted calls (1% of all calls) ───────╮
+  │ Edit      ×125 repeats    (100%)                                         │
+  │                                                                          │
+  │ Top stuck patterns:                                                      │
+  │ ×126  /home/u/node9/src/scan.ts                                          │
+  ╰──────────────────────────────────────────────────────────────────────────╯
+
+  ╭─ BLAST RADIUS  ·  5 paths reachable right now ───────────────────────────╮
+  │ ✗  ~/.ssh/id_rsa                       RSA private key                   │
+  │ ✗  ~/.ssh/id_ed25519                   Ed25519 private key               │
+  │ ✗  ~/.config/gcloud/credentials.db     GCP credentials                   │
+  │ ✗  ~/.npmrc                            npm auth token                    │
+  │ ✗  ~/.node9/credentials.json           Node9 cloud API key               │
+  ╰──────────────────────────────────────────────────────────────────────────╯
+
+  ╭─ SHIELDS  ·  your coverage vs what we found ─────────────────────────────╮
+  │ 🛡️  project-jail  catches 4 ops         ✓ enabled — enforcing in-path    │
+  │       review-read-credentials ×3, block-read-ssh                         │
+  │ ☐   bash-safe     catches 1 op                                           │
+  │       block-eval-remote                                                  │
+  │                                                                          │
+  │ ✓ active: postgres  (no hits in this history)                            │
+  │                                                                          │
+  │ aws · docker · filesystem · github · k8s · mongodb · redis               │
+  │       no hits in your history — install proactively                      │
+  │                                                                          │
+  │ ✓ recommended shields are enabled                                        │
+  ╰──────────────────────────────────────────────────────────────────────────╯
+"
+`;
+
+exports[`N6 — state-aware phrasing (enabledShields injected) > ink scorecard: same state law through StaticScorecard 1`] = `
+"
+🛡  node9 dashboard  ·  scanned last 90 days
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Spend & activity ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+╭──────────────────────────────────────────╮ ╭──────────────────────────────────────────╮
+│ COST                                     │ │ ACTIVITY                                 │
+│ Total           $14.5K                   │ │ Sessions        39                       │
+│ Wasted on loops ~$0.25                   │ │ Tools           15,000                   │
+│                                          │ │   Shell         7,500                    │
+│                                          │ │ Tools / session ~385                     │
+│                                          │ │ Cost / session  ~$372                    │
+╰──────────────────────────────────────────╯ ╰──────────────────────────────────────────╯
+━━━━━━━━━━━━━━━━━━ Critical (2 secrets leaked + 2 ops would be blocked) ━━━━━━━━━━━━━━━━━━
+╭──────────────────────────────────────────╮ ╭──────────────────────────────────────────╮
+│ CREDENTIAL LEAKS                         │ │ WOULD HAVE BLOCKED                       │
+│   2d GitHub Token   [Bash]        claude │ │ ✗ block-read-ssh    ×1  ✓ shield:projec… │
+│  19d GCP API Key    [user-prompt] gemini │ │ ✗ block-eval-remote ×1  needs shield:ba… │
+│ → DLP · node9 mask (runtime + cleanup)   │ │ → ✓ rules are enforced in-path · enable… │
+╰──────────────────────────────────────────╯ ╰──────────────────────────────────────────╯
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ High (5 paths reachable) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+╭────────────────────────────────────────────────────────────────────────────────────────╮
+│ BLAST RADIUS · top 4 of 5                                                              │
+│ ✗  ~/.ssh/id_rsa                       RSA private key                                 │
+│ ✗  ~/.ssh/id_ed25519                   Ed25519 private key                             │
+│ ✗  ~/.config/gcloud/credentials.db     GCP credentials                                 │
+│ ✗  ~/.npmrc                            npm auth token                                  │
+│ → project-jail shield blocks agent reads of these paths                                │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
+━━━━━━━━━ Medium (37 ops flagged · 1 loop · 125 wasted calls (1% of all calls)) ━━━━━━━━━━
+╭──────────────────────────────────────────╮ ╭──────────────────────────────────────────╮
+│ REVIEW QUEUE                             │ │ AGENT LOOPS                              │
+│ review-git-destructive×22   default      │ │ Edit      ×125          100%             │
+│ review-sudo           ×12   default      │ │ Top stuck:                               │
+│ review-read-cred… ×3  ✓ shield:project-… │ │ ×126    /home/u/node9/src/scan.ts        │
+│ → runtime approval                       │ │ → live loop-detector                     │
+╰──────────────────────────────────────────╯ ╰──────────────────────────────────────────╯
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Recommended action ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+╭────────────────────────────────────────────────────────────────────────────────────────╮
+│ SHIELDS                                                                                │
+│ project-jail    catches 4 ops       ✓ enabled — enforcing in-path                      │
+│ bash-safe       catches 1 op                                                           │
+│ ✓ active: postgres  (no hits in this history)                                          │
+│ aws · docker · filesystem · github · k8s · mongodb · redis  (no hits — install proact… │
+│ ✓ recommended shields are enabled                                                      │
+╰────────────────────────────────────────────────────────────────────────────────────────╯"
+`;
+
 exports[`buildScanJson — envelope snapshot > rich fixture 1`] = `
 "{
   "schemaVersion": 1,
@@ -257,7 +359,7 @@ exports[`renderPanelScorecard — output snapshots > panel fixture (critical sco
   │ 🚨 2 credential leaks in tool input  (latest: 2d ago, GitHub Token)      │
   │ 🛑 2 ops node9 would have blocked  (block-read-ssh, block-eval-remote)   │
   │ 🔁 1 agent loops detected  (Edit dominates, 125 wasted calls · 1% of calls) │
-  │ 🔭 5 secrets reachable on disk  → enable project-jail (+53 pts)          │
+  │ 🔭 5 secrets reachable on disk  → enable project-jail                    │
   ╰──────────────────────────────────────────────────────────────────────────╯
 
   ╭─ LEAKS  ·  2 secrets in plain text ──────────────────────────────────────╮
@@ -292,15 +394,15 @@ exports[`renderPanelScorecard — output snapshots > panel fixture (critical sco
   ╰──────────────────────────────────────────────────────────────────────────╯
 
   ╭─ SHIELDS  ·  install node9 + enable these to catch what we found ────────╮
-  │ 🛡️  project-jail  would catch 4 ops       →  +53 pts  (25 → 78)          │
+  │ 🛡️  project-jail  catches 4 ops         → blocks these reads in-path     │
   │       review-read-credentials ×3, block-read-ssh                         │
-  │ ☐   bash-safe     would catch 1 op                                       │
+  │ ☐   bash-safe     catches 1 op                                           │
   │       block-eval-remote                                                  │
   │                                                                          │
   │ aws · docker · filesystem · github · k8s · mongodb · postgres · redis    │
   │       no hits in your history — install proactively                      │
   │                                                                          │
-  │ → node9 shield enable project-jail   (start here — +53 pts)              │
+  │ → node9 shield enable project-jail   (start here — widest coverage)      │
   ╰──────────────────────────────────────────────────────────────────────────╯
 "
 `;

--- a/src/__tests__/__snapshots__/scan-render.snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/scan-render.snapshot.test.ts.snap
@@ -183,7 +183,7 @@ exports[`buildScanJson — envelope snapshot > rich fixture 1`] = `
 exports[`renderCompactScorecard — output snapshots > clean fixture (good score, no findings) 1`] = `
 "🛡  Node9 Scan  ·  5 sessions  ·  200 tool calls  ·  May 1, 2026 – May 7, 2026
 
-Security Score: 95/100  ·  Good
+Exposure: 0 paths reachable by the agent
 $1.50 AI spend  ·  0 risky operations
 
 
@@ -195,7 +195,7 @@ $1.50 AI spend  ·  0 risky operations
 exports[`renderCompactScorecard — output snapshots > rich fixture (critical score) 1`] = `
 "🛡  Node9 Scan  ·  39 sessions  ·  12,481 tool calls  ·  Apr 6, 2026 – May 7, 2026
 
-Security Score: 25/100  ·  Critical
+Exposure: 5 paths reachable by the agent
 $9025.15 AI spend  ·  4 risky operations
 
 🔑  4   credential leak     (GitHub Token ×2, AWS Access Key, JWT)
@@ -214,7 +214,7 @@ $9025.15 AI spend  ·  4 risky operations
 exports[`renderNarrativeScorecard — output snapshots > clean fixture (good score, no findings) 1`] = `
 "🛡  Node9 Scan  ·  5 sessions  ·  $1.50 spend  ·  May 1, 2026 – May 7, 2026
 
-Security Score: 95/100  ·  Good
+Exposure: 0 paths reachable by the agent
 
 →  npx node9-ai scan       run this on your machine
 →  github.com/node9-ai/node9-proxy
@@ -224,7 +224,7 @@ Security Score: 95/100  ·  Good
 exports[`renderNarrativeScorecard — output snapshots > rich fixture (critical score) 1`] = `
 "🛡  Node9 Scan  ·  39 sessions  ·  $9025.15 spend  ·  Apr 6, 2026 – May 7, 2026
 
-⚠  Security Score: 25/100  ·  Critical
+⚠  Exposure: 5 paths reachable by the agent
 
   🔴  CRITICAL  5 findings
      • 4 credential leaks (GitHub Token ×2, AWS Access Key, JWT)
@@ -363,9 +363,9 @@ exports[`renderScanScorecardInk — output snapshots > panel fixture (critical s
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Recommended action ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ╭────────────────────────────────────────────────────────────────────────────────────────╮
 │ SHIELDS                                                                                │
-│ project-jail    catches 4 ops       → +53 pts (25 → 78)                                │
+│ project-jail    catches 4 ops       → blocks these reads in-path                       │
 │ bash-safe       catches 1 op                                                           │
 │ aws · docker · filesystem · github · k8s · mongodb · postgres · redis  (no hits — ins… │
-│ → node9 shield enable project-jail   (start here — +53 pts)                            │
+│ → node9 shield enable project-jail   (start here — widest coverage)                    │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯"
 `;

--- a/src/__tests__/applied-shields.spec.ts
+++ b/src/__tests__/applied-shields.spec.ts
@@ -1,0 +1,109 @@
+// N6 — policy.appliedShields: the apply loop's own testimony of which
+// shields it actually injected (doc/n6-state-aware-scan.md §1).
+//
+// Renderers (scan/posture) read this field to phrase recommendations, so
+// its contract is load-bearing: a shield listed here IS enforcing; a
+// shield absent is NOT — including a cloud-mandated name whose body
+// failed to resolve (fail-closed, B1 #2), which the raw local∪cloud
+// union would misreport as running.
+//
+// Harness cloned from b1-cloud-shield-unweakenable.spec.ts: real
+// getConfig + real catalog; only the local-file readers are mocked
+// (their path is a module-load-time const HOME can't move).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const activeShields = { current: [] as string[] };
+
+vi.mock('../shields', async () => {
+  const actual = await vi.importActual<typeof import('../shields')>('../shields');
+  return {
+    ...actual,
+    readActiveShields: () => activeShields.current,
+    readShieldOverrides: () => ({}),
+  };
+});
+
+import { getConfig, _resetConfigCache } from '../config';
+
+describe('N6 — policy.appliedShields is the apply loop testimony', () => {
+  let tmpHome: string;
+  let origHome: string | undefined;
+  let origUserprofile: string | undefined;
+
+  const setCloud = (cloudShields: string[]) => {
+    fs.writeFileSync(
+      path.join(tmpHome, '.node9', 'rules-cache.json'),
+      JSON.stringify({
+        fetchedAt: '2026-07-01T00:00:00Z',
+        rules: [],
+        shields: cloudShields,
+      })
+    );
+    _resetConfigCache();
+  };
+
+  const setLocal = (active: string[]) => {
+    activeShields.current = active;
+    _resetConfigCache();
+  };
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-n6-'));
+    origHome = process.env.HOME;
+    origUserprofile = process.env.USERPROFILE;
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    fs.mkdirSync(path.join(tmpHome, '.node9'), { recursive: true });
+    activeShields.current = [];
+    _resetConfigCache();
+  });
+
+  afterEach(() => {
+    if (origHome !== undefined) process.env.HOME = origHome;
+    else delete process.env.HOME;
+    if (origUserprofile !== undefined) process.env.USERPROFILE = origUserprofile;
+    else delete process.env.USERPROFILE;
+    _resetConfigCache();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('nothing enabled → empty ARRAY, never undefined (a renderer must not read absence as unknown)', () => {
+    expect(getConfig().policy.appliedShields).toEqual([]);
+  });
+
+  it('locally enabled shields are listed, sorted', () => {
+    setLocal(['redis', 'bash-safe']);
+    expect(getConfig().policy.appliedShields).toEqual(['bash-safe', 'redis']);
+  });
+
+  it('a cloud-mandated shield is listed', () => {
+    setCloud(['postgres']);
+    expect(getConfig().policy.appliedShields).toEqual(['postgres']);
+  });
+
+  it('a shield enabled both locally and by mandate appears ONCE', () => {
+    setCloud(['redis']);
+    setLocal(['redis']);
+    expect(getConfig().policy.appliedShields).toEqual(['redis']);
+  });
+
+  it('a mandated name with no resolvable body is ABSENT — fail-closed mandates are not "running"', () => {
+    // B1 #2: a cloud mandate resolves its body from BUILTIN_SHIELDS only;
+    // an unknown name is dropped rather than enforced. Reporting it as
+    // applied would let scan/posture claim coverage that does not exist.
+    setCloud(['no-such-shield', 'redis']);
+    expect(getConfig().policy.appliedShields).toEqual(['redis']);
+  });
+
+  it('testimony matches injection: every listed shield contributed at least one smartRule', () => {
+    setLocal(['redis', 'project-jail']);
+    const cfg = getConfig();
+    const names = cfg.policy.smartRules.map((r) => r.name ?? '');
+    for (const shield of cfg.policy.appliedShields ?? []) {
+      expect(names.some((n) => n.startsWith(`shield:${shield}:`))).toBe(true);
+    }
+  });
+});

--- a/src/__tests__/connect.integration.test.ts
+++ b/src/__tests__/connect.integration.test.ts
@@ -55,7 +55,8 @@ describe('node9 connect (integration)', () => {
   afterEach(() => fs.rmSync(tmpHome, { recursive: true, force: true }));
 
   function runConnect(
-    token: string
+    token: string,
+    envOverride: Record<string, string | undefined> = {}
   ): Promise<{ status: number | null; stdout: string; stderr: string }> {
     return new Promise((resolve) => {
       const child = spawn(
@@ -68,6 +69,7 @@ describe('node9 connect (integration)', () => {
             NODE9_NO_AUTO_DAEMON: '1',
             HOME: tmpHome,
             USERPROFILE: tmpHome,
+            ...envOverride,
           },
         }
       );
@@ -96,5 +98,28 @@ describe('node9 connect (integration)', () => {
     expect(r.status).toBe(1);
     expect(r.stderr).toMatch(/expired or was already used/);
     expect(fs.existsSync(credsPath())).toBe(false);
+  });
+
+  it('fails LOUDLY with exit 1 when the cloud never acks (B0 regression)', async () => {
+    // The old connect ignored runCloudSync's { ok: false } and printed
+    // "✅ Connected" while the machine never registered. Real spawn path,
+    // NODE9_TESTING unset so the cloud steps actually run; creds env points at
+    // a closed port so sync + the snapshot ack both fail hermetically.
+    mode = 'ok';
+    const r = await runConnect('n9_connect_valid', {
+      NODE9_TESTING: undefined,
+      NODE9_API_KEY: 'n9_live_env',
+      NODE9_API_URL: 'https://127.0.0.1:9/api/v1/intercept/policies/sync',
+      NODE9_BLAST_DISABLE: '1',
+      NODE9_SCAN_DISABLE: '1',
+      NODE9_POSTURE_DISABLE: '1',
+    });
+    expect(r.status).toBe(1);
+    // Not the success headline (agent-setup may print its own ✅ per agent).
+    expect(r.stdout).not.toMatch(/✅ Connected/);
+    expect(r.stdout).toMatch(/Connection incomplete/);
+    // Credentials ARE written (the key exchange succeeded) — only the cloud
+    // verification failed, and the scorecard must say which step.
+    expect(fs.existsSync(credsPath())).toBe(true);
   });
 });

--- a/src/__tests__/credentials.unit.test.ts
+++ b/src/__tests__/credentials.unit.test.ts
@@ -32,6 +32,63 @@ describe('writeCredentialsAndConfig', () => {
     expect(config().settings.approvers.cloud).toBe(false);
   });
 
+  it('always sets cloud=true over an existing cloud:false (init-then-login trap)', () => {
+    // `node9 init` seeds DEFAULT_CONFIG (cloud:false). Login MUST override it —
+    // preserve-on-login is what used to lock machines out of the cloud forever.
+    fs.mkdirSync(path.join(tmp, '.node9'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, '.node9', 'config.json'),
+      JSON.stringify({
+        settings: {
+          mode: 'standard',
+          approvers: { native: true, browser: false, cloud: false, terminal: true },
+        },
+      })
+    );
+    const r = writeCredentialsAndConfig('n9_live_abc', { homeDir: tmp });
+    expect(r.effectiveCloud).toBe(true);
+    expect(config().settings.approvers.cloud).toBe(true);
+    expect(config().settings.mode).toBe('standard');
+  });
+
+  it('re-login without --local re-enables cloud after a --local login', () => {
+    writeCredentialsAndConfig('n9_live_abc', { isLocal: true, homeDir: tmp });
+    const r = writeCredentialsAndConfig('n9_live_abc', { homeDir: tmp });
+    expect(r.effectiveCloud).toBe(true);
+    expect(config().settings.approvers.cloud).toBe(true);
+  });
+
+  it('preserves user-customized native/terminal approvers', () => {
+    fs.mkdirSync(path.join(tmp, '.node9'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, '.node9', 'config.json'),
+      JSON.stringify({ settings: { approvers: { native: false, terminal: false, cloud: false } } })
+    );
+    writeCredentialsAndConfig('n9_live_abc', { homeDir: tmp });
+    expect(config().settings.approvers.native).toBe(false);
+    expect(config().settings.approvers.terminal).toBe(false);
+    expect(config().settings.approvers.cloud).toBe(true);
+  });
+
+  it('drops the legacy browser approver key on every write', () => {
+    fs.mkdirSync(path.join(tmp, '.node9'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, '.node9', 'config.json'),
+      JSON.stringify({ settings: { approvers: { native: true, browser: true, cloud: true } } })
+    );
+    writeCredentialsAndConfig('n9_live_abc', { homeDir: tmp });
+    expect('browser' in config().settings.approvers).toBe(false);
+    // Fresh configs never get the key either.
+    const tmp2 = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-creds2-'));
+    try {
+      writeCredentialsAndConfig('n9_live_abc', { homeDir: tmp2 });
+      const fresh = JSON.parse(fs.readFileSync(path.join(tmp2, '.node9', 'config.json'), 'utf-8'));
+      expect('browser' in fresh.settings.approvers).toBe(false);
+    } finally {
+      fs.rmSync(tmp2, { recursive: true, force: true });
+    }
+  });
+
   it('a named profile writes creds but not the default config.json', () => {
     const r = writeCredentialsAndConfig('n9_live_x', { profileName: 'work', homeDir: tmp });
     expect(r).toEqual({ profileName: 'work', effectiveCloud: null });

--- a/src/__tests__/onboarding.unit.test.ts
+++ b/src/__tests__/onboarding.unit.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { onboardMachine, renderOnboardOutcome } from '../onboarding';
+import { writeCredentialsAndConfig } from '../credentials';
+import { setupDetectedAgents } from '../setup';
+import { runCloudSync, runPolicyPush } from '../daemon/sync';
+import { isTestingMode } from '../cli/daemon-starter';
+
+vi.mock('../credentials', () => ({ writeCredentialsAndConfig: vi.fn() }));
+vi.mock('../setup', () => ({ setupDetectedAgents: vi.fn() }));
+vi.mock('../daemon/sync', () => ({ runCloudSync: vi.fn(), runPolicyPush: vi.fn() }));
+vi.mock('../daemon/service', () => ({ ensureAutostartHealthy: vi.fn(() => 'skipped') }));
+vi.mock('../auth/daemon', () => ({ isDaemonRunning: vi.fn(() => false) }));
+vi.mock('../cli/daemon-starter', () => ({ isTestingMode: vi.fn(() => false) }));
+vi.mock('../config', () => ({
+  DEFAULT_CONFIG: { settings: { approvers: { native: true, terminal: true } } },
+  getConfig: vi.fn(() => ({ settings: { autoStartDaemon: true } })),
+}));
+
+const step = (out: Awaited<ReturnType<typeof onboardMachine>>, name: string) =>
+  out.steps.find((s) => s.name === name);
+
+describe('onboardMachine', () => {
+  beforeEach(() => {
+    vi.mocked(writeCredentialsAndConfig).mockReturnValue({
+      profileName: 'default',
+      effectiveCloud: true,
+    });
+    vi.mocked(setupDetectedAgents).mockResolvedValue(['claude']);
+    vi.mocked(runCloudSync).mockResolvedValue({
+      ok: true,
+      rules: 3,
+      fetchedAt: '2026-08-28T00:00:00Z',
+    });
+    vi.mocked(runPolicyPush).mockResolvedValue({ ok: true });
+    vi.mocked(isTestingMode).mockReturnValue(false);
+  });
+
+  it('is ok only when credentials + sync + register all succeed', async () => {
+    const out = await onboardMachine('n9_live_x');
+    expect(out.ok).toBe(true);
+    expect(out.wired).toEqual(['claude']);
+    expect(step(out, 'register')?.ok).toBe(true);
+  });
+
+  it('a failed cloud sync fails the onboarding with the reason', async () => {
+    vi.mocked(runCloudSync).mockResolvedValue({ ok: false, reason: 'API returned 500' });
+    const out = await onboardMachine('n9_live_x');
+    expect(out.ok).toBe(false);
+    expect(step(out, 'policy-sync')).toMatchObject({ ok: false, detail: 'API returned 500' });
+  });
+
+  it('a failed snapshot push (registration ack) fails the onboarding', async () => {
+    vi.mocked(runPolicyPush).mockResolvedValue({ ok: false, reason: 'Push failed' });
+    const out = await onboardMachine('n9_live_x');
+    expect(out.ok).toBe(false);
+    expect(step(out, 'register')).toMatchObject({ ok: false, detail: 'Push failed' });
+  });
+
+  it('an agent-wiring failure does NOT fail the onboarding (best-effort)', async () => {
+    vi.mocked(setupDetectedAgents).mockRejectedValue(new Error('no settings file'));
+    const out = await onboardMachine('n9_live_x');
+    expect(out.ok).toBe(true);
+    expect(step(out, 'agents')?.ok).toBe(false);
+  });
+
+  it('a credentials write failure short-circuits everything', async () => {
+    vi.mocked(writeCredentialsAndConfig).mockImplementation(() => {
+      throw new Error('EACCES');
+    });
+    const out = await onboardMachine('n9_live_x');
+    expect(out.ok).toBe(false);
+    expect(out.steps).toHaveLength(1);
+    expect(runCloudSync).not.toHaveBeenCalled();
+  });
+
+  it('testing mode skips the cloud steps but still counts as ok', async () => {
+    vi.mocked(isTestingMode).mockReturnValue(true);
+    const out = await onboardMachine('n9_live_x');
+    expect(out.ok).toBe(true);
+    expect(runCloudSync).not.toHaveBeenCalled();
+    expect(runPolicyPush).not.toHaveBeenCalled();
+  });
+
+  it('a named profile skips the cloud steps (they would verify the wrong key)', async () => {
+    const out = await onboardMachine('n9_live_x', { profileName: 'work' });
+    expect(out.ok).toBe(true);
+    expect(runCloudSync).not.toHaveBeenCalled();
+    expect(step(out, 'policy-sync')?.detail).toContain('named profile');
+  });
+});
+
+describe('renderOnboardOutcome', () => {
+  it('claims success only when ok, and carries failure reasons', async () => {
+    vi.mocked(runPolicyPush).mockResolvedValue({ ok: false, reason: 'network down' });
+    const out = await onboardMachine('n9_live_x');
+    const text = renderOnboardOutcome(out, { workspaceName: 'Acme' });
+    expect(text).not.toContain('✅');
+    expect(text).toContain('Connection incomplete');
+    expect(text).toContain('network down');
+    expect(text).toContain('node9 sync');
+  });
+});

--- a/src/__tests__/scan-render.snapshot.test.ts
+++ b/src/__tests__/scan-render.snapshot.test.ts
@@ -684,7 +684,7 @@ describe('N6 — state-aware phrasing (enabledShields injected)', () => {
     const out = captureOutput();
     // S2 — the founder's bug: CTA for an enabled shield.
     expect(out).not.toContain('shield enable project-jail');
-    expect(out).toContain('✓ enabled — enforcing in-path');
+    expect(out).toContain('✓ enabled');
     expect(out).toContain('✓ recommended shields are enabled');
     // S2 — origin tags follow the same state.
     expect(out).toContain('✓ shield:project-jail');
@@ -712,7 +712,7 @@ describe('N6 — state-aware phrasing (enabledShields injected)', () => {
       );
       const out = stripTerminalEscapes(lastFrame() ?? '');
       expect(out).not.toContain('shield enable project-jail');
-      expect(out).toContain('✓ enabled — enforcing in-path');
+      expect(out).toContain('✓ enabled');
       // Ink truncates the origin column (`✓ shield:projec…`), so both the
       // positive AND the negative assertion must use truncation-surviving
       // prefixes — `not.toContain('needs shield:project-jail')` would pass

--- a/src/__tests__/scan-render.snapshot.test.ts
+++ b/src/__tests__/scan-render.snapshot.test.ts
@@ -661,3 +661,68 @@ describe('renderScanScorecardInk — output snapshots', () => {
     expect(stripTerminalEscapes(lastFrame() ?? '')).toMatchSnapshot();
   });
 });
+
+// ---------------------------------------------------------------------------
+// N6 — state-aware phrasing. Same fixture, enabledShields injected: the
+// renderers must stop recommending what is already enforcing, flip origin
+// tags to ✓, and move enabled zero-hit shields off the "install
+// proactively" pitch. The un-injected snapshots above are the S1 guard:
+// pre-install output must not change.
+// ---------------------------------------------------------------------------
+
+describe('N6 — state-aware phrasing (enabledShields injected)', () => {
+  const NOW = new Date('2026-05-12T00:00:00Z');
+  // project-jail has hits in panelFixture; postgres has none — covers
+  // both the row path and the zero-hit path.
+  const withState = (): CompactInput => ({
+    ...panelFixture(),
+    enabledShields: ['postgres', 'project-jail'],
+  });
+
+  it('chalk panel: an enabled shield is never recommended, tags flip to ✓', () => {
+    renderPanelScorecard(withState(), NOW);
+    const out = captureOutput();
+    // S2 — the founder's bug: CTA for an enabled shield.
+    expect(out).not.toContain('shield enable project-jail');
+    expect(out).toContain('✓ enabled — enforcing in-path');
+    expect(out).toContain('✓ recommended shields are enabled');
+    // S2 — origin tags follow the same state.
+    expect(out).toContain('✓ shield:project-jail');
+    expect(out).not.toContain('needs shield:project-jail');
+    // S4 — enabled zero-hit shield moves off the upsell line.
+    expect(out).toContain('✓ active: postgres');
+    const proactive = out.split('\n').filter((l) => l.includes('·') && l.includes('redis'));
+    for (const line of proactive) expect(line).not.toContain('postgres');
+    expect(out).toMatchSnapshot();
+  });
+
+  it('ink scorecard: same state law through StaticScorecard', async () => {
+    const ORIG_COLUMNS = process.stdout.columns;
+    Object.defineProperty(process.stdout, 'columns', { value: 90, configurable: true });
+    try {
+      const { render } = await import('ink-testing-library');
+      const { StaticScorecard } = await import('../cli/render/ink/StaticScorecard.js');
+      const React = await import('react');
+      const { lastFrame } = render(
+        React.createElement(StaticScorecard, {
+          input: withState(),
+          rangeLabel: 'last 90 days',
+          now: NOW,
+        })
+      );
+      const out = stripTerminalEscapes(lastFrame() ?? '');
+      expect(out).not.toContain('shield enable project-jail');
+      expect(out).toContain('✓ enabled — enforcing in-path');
+      // Ink truncates the origin column (`✓ shield:projec…`), so both the
+      // positive AND the negative assertion must use truncation-surviving
+      // prefixes — `not.toContain('needs shield:project-jail')` would pass
+      // vacuously against a truncated tag (a false witness).
+      expect(out).toContain('✓ shield:proje');
+      expect(out).not.toContain('needs shield:pr');
+      expect(out).toContain('✓ active: postgres');
+      expect(out).toMatchSnapshot();
+    } finally {
+      Object.defineProperty(process.stdout, 'columns', { value: ORIG_COLUMNS, configurable: true });
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,8 +34,8 @@ import { spawn } from 'child_process';
 import { confirm } from '@inquirer/prompts';
 import { parseDuration } from './utils/duration';
 import { runProxy } from './proxy';
-import { autoStartDaemonAndWait, isTestingMode } from './cli/daemon-starter';
-import { ensureAutostartHealthy } from './daemon/service';
+import { autoStartDaemonAndWait } from './cli/daemon-starter';
+import { onboardMachine, renderOnboardOutcome } from './onboarding';
 import { registerCheckCommand } from './cli/commands/check';
 import { registerLogCommand } from './cli/commands/log';
 import { registerShieldCommand, registerConfigShowCommand } from './cli/commands/shield';
@@ -82,38 +82,32 @@ program
   .argument('<apiKey>')
   .option('--local', 'Save key for audit/logging only — local config still controls all decisions')
   .option('--profile <name>', 'Save as a named profile (default: "default")')
-  .action((apiKey, options: { local?: boolean; profile?: string }) => {
-    const { profileName, effectiveCloud } = writeCredentialsAndConfig(apiKey, {
-      profileName: options.profile,
-      isLocal: options.local,
-    });
-
-    if (options.profile && profileName !== 'default') {
+  .action(async (apiKey, options: { local?: boolean; profile?: string }) => {
+    // Named profile / --local keep their narrow legacy behavior: write the key,
+    // say what happened, no cloud onboarding. Profiles are on a deprecation
+    // path (login-v2 §6); --local is the explicit privacy-mode switch.
+    if (options.profile && options.profile !== 'default') {
+      const { profileName } = writeCredentialsAndConfig(apiKey, {
+        profileName: options.profile,
+        isLocal: options.local,
+      });
       console.log(chalk.green(`✅ Profile "${profileName}" saved`));
       console.log(chalk.gray(`   Switch to it per-session:  NODE9_PROFILE=${profileName} claude`));
-    } else if (options.local || effectiveCloud === false) {
+      return;
+    }
+    if (options.local) {
+      writeCredentialsAndConfig(apiKey, { isLocal: true });
       console.log(chalk.green(`✅ Key saved — Privacy mode 🛡️`));
       console.log(chalk.gray(`   All decisions stay on this machine. Nothing syncs to the cloud.`));
-      if (!options.local) {
-        console.log(
-          chalk.yellow(`   Your config has cloud approvals OFF (settings.approvers.cloud).`)
-        );
-        console.log(
-          chalk.gray(`   To enable team policy + dashboard sync: set it to true, or re-init.`)
-        );
-      }
-    } else {
-      console.log(chalk.green(`✅ Logged in — agent mode`));
-      console.log(chalk.gray(`   Team policy enforced for all calls via Node9 cloud.`));
-      // Self-heal autostart: a missing/disabled service (the stale-policy trigger)
-      // gets (re)enabled at the moment the machine becomes cloud-enabled, so cloud
-      // policy keeps syncing across reboots. Best-effort, only when opted in.
-      if (!isTestingMode()) {
-        const healed = ensureAutostartHealthy(!!getConfig().settings.autoStartDaemon);
-        if (healed === 'repaired')
-          console.log(chalk.green(`   ✓ Re-enabled daemon autostart (survives reboot)`));
-      }
+      return;
     }
+
+    // Default profile, cloud mode: run THE shared onboarding routine
+    // (onboarding.ts) — same steps and same scorecard as `node9 connect`, so a
+    // manually-entered key ends with a machine the dashboard can actually see.
+    const outcome = await onboardMachine(apiKey);
+    console.log(renderOnboardOutcome(outcome));
+    if (!outcome.ok) process.exitCode = 1;
   });
 
 // 1b. SIGNUP — open the node9 dashboard signup/login in the browser (Phase-1 capture).

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -3,15 +3,14 @@ import http from 'http';
 import https from 'https';
 import { URL } from 'url';
 import chalk from 'chalk';
-import { writeCredentialsAndConfig } from '../../credentials';
-import { setupDetectedAgents } from '../../setup';
-import { runCloudSync } from '../../daemon/sync';
-import { isTestingMode } from '../daemon-starter';
+import { onboardMachine, renderOnboardOutcome } from '../../onboarding';
 
 // node9 connect <token> — the onboarding bridge. Exchanges a dashboard connect
-// token for a workspace key (POST /cli/connect), writes credentials + config,
-// wires detected agents non-interactively, and fires one sync so the machine
-// shows up in the dashboard. No raw key is ever copy-pasted by the user.
+// token for a workspace key (POST /cli/connect), then hands off to THE shared
+// onboarding routine (onboarding.ts): credentials, agent wiring, policy sync,
+// and the acked snapshot push that makes the machine exist in the dashboard.
+// No raw key is ever copy-pasted by the user. Exit 1 when any required step
+// fails — a machine the cloud never acked must not hear "Connected".
 const DEFAULT_CONNECT_URL = 'https://api.node9.ai/api/v1/cli/connect';
 
 interface ConnectResponse {
@@ -96,35 +95,8 @@ export function registerConnectCommand(program: Command): void {
         return;
       }
 
-      // Reuse login's writer (credentials.json + config.json approvers).
-      writeCredentialsAndConfig(resp.apiKey, { profileName: options.profile });
-
-      // Wire detected agents without prompting (curl | sh has no TTY).
-      process.env.NODE9_NONINTERACTIVE = '1';
-      let wired: string[] = [];
-      try {
-        wired = await setupDetectedAgents();
-      } catch {
-        // Agent wiring is best-effort; the connection itself already succeeded.
-      }
-
-      // Register the machine with the cloud so the dashboard shows it. Skipped
-      // under the test runner (no live cloud).
-      if (!isTestingMode()) {
-        try {
-          await runCloudSync();
-        } catch {
-          // Best-effort — the first hook call will sync anyway.
-        }
-      }
-
-      console.log(chalk.green(`✅ Connected to ${resp.workspaceName}`));
-      if (wired.length) {
-        console.log(chalk.gray(`   Wired: ${wired.join(', ')}`));
-      } else {
-        console.log(
-          chalk.gray('   No agents detected yet — run `node9 init` after installing one.')
-        );
-      }
+      const outcome = await onboardMachine(resp.apiKey, { profileName: options.profile });
+      console.log(renderOnboardOutcome(outcome, { workspaceName: resp.workspaceName }));
+      if (!outcome.ok) process.exitCode = 1;
     });
 }

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -2693,9 +2693,11 @@ export function renderCompactScorecard(input: CompactInput): void {
   const longIterations = scan.loopFindings.filter((l) => l.kind === 'long-iteration');
 
   if (realLoops.length > 0) {
-    const { wastePct } = computeLoopWaste(realLoops, scan.totalToolCalls);
+    const { wastePct, wastedCalls } = computeLoopWaste(realLoops, scan.totalToolCalls);
     const wasteParts: string[] = [];
-    if (wastePct > 0) wasteParts.push(`${wastePct}% wasted`);
+    // "% of all calls", never bare "% wasted": the percentage is a share of
+    // tool CALLS, and unlabeled it reads as a share of the cost beside it.
+    if (wastedCalls > 0) wasteParts.push(`${wastedCalls} wasted calls (${wastePct}% of all calls)`);
     if (summary.loopWastedUSD > 0) wasteParts.push('~' + fmtCost(summary.loopWastedUSD));
     const wasteSummary = wasteParts.length ? `(${wasteParts.join('  ·  ')})` : '';
     console.log(
@@ -2822,10 +2824,10 @@ export function renderNarrativeScorecard(input: CompactInput): void {
 
   // ── Loops → medium ──────────────────────────────────────────────────
   if (scan.loopFindings.length > 0) {
-    const { wastePct } = computeLoopWaste(scan.loopFindings, scan.totalToolCalls);
+    const { wastePct, wastedCalls } = computeLoopWaste(scan.loopFindings, scan.totalToolCalls);
     const cost = summary.loopWastedUSD > 0 ? `, ~${fmtCost(summary.loopWastedUSD)} wasted` : '';
     medium.push({
-      label: `${scan.loopFindings.length} agent loops (${wastePct}% of calls${cost})`,
+      label: `${scan.loopFindings.length} agent loops (${wastedCalls} wasted calls, ${wastePct}% of calls${cost})`,
       count: scan.loopFindings.length,
     });
   }
@@ -3018,7 +3020,7 @@ export function renderPanelScorecard(input: CompactInput, now: Date = new Date()
     );
   }
   if (scan.loopFindings.length > 0) {
-    const { wastePct } = computeLoopWaste(scan.loopFindings, scan.totalToolCalls);
+    const { wastePct, wastedCalls } = computeLoopWaste(scan.loopFindings, scan.totalToolCalls);
     // Surface the dominant tool name inline — more useful than
     // "repeated patterns" filler and lets the line fit in 72 cols.
     const byTool = new Map<string, number>();
@@ -3026,7 +3028,8 @@ export function renderPanelScorecard(input: CompactInput, now: Date = new Date()
       byTool.set(f.toolName, (byTool.get(f.toolName) ?? 0) + Math.max(0, f.count - 1));
     }
     const top = [...byTool.entries()].sort((a, b) => b[1] - a[1])[0];
-    const wasteSuffix = wastePct > 0 ? `, ${wastePct}% wasted` : '';
+    const wasteSuffix =
+      wastedCalls > 0 ? `, ${wastedCalls} wasted calls · ${wastePct}% of calls` : '';
     const detail = top ? `(${top[0]} dominates${wasteSuffix})` : '';
     topLines.push(
       mkLine(
@@ -3141,7 +3144,7 @@ export function renderPanelScorecard(input: CompactInput, now: Date = new Date()
   // Efficiency, not severity. Split off from REVIEW so the eye isn't
   // confused about what "needs approval" vs "is wasteful but harmless".
   if (scan.loopFindings.length > 0) {
-    const { wastePct } = computeLoopWaste(scan.loopFindings, scan.totalToolCalls);
+    const { wastePct, wastedCalls } = computeLoopWaste(scan.loopFindings, scan.totalToolCalls);
 
     // Group loop findings by toolName to compute the breakdown.
     const byTool = new Map<string, number>();
@@ -3179,8 +3182,9 @@ export function renderPanelScorecard(input: CompactInput, now: Date = new Date()
       }
     }
 
-    const wasteSuffix = wastePct > 0 ? `  ·  ${wastePct}% wasted` : '';
-    const title = `AGENT LOOPS  ·  ${scan.loopFindings.length} repeated patterns${wasteSuffix}`;
+    const wasteSuffix =
+      wastedCalls > 0 ? `  ·  ${wastedCalls} wasted calls (${wastePct}% of all calls)` : '';
+    const title = `AGENT LOOPS  ·  ${scan.loopFindings.length} pattern${scan.loopFindings.length !== 1 ? 's' : ''}${wasteSuffix}`;
     for (const ln of boxPanel(title, loopLines)) console.log('  ' + ln);
     // Earlier the "N repeated calls (~N × cost-per-iteration)" line
     // printed below the panel, but it sat outside the frame and read
@@ -3711,7 +3715,7 @@ export function registerScanCommand(program: Command): void {
           }
           if (scan.loopFindings.length > 0) {
             const { wastePct } = computeLoopWaste(scan.loopFindings, scan.totalToolCalls);
-            const wasteSuffix = wastePct > 0 ? chalk.dim(` (${wastePct}% wasted)`) : '';
+            const wasteSuffix = wastePct > 0 ? chalk.dim(` (${wastePct}% of calls)`) : '';
             cardParts.push(
               chalk.yellow('🔁 ') +
                 chalk.yellow.bold(String(scan.loopFindings.length)) +

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -3066,7 +3066,7 @@ export function renderPanelScorecard(input: CompactInput, now: Date = new Date()
     // figure the reader cannot check. State-aware CTA (N6): never tell
     // the user to enable a shield that is already enforcing.
     const cta = enabledSet.has('project-jail')
-      ? '  → agent reads blocked in-path (project-jail ✓)'
+      ? '  → project-jail ✓ enabled'
       : '  → enable project-jail';
     topLines.push(
       mkLine(
@@ -3272,11 +3272,7 @@ export function renderPanelScorecard(input: CompactInput, now: Date = new Date()
     // cannot check (this chalk twin lagged the ink fix in 3c10119).
     // Tense honesty (N6): `✓ enabled` is a statement about NOW; whether
     // PAST events were blocked is report's claim to make, not scan's.
-    const suffix = isOn
-      ? '✓ enabled — enforcing in-path'
-      : discount > 0
-        ? '→ blocks these reads in-path'
-        : '';
+    const suffix = isOn ? '✓ enabled' : discount > 0 ? '→ blocks these reads in-path' : '';
     shieldLines.push(
       mkLine(
         [icon, discount > 0 ? chalk.cyan : chalk.dim],
@@ -4052,7 +4048,7 @@ export function registerScanCommand(program: Command): void {
             if (reviewRules.length === 0) continue;
             const enableHint = section.shieldKey
               ? enabledShieldSet.has(section.shieldKey)
-                ? chalk.green(`  ✓  ${section.shieldKey} enabled — enforcing in-path`)
+                ? chalk.green(`  ✓  ${section.shieldKey} enabled`)
                 : chalk.dim(`  →  node9 shield enable ${section.shieldKey}`)
               : '';
             console.log('  ' + chalk.dim('─'.repeat(70)));

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -15,7 +15,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { SHIELDS } from '../../shields';
-import { DEFAULT_CONFIG } from '../../config';
+import { DEFAULT_CONFIG, getConfig } from '../../config';
 
 // Scan forecasts DEFAULT protection (see the note in the rule-source builder),
 // so rule/tool matching keys off the DEFAULT toolInspection map. Shared with the
@@ -61,6 +61,7 @@ import {
   boxPanel,
   classifyScore,
   computeLoopWaste,
+  originForRule,
   relativeDate,
   rollupByShield,
   topDlpPatterns,
@@ -2620,6 +2621,14 @@ export interface CompactInput {
   blastExposures: number;
   blockedCount: number;
   reviewCount: number;
+  /** Shields the gate is ACTUALLY enforcing right now — read off
+   *  `getConfig().policy.appliedShields` (the apply loop's own testimony,
+   *  N6). Renderers use it to phrase recommendations: an enabled shield
+   *  must never be offered as `shield enable X` / "install proactively".
+   *  Absent or empty = pre-install machine → pure-forecast phrasing
+   *  (today's output, unchanged). Snapshot fixtures omit it, so tests
+   *  stay hermetic and pin the pre-install shape by default. */
+  enabledShields?: string[];
 }
 
 export function renderCompactScorecard(input: CompactInput): void {
@@ -2992,6 +3001,9 @@ function shortRule(name: string, width: number): string {
 
 export function renderPanelScorecard(input: CompactInput, now: Date = new Date()): void {
   const { scan, summary, blast, blastExposures, blockedCount, reviewCount } = input;
+  // Gate testimony (policy.appliedShields, N6). Empty = pre-install
+  // machine → forecast phrasing, unchanged.
+  const enabledSet = new Set(input.enabledShields ?? []);
 
   // ── TOP FINDINGS ─────────────────────────────────────────────────────
   // Auto-derived: pick the highest-impact one fact per category. Each
@@ -3050,10 +3062,12 @@ export function renderPanelScorecard(input: CompactInput, now: Date = new Date()
     );
   }
   if (blastExposures > 0) {
-    const exposed = Math.max(0, 100 - blast.score);
-    const pjDiscount = PROTECTIVE_SHIELD_DISCOUNTS['project-jail'] ?? 0;
-    const pjBonus = Math.round(exposed * pjDiscount);
-    const cta = pjBonus > 0 ? `  → enable project-jail (+${pjBonus} pts)` : '';
+    // Option B (N1): no `+N pts` — the points were exposed × discount, a
+    // figure the reader cannot check. State-aware CTA (N6): never tell
+    // the user to enable a shield that is already enforcing.
+    const cta = enabledSet.has('project-jail')
+      ? '  → agent reads blocked in-path (project-jail ✓)'
+      : '  → enable project-jail';
     topLines.push(
       mkLine(
         ['🔭 ', chalk.red],
@@ -3106,7 +3120,7 @@ export function renderPanelScorecard(input: CompactInput, now: Date = new Date()
     const blockedLines: Line[] = [];
     const ruleEntries = topRulesByVerdict(summary.sections, 'block', 12);
     for (const r of ruleEntries) {
-      const origin = originForRule(r.name, summary.sections);
+      const origin = originForRule(r.name, summary.sections, enabledSet);
       blockedLines.push(
         mkLine(
           ['✗ ', chalk.red],
@@ -3130,7 +3144,7 @@ export function renderPanelScorecard(input: CompactInput, now: Date = new Date()
     const reviewLines: Line[] = [];
     const ruleEntries = topRulesByVerdict(summary.sections, 'review', 12);
     for (const r of ruleEntries) {
-      const origin = originForRule(r.name, summary.sections);
+      const origin = originForRule(r.name, summary.sections, enabledSet);
       reviewLines.push(
         mkLine(
           // VS-16 (U+FE0F) forces emoji-presentation so string-width
@@ -3238,7 +3252,6 @@ export function renderPanelScorecard(input: CompactInput, now: Date = new Date()
   // shields (project-jail today; future protective shields auto-extend
   // via PROTECTIVE_SHIELD_DISCOUNTS).
   const shieldImpacts = rollupByShield(summary.sections);
-  const exposed = Math.max(0, 100 - blast.score);
   const shieldLines: Line[] = [];
 
   // Sort: protective shields with score impact first, then by hit count.
@@ -3252,17 +3265,24 @@ export function renderPanelScorecard(input: CompactInput, now: Date = new Date()
   for (const impact of ranked) {
     if (impact.totalCatches === 0) continue; // hit shields only — zero-hits go to footer
     const discount = PROTECTIVE_SHIELD_DISCOUNTS[impact.shieldName] ?? 0;
-    const bonus = Math.round(exposed * discount);
+    const isOn = enabledSet.has(impact.shieldName);
     const icon = discount > 0 ? '🛡️  ' : '☐   ';
-    const wouldCatch = `would catch ${impact.totalCatches} op${impact.totalCatches !== 1 ? 's' : ''}`;
-    const deltaSuffix =
-      bonus > 0 ? `  →  +${bonus} pts  (${blast.score} → ${blast.score + bonus})` : '';
+    const wouldCatch = `catches ${impact.totalCatches} op${impact.totalCatches !== 1 ? 's' : ''}`;
+    // Option B (N1): no `+N pts (5 → 72)` — score arithmetic the reader
+    // cannot check (this chalk twin lagged the ink fix in 3c10119).
+    // Tense honesty (N6): `✓ enabled` is a statement about NOW; whether
+    // PAST events were blocked is report's claim to make, not scan's.
+    const suffix = isOn
+      ? '✓ enabled — enforcing in-path'
+      : discount > 0
+        ? '→ blocks these reads in-path'
+        : '';
     shieldLines.push(
       mkLine(
         [icon, discount > 0 ? chalk.cyan : chalk.dim],
         [impact.shieldName.padEnd(14), chalk.bold],
         [wouldCatch.padEnd(22), chalk.dim],
-        [deltaSuffix, bonus > 0 ? chalk.green.bold : chalk.dim]
+        [suffix, isOn || discount > 0 ? chalk.green.bold : chalk.dim]
       )
     );
     // Top rule descriptions on a sub-line.
@@ -3280,49 +3300,67 @@ export function renderPanelScorecard(input: CompactInput, now: Date = new Date()
   // Built-ins only — a user-installed shield must not appear in the "install
   // these builtins proactively" hint, and keeping this off the user-shield
   // registry (SHIELDS) also makes the render hermetic for snapshot tests.
-  const zeroHitBuiltins = Object.keys(BUILTIN_SHIELDS)
+  // Zero-hit builtins split by state (N6): only a shield that is NOT
+  // already enforcing may be pitched as "install proactively" — the
+  // founder's machine showed an ACTIVE postgres shield under that line.
+  const zeroHitAll = Object.keys(BUILTIN_SHIELDS)
     .filter((name) => !hitShieldSet.has(name))
     .sort();
+  const zeroHitBuiltins = zeroHitAll.filter((name) => !enabledSet.has(name));
+  const zeroHitEnabled = zeroHitAll.filter((name) => enabledSet.has(name));
+  if (zeroHitEnabled.length > 0) {
+    shieldLines.push(mkLine([''])); // blank separator
+    shieldLines.push(
+      mkLine([
+        `✓ active: ${zeroHitEnabled.join(' · ')}  (no hits in this history)`,
+        chalk.green.dim,
+      ])
+    );
+  }
   if (zeroHitBuiltins.length > 0) {
     shieldLines.push(mkLine([''])); // blank separator
     shieldLines.push(mkLine([zeroHitBuiltins.join(' · '), chalk.dim]));
     shieldLines.push(mkLine(['      no hits in your history — install proactively', chalk.dim]));
   }
 
-  // Final CTA line inside the panel: highest-impact recommendation.
+  // Final CTA line: highest-impact protective shield NOT already enabled
+  // (N6 — never hand the user a command that is already true). Option B
+  // (N1): "widest coverage", not `+N pts` (chalk twin of ink 3c10119).
   const topRec = ranked.find(
-    (r) => r.totalCatches > 0 && (PROTECTIVE_SHIELD_DISCOUNTS[r.shieldName] ?? 0) > 0
+    (r) =>
+      r.totalCatches > 0 &&
+      (PROTECTIVE_SHIELD_DISCOUNTS[r.shieldName] ?? 0) > 0 &&
+      !enabledSet.has(r.shieldName)
   );
+  const allCovered =
+    !topRec &&
+    ranked.some(
+      (r) =>
+        r.totalCatches > 0 &&
+        (PROTECTIVE_SHIELD_DISCOUNTS[r.shieldName] ?? 0) > 0 &&
+        enabledSet.has(r.shieldName)
+    );
   if (topRec) {
-    const bonus = Math.round(exposed * (PROTECTIVE_SHIELD_DISCOUNTS[topRec.shieldName] ?? 0));
-    const cta = `→ node9 shield enable ${topRec.shieldName}   (start here — +${bonus} pts)`;
+    const cta = `→ node9 shield enable ${topRec.shieldName}   (start here — widest coverage)`;
     shieldLines.push(mkLine([''])); // blank separator
     shieldLines.push(mkLine([cta, chalk.cyan]));
+  } else if (allCovered) {
+    shieldLines.push(mkLine([''])); // blank separator
+    shieldLines.push(mkLine(['✓ recommended shields are enabled', chalk.green.bold]));
   }
 
   if (shieldLines.length > 0) {
-    const title = 'SHIELDS  ·  install node9 + enable these to catch what we found';
+    const title =
+      enabledSet.size > 0
+        ? 'SHIELDS  ·  your coverage vs what we found'
+        : 'SHIELDS  ·  install node9 + enable these to catch what we found';
     for (const ln of boxPanel(title, shieldLines)) console.log('  ' + ln);
     console.log('');
   }
 }
 
-/** Find which origin tag (e.g. `default` or `needs shield:project-jail`)
- *  applies to a given rule name. The lookup walks the summary sections
- *  to find which one owns the rule. Used by BLOCKED + REVIEW QUEUE
- *  panels to render the rightmost origin column. */
-function originForRule(
-  ruleName: string,
-  sections: ReadonlyArray<ScanSummary['sections'][number]>
-): string {
-  for (const section of sections) {
-    if (section.rules.some((r) => r.name === ruleName)) {
-      if (section.sourceType === 'default') return 'default';
-      if (section.sourceType === 'shield') return `needs shield:${section.shieldKey ?? section.id}`;
-    }
-  }
-  return '';
-}
+// originForRule moved to scan-derive.ts when it became state-aware (N6) —
+// one law shared with BlockedPanel/ReviewQueuePanel so phrasing can't drift.
 
 // ---------------------------------------------------------------------------
 // Registered command
@@ -3401,6 +3439,13 @@ export function registerScanCommand(program: Command): void {
         // for ~/.node9/audit.log alone falsely treats npx users as installed
         // after their first run.
         const isWired = getAgentsStatus().some((a) => a.wired);
+
+        // What the gate is ACTUALLY enforcing (N6) — the apply loop's own
+        // testimony, never shields.json / rules-cache.json directly (the
+        // two files can diverge; the testimony can't). Read once here,
+        // threaded to every renderer via CompactInput.
+        const enabledShields = getConfig().policy.appliedShields ?? [];
+        const enabledShieldSet = new Set(enabledShields);
 
         // Compact / narrative modes print their own self-contained scorecard —
         // suppress the verbose preamble (banner + "scanning..." line) so the
@@ -3624,6 +3669,7 @@ export function registerScanCommand(program: Command): void {
             blastExposures,
             blockedCount,
             reviewCount,
+            enabledShields,
           });
           return;
         }
@@ -3640,6 +3686,7 @@ export function registerScanCommand(program: Command): void {
             blastExposures,
             blockedCount,
             reviewCount,
+            enabledShields,
           });
           return;
         }
@@ -3809,6 +3856,7 @@ export function registerScanCommand(program: Command): void {
                   blastExposures,
                   blockedCount,
                   reviewCount,
+                  enabledShields,
                 },
                 rangeLabel
               );
@@ -3825,6 +3873,7 @@ export function registerScanCommand(program: Command): void {
                 blastExposures,
                 blockedCount,
                 reviewCount,
+                enabledShields,
               });
             }
             // Footer CTAs — distinct from the legacy footer at end of
@@ -4002,7 +4051,9 @@ export function registerScanCommand(program: Command): void {
             const reviewRules = section.rules.filter((r) => r.verdict !== 'block');
             if (reviewRules.length === 0) continue;
             const enableHint = section.shieldKey
-              ? chalk.dim(`  →  node9 shield enable ${section.shieldKey}`)
+              ? enabledShieldSet.has(section.shieldKey)
+                ? chalk.green(`  ✓  ${section.shieldKey} enabled — enforcing in-path`)
+                : chalk.dim(`  →  node9 shield enable ${section.shieldKey}`)
               : '';
             console.log('  ' + chalk.dim('─'.repeat(70)));
             console.log(
@@ -4020,14 +4071,30 @@ export function registerScanCommand(program: Command): void {
           }
 
           // ── Inactive Shields — upsell, always last ─────────────────────────
-          const activeShieldIds = new Set(
+          // hitShieldIds = shields with FINDINGS in this history (they render
+          // their own sections above); this footer covers the rest. Split by
+          // gate state (N6): "Inactive" must mean not-enabled — an ENABLED
+          // shield with no hits is coverage, not an upsell target.
+          const hitShieldIds = new Set(
             summary.sections
               .filter((s) => s.sourceType === 'shield' && s.shieldKey)
               .map((s) => s.shieldKey!)
           );
-          const emptyShields = Object.keys(SHIELDS)
-            .filter((n) => !activeShieldIds.has(n))
+          const noHitShields = Object.keys(SHIELDS)
+            .filter((n) => !hitShieldIds.has(n))
             .sort();
+          const quietEnabled = noHitShields.filter((n) => enabledShieldSet.has(n));
+          const emptyShields = noHitShields.filter((n) => !enabledShieldSet.has(n));
+          if (quietEnabled.length > 0) {
+            console.log('  ' + chalk.dim('─'.repeat(70)));
+            console.log(
+              '  ' +
+                chalk.bold('🛡  Active Shields') +
+                chalk.dim('  ·  enabled, no hits in this history')
+            );
+            console.log('  ' + chalk.green('✓ ') + chalk.dim(quietEnabled.join(' · ')));
+            console.log('');
+          }
           if (emptyShields.length > 0) {
             console.log('  ' + chalk.dim('─'.repeat(70)));
             console.log(

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -2640,13 +2640,20 @@ export function renderCompactScorecard(input: CompactInput): void {
   );
   console.log('');
 
-  // ── Score + risky count ──────────────────────────────────────────────
-  const score = classifyScore(blast.score);
+  // ── Exposure + risky count ───────────────────────────────────────────
+  // Option B (BUGS.md N1): scan reports COUNTS, not an N/100. Two different
+  // formulas both rendered as "score" made scan and posture contradict each
+  // other on one machine; a count and a score cannot. posture owns the only
+  // N/100, and blast.score itself still ships unchanged (SaaS, --json, trend).
+  const exposurePaths = blast.reachable.length;
+  const exposureEnvs = blast.envFindings.length;
   console.log(
-    chalk.bold('Security Score: ') +
-      score.color.bold(`${blast.score}/100`) +
-      chalk.dim('  ·  ') +
-      score.color(score.label)
+    chalk.bold('Exposure: ') +
+      (exposurePaths > 0 ? chalk.red.bold : chalk.green.bold)(
+        `${exposurePaths} path${exposurePaths !== 1 ? 's' : ''}` +
+          (exposureEnvs > 0 ? ` + ${exposureEnvs} env var${exposureEnvs !== 1 ? 's' : ''}` : '')
+      ) +
+      chalk.dim(' reachable by the agent')
   );
   if (scan.totalCostUSD > 0) {
     console.log(
@@ -2856,14 +2863,17 @@ export function renderNarrativeScorecard(input: CompactInput): void {
   );
   console.log('');
 
-  // ── Score ──────────────────────────────────────────────────────────
-  const score = classifyScore(blast.score);
+  // ── Exposure (option B — counts, not a second N/100; see N1) ────────
+  const nPaths = blast.reachable.length;
+  const nEnvs = blast.envFindings.length;
   console.log(
-    (score.band === 'critical' ? chalk.red.bold('⚠  ') : '') +
-      chalk.bold('Security Score: ') +
-      score.color.bold(`${blast.score}/100`) +
-      chalk.dim('  ·  ') +
-      score.color(score.label)
+    (nPaths > 0 ? chalk.red.bold('⚠  ') : '') +
+      chalk.bold('Exposure: ') +
+      (nPaths > 0 ? chalk.red.bold : chalk.green.bold)(
+        `${nPaths} path${nPaths !== 1 ? 's' : ''}` +
+          (nEnvs > 0 ? ` + ${nEnvs} env var${nEnvs !== 1 ? 's' : ''}` : '')
+      ) +
+      chalk.dim(' reachable by the agent')
   );
   console.log('');
 

--- a/src/cli/render/ink/StaticScorecard.tsx
+++ b/src/cli/render/ink/StaticScorecard.tsx
@@ -162,7 +162,7 @@ export function StaticScorecard({ input, rangeLabel, now }: Props): React.ReactE
       })()}
 
       <SeverityBand label="Recommended action" width={width} />
-      <ShieldsPanel summary={input.summary} blastScore={input.blast.score} width={width} />
+      <ShieldsPanel summary={input.summary} width={width} />
     </Box>
   );
 }

--- a/src/cli/render/ink/StaticScorecard.tsx
+++ b/src/cli/render/ink/StaticScorecard.tsx
@@ -82,7 +82,10 @@ export function StaticScorecard({ input, rangeLabel, now }: Props): React.ReactE
       parts.push(`${leakCount} secret${leakCount !== 1 ? 's' : ''} leaked`);
     }
     if (blockedCount > 0) {
-      parts.push(`${blockedCount} op${blockedCount !== 1 ? 's' : ''} blocked`);
+      // "would be blocked", never "blocked": the panel beneath is WOULD HAVE
+      // BLOCKED (shields not yet enabled). The header must not claim an action
+      // node9 did not take.
+      parts.push(`${blockedCount} op${blockedCount !== 1 ? 's' : ''} would be blocked`);
     }
     return `Critical (${parts.join(' + ')})`;
   })();
@@ -110,7 +113,15 @@ export function StaticScorecard({ input, rangeLabel, now }: Props): React.ReactE
       {input.blastExposures > 0 ? (
         <>
           <SeverityBand
-            label={`High (${input.blastExposures} path${input.blastExposures !== 1 ? 's' : ''} reachable on disk)`}
+            label={(() => {
+              // blastExposures = paths + env vars; calling the sum "paths" made
+              // the band disagree with the panel's row groups. Name each part.
+              const paths = input.blast.reachable.length;
+              const envs = input.blast.envFindings.length;
+              const pathPart = `${paths} path${paths !== 1 ? 's' : ''}`;
+              const envPart = envs > 0 ? ` + ${envs} env var${envs !== 1 ? 's' : ''}` : '';
+              return `High (${pathPart}${envPart} reachable)`;
+            })()}
             width={width}
           />
           <BlastRadiusPanel
@@ -125,12 +136,19 @@ export function StaticScorecard({ input, rangeLabel, now }: Props): React.ReactE
         const reviewCount = input.reviewCount;
         const loopCount = input.scan.loopFindings.length;
         if (reviewCount === 0 && loopCount === 0) return null;
-        const { wastePct } = computeLoopWaste(input.scan.loopFindings, input.scan.totalToolCalls);
+        const { wastePct, wastedCalls } = computeLoopWaste(
+          input.scan.loopFindings,
+          input.scan.totalToolCalls
+        );
         const parts: string[] = [];
         if (reviewCount > 0) parts.push(`${reviewCount} op${reviewCount !== 1 ? 's' : ''} flagged`);
         if (loopCount > 0)
+          // loops = repeated PATTERNS; wasted calls = repeats inside them. The
+          // % is a share of ALL TOOL CALLS — never render it as a cost share.
           parts.push(
-            `${loopCount} loop${loopCount !== 1 ? 's' : ''}${wastePct > 0 ? ` · ${wastePct}% wasted` : ''}`
+            `${loopCount} loop${loopCount !== 1 ? 's' : ''}${
+              wastedCalls > 0 ? ` · ${wastedCalls} wasted calls (${wastePct}% of all calls)` : ''
+            }`
           );
         return (
           <>

--- a/src/cli/render/ink/StaticScorecard.tsx
+++ b/src/cli/render/ink/StaticScorecard.tsx
@@ -105,7 +105,11 @@ export function StaticScorecard({ input, rangeLabel, now }: Props): React.ReactE
           <SeverityBand label={criticalLabel} width={width} />
           <Box flexDirection="row" gap={1}>
             <LeaksPanel summary={summary} width={halfWidth} now={now} />
-            <BlockedPanel summary={summary} width={halfWidth} />
+            <BlockedPanel
+              summary={summary}
+              width={halfWidth}
+              enabledShields={input.enabledShields}
+            />
           </Box>
         </>
       ) : null}
@@ -154,7 +158,11 @@ export function StaticScorecard({ input, rangeLabel, now }: Props): React.ReactE
           <>
             <SeverityBand label={`Medium (${parts.join(' · ')})`} width={width} />
             <Box flexDirection="row" gap={1}>
-              <ReviewQueuePanel summary={input.summary} width={halfWidth} />
+              <ReviewQueuePanel
+                summary={input.summary}
+                width={halfWidth}
+                enabledShields={input.enabledShields}
+              />
               <AgentLoopsPanel loopFindings={input.scan.loopFindings} width={halfWidth} />
             </Box>
           </>
@@ -162,7 +170,7 @@ export function StaticScorecard({ input, rangeLabel, now }: Props): React.ReactE
       })()}
 
       <SeverityBand label="Recommended action" width={width} />
-      <ShieldsPanel summary={input.summary} width={width} />
+      <ShieldsPanel summary={input.summary} width={width} enabledShields={input.enabledShields} />
     </Box>
   );
 }

--- a/src/cli/render/ink/panels/AgentLoopsPanel.tsx
+++ b/src/cli/render/ink/panels/AgentLoopsPanel.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import { Box, Text } from 'ink';
 
 import type { LoopFinding } from '../../../commands/scan.js';
+import { topOf } from './title-count.js';
 
 interface Props {
   loopFindings: LoopFinding[];
@@ -51,7 +52,10 @@ export function AgentLoopsPanel({ loopFindings, width }: Props): React.ReactElem
 
   return (
     <Box borderStyle="round" borderColor="gray" paddingX={1} flexDirection="column" width={width}>
-      <Text bold>AGENT LOOPS</Text>
+      <Text bold>
+        AGENT LOOPS
+        <Text dimColor>{topOf(toolEntries.length, byTool.size)}</Text>
+      </Text>
 
       {toolEntries.map(([tool, repeats]) => {
         const pct = totalRepeats > 0 ? Math.round((repeats / totalRepeats) * 100) : 0;

--- a/src/cli/render/ink/panels/BlastRadiusPanel.tsx
+++ b/src/cli/render/ink/panels/BlastRadiusPanel.tsx
@@ -14,6 +14,7 @@ import React from 'react';
 import { Box, Text } from 'ink';
 
 import type { CompactInput } from '../../../commands/scan.js';
+import { topOf } from './title-count.js';
 
 // CompactInput.blast carries the BlastResult shape (envFindings is an
 // array, not a count). Don't use BlastSnapshot — that's a separate
@@ -26,10 +27,13 @@ interface Props {
   width: number;
 }
 
-/** Max path rows shown individually. Above this, append a `… +N more`
- *  line. 4 keeps the panel tight; typical dev machines have ≤5 paths
- *  and the +N more roll-up handles longer lists. */
+/** Max path rows shown individually. 4 keeps the panel tight; typical
+ *  dev machines have ≤5 paths. Overflow is signalled in the panel TITLE
+ *  (`· top N of M`, see title-count.ts) — a `+N more` row was tried and
+ *  removed to save vertical space. Env rows carry their own cap below. */
 const ROW_LIMIT = 4;
+/** Max env-var rows (matches the slice(0, 3) in the render). */
+const ENV_ROW_LIMIT = 3;
 
 export function BlastRadiusPanel({
   blast,
@@ -38,10 +42,14 @@ export function BlastRadiusPanel({
 }: Props): React.ReactElement | null {
   if (blastExposures === 0) return null;
 
+  const shown =
+    Math.min(blast.reachable.length, ROW_LIMIT) + Math.min(blast.envFindings.length, ENV_ROW_LIMIT);
+
   return (
     <Box borderStyle="round" borderColor="yellow" paddingX={1} flexDirection="column" width={width}>
       <Text bold color="yellow">
         BLAST RADIUS
+        <Text dimColor>{topOf(shown, blastExposures)}</Text>
       </Text>
 
       {blast.reachable.slice(0, ROW_LIMIT).map((path, i) => {
@@ -69,10 +77,9 @@ export function BlastRadiusPanel({
         </Box>
       ))}
 
-      {/* No `… +N more` line — the severity-band header already
-       *  reports the total count, e.g. "High (5 paths reachable on
-       *  disk)". Keeping the panel one row tighter saves vertical
-       *  space. */}
+      {/* No `… +N more` row — the subset signal lives in the panel
+       *  title (`· top N of M`) so the panel stays one row tighter.
+       *  The severity band above carries the totals as well. */}
       <Box>
         <Text dimColor>{'→ '}</Text>
         <Text bold color="cyan">

--- a/src/cli/render/ink/panels/BlockedPanel.tsx
+++ b/src/cli/render/ink/panels/BlockedPanel.tsx
@@ -16,6 +16,7 @@ import { Box, Text } from 'ink';
 
 import type { ScanSummary } from '../../../../scan-summary.js';
 import { topRulesByVerdict } from '../../scan-derive.js';
+import { topOf } from './title-count.js';
 
 interface Props {
   summary: ScanSummary;
@@ -40,17 +41,20 @@ function originForRule(ruleName: string, sections: ScanSummary['sections']): str
   return '';
 }
 
-/** Cap on rule rows. Above this, append a `… +N more` line. */
+/** Cap on rule rows. Overflow is signalled in the panel title
+ *  (`· top N of M`, see title-count.ts) rather than a `+N more` row. */
 const ROW_LIMIT = 12;
 
 export function BlockedPanel({ summary, width }: Props): React.ReactElement | null {
-  const rules = topRulesByVerdict(summary.sections, 'block', ROW_LIMIT);
+  const allRules = topRulesByVerdict(summary.sections, 'block', Number.MAX_SAFE_INTEGER);
+  const rules = allRules.slice(0, ROW_LIMIT);
   if (rules.length === 0) return null;
 
   return (
     <Box borderStyle="round" borderColor="red" paddingX={1} flexDirection="column" width={width}>
       <Text bold color="red">
         WOULD HAVE BLOCKED
+        <Text dimColor>{topOf(rules.length, allRules.length)}</Text>
       </Text>
 
       {rules.map((rule, i) => (

--- a/src/cli/render/ink/panels/BlockedPanel.tsx
+++ b/src/cli/render/ink/panels/BlockedPanel.tsx
@@ -49,8 +49,8 @@ export function BlockedPanel({
     enabled.size === 0
       ? '→ install node9 + enable shields above'
       : anyNeeds
-        ? '→ ✓ rules are enforced in-path · enable the remaining shields above'
-        : '→ ✓ enforced in-path by your enabled shields';
+        ? '→ ✓ marks rules from enabled shields · enable the rest above'
+        : '→ ✓ all these rules come from enabled shields';
 
   return (
     <Box borderStyle="round" borderColor="red" paddingX={1} flexDirection="column" width={width}>

--- a/src/cli/render/ink/panels/BlockedPanel.tsx
+++ b/src/cli/render/ink/panels/BlockedPanel.tsx
@@ -15,40 +15,42 @@ import React from 'react';
 import { Box, Text } from 'ink';
 
 import type { ScanSummary } from '../../../../scan-summary.js';
-import { topRulesByVerdict } from '../../scan-derive.js';
+import { originForRule, topRulesByVerdict } from '../../scan-derive.js';
 import { topOf } from './title-count.js';
 
 interface Props {
   summary: ScanSummary;
   width: number;
-}
-
-/** Find which origin tag (e.g. `default` or `needs shield:project-jail`)
- *  applies to a given rule name. Walks summary sections to find which
- *  one owns the rule. Mirrors the helper that lives inline inside
- *  the chalk renderPanelScorecard — kept duplicated for now to avoid
- *  touching scan.ts; can extract to scan-derive when commit #8
- *  consolidates the helpers. */
-function originForRule(ruleName: string, sections: ScanSummary['sections']): string {
-  for (const section of sections) {
-    if (section.rules.some((r) => r.name === ruleName)) {
-      if (section.sourceType === 'default') return 'default';
-      if (section.sourceType === 'shield') {
-        return `needs shield:${section.shieldKey ?? section.id}`;
-      }
-    }
-  }
-  return '';
+  /** Gate testimony (policy.appliedShields, N6). Empty/omitted =
+   *  pre-install machine → forecast phrasing, unchanged. */
+  enabledShields?: string[];
 }
 
 /** Cap on rule rows. Overflow is signalled in the panel title
  *  (`· top N of M`, see title-count.ts) rather than a `+N more` row. */
 const ROW_LIMIT = 12;
 
-export function BlockedPanel({ summary, width }: Props): React.ReactElement | null {
+export function BlockedPanel({
+  summary,
+  width,
+  enabledShields = [],
+}: Props): React.ReactElement | null {
+  const enabled = new Set(enabledShields);
   const allRules = topRulesByVerdict(summary.sections, 'block', Number.MAX_SAFE_INTEGER);
   const rules = allRules.slice(0, ROW_LIMIT);
   if (rules.length === 0) return null;
+
+  // Footer phrasing follows the ROWS' own origin tags, so the two can
+  // never disagree: any `needs shield:` row → keep the enable CTA; all
+  // rows enforced (or default) with shields on → state the coverage.
+  const origins = rules.map((r) => originForRule(r.name, summary.sections, enabled));
+  const anyNeeds = origins.some((o) => o.startsWith('needs shield:'));
+  const footer =
+    enabled.size === 0
+      ? '→ install node9 + enable shields above'
+      : anyNeeds
+        ? '→ ✓ rules are enforced in-path · enable the remaining shields above'
+        : '→ ✓ enforced in-path by your enabled shields';
 
   return (
     <Box borderStyle="round" borderColor="red" paddingX={1} flexDirection="column" width={width}>
@@ -71,14 +73,14 @@ export function BlockedPanel({ summary, width }: Props): React.ReactElement | nu
             <Text bold>{`×${rule.count}`}</Text>
           </Box>
           <Text dimColor wrap="truncate-end">
-            {originForRule(rule.name, summary.sections)}
+            {originForRule(rule.name, summary.sections, enabled)}
           </Text>
         </Box>
       ))}
 
       <Box>
         <Text dimColor wrap="truncate-end">
-          {'→ install node9 + enable shields above'}
+          {footer}
         </Text>
       </Box>
     </Box>

--- a/src/cli/render/ink/panels/LeaksPanel.tsx
+++ b/src/cli/render/ink/panels/LeaksPanel.tsx
@@ -14,6 +14,7 @@ import { Box, Text } from 'ink';
 
 import type { ScanSummary } from '../../../../scan-summary.js';
 import { relativeDate } from '../../scan-derive.js';
+import { topOf } from './title-count.js';
 
 interface Props {
   summary: ScanSummary;
@@ -24,10 +25,10 @@ interface Props {
   now?: Date;
 }
 
-/** Max leak rows shown individually. Anything past this collapses to
- *  a `… +N more` line so the panel stays bounded on heavy-leak
- *  machines. 4 keeps the panel tight against BLOCKED in the side-by-
- *  side Critical band — the +N more line handles overflow. */
+/** Max leak rows shown individually. 4 keeps the panel tight against
+ *  BLOCKED in the side-by-side Critical band. Overflow is signalled in
+ *  the panel TITLE (`· top 4 of N`, see title-count.ts) — a `+N more`
+ *  row was tried and removed to save vertical space. */
 const ROW_LIMIT = 4;
 
 export function LeaksPanel({ summary, width, now = new Date() }: Props): React.ReactElement | null {
@@ -38,6 +39,7 @@ export function LeaksPanel({ summary, width, now = new Date() }: Props): React.R
     <Box borderStyle="round" borderColor="red" paddingX={1} flexDirection="column" width={width}>
       <Text bold color="red">
         CREDENTIAL LEAKS
+        <Text dimColor>{topOf(Math.min(leaks.length, ROW_LIMIT), leaks.length)}</Text>
       </Text>
 
       {leaks.slice(0, ROW_LIMIT).map((leak, i) => (
@@ -59,9 +61,9 @@ export function LeaksPanel({ summary, width, now = new Date() }: Props): React.R
         </Box>
       ))}
 
-      {/* No `… +N more` line — the severity-band header already
-       *  reports the total count, e.g. "Critical (5 secrets leaked)".
-       *  Keeping the panel one row tighter saves vertical space. */}
+      {/* No `… +N more` row — the subset signal lives in the panel
+       *  title (`· top 4 of N`) so the panel stays one row tighter.
+       *  The severity band above carries the total as well. */}
       <Box>
         <Text dimColor>{'→ '}</Text>
         <Text bold color="cyan">

--- a/src/cli/render/ink/panels/ReviewQueuePanel.tsx
+++ b/src/cli/render/ink/panels/ReviewQueuePanel.tsx
@@ -12,28 +12,24 @@ import React from 'react';
 import { Box, Text } from 'ink';
 
 import type { ScanSummary } from '../../../../scan-summary.js';
-import { topRulesByVerdict } from '../../scan-derive.js';
+import { originForRule, topRulesByVerdict } from '../../scan-derive.js';
 
 interface Props {
   summary: ScanSummary;
   width: number;
-}
-
-function originForRule(ruleName: string, sections: ScanSummary['sections']): string {
-  for (const section of sections) {
-    if (section.rules.some((r) => r.name === ruleName)) {
-      if (section.sourceType === 'default') return 'default';
-      if (section.sourceType === 'shield') {
-        return `needs shield:${section.shieldKey ?? section.id}`;
-      }
-    }
-  }
-  return '';
+  /** Gate testimony (policy.appliedShields, N6). Empty/omitted =
+   *  pre-install machine → forecast phrasing, unchanged. */
+  enabledShields?: string[];
 }
 
 const ROW_LIMIT = 5;
 
-export function ReviewQueuePanel({ summary, width }: Props): React.ReactElement | null {
+export function ReviewQueuePanel({
+  summary,
+  width,
+  enabledShields = [],
+}: Props): React.ReactElement | null {
+  const enabled = new Set(enabledShields);
   const rules = topRulesByVerdict(summary.sections, 'review', ROW_LIMIT);
   if (rules.length === 0) return null;
 
@@ -49,7 +45,7 @@ export function ReviewQueuePanel({ summary, width }: Props): React.ReactElement 
             <Text bold>{`×${rule.count}`}</Text>
           </Box>
           <Text dimColor wrap="truncate-end">
-            {originForRule(rule.name, summary.sections)}
+            {originForRule(rule.name, summary.sections, enabled)}
           </Text>
         </Box>
       ))}

--- a/src/cli/render/ink/panels/ShieldsPanel.tsx
+++ b/src/cli/render/ink/panels/ShieldsPanel.tsx
@@ -21,9 +21,13 @@ import { BUILTIN_SHIELDS } from '@node9/policy-engine';
 interface Props {
   summary: ScanSummary;
   width: number;
+  /** Gate testimony (policy.appliedShields, N6). Empty/omitted =
+   *  pre-install machine → forecast phrasing, unchanged. */
+  enabledShields?: string[];
 }
 
-export function ShieldsPanel({ summary, width }: Props): React.ReactElement {
+export function ShieldsPanel({ summary, width, enabledShields = [] }: Props): React.ReactElement {
+  const enabled = new Set(enabledShields);
   const impacts = rollupByShield(summary.sections);
 
   // Option B (BUGS.md N1): no score arithmetic in the recommendation — the
@@ -41,11 +45,26 @@ export function ShieldsPanel({ summary, width }: Props): React.ReactElement {
 
   const hitShields = ranked.filter((i) => i.totalCatches > 0);
   const hitNames = new Set(hitShields.map((i) => i.shieldName));
-  const zeroHitBuiltins = Object.keys(BUILTIN_SHIELDS)
+  // Zero-hit builtins split by state (N6): only a shield that is NOT
+  // already enforcing may be pitched as "install proactively" — the
+  // founder's machine showed an ACTIVE postgres shield under that line.
+  const zeroHitAll = Object.keys(BUILTIN_SHIELDS)
     .filter((name) => !hitNames.has(name))
     .sort();
+  const zeroHitBuiltins = zeroHitAll.filter((name) => !enabled.has(name));
+  const zeroHitEnabled = zeroHitAll.filter((name) => enabled.has(name));
 
-  const topRec = hitShields.find((r) => (PROTECTIVE_SHIELD_DISCOUNTS[r.shieldName] ?? 0) > 0);
+  // The CTA must never hand the user a command that is already true —
+  // recommend the highest-impact protective shield they have NOT enabled.
+  const topRec = hitShields.find(
+    (r) => (PROTECTIVE_SHIELD_DISCOUNTS[r.shieldName] ?? 0) > 0 && !enabled.has(r.shieldName)
+  );
+  // All protective hit shields already on → say so instead of silence.
+  const allCovered =
+    !topRec &&
+    hitShields.some(
+      (r) => (PROTECTIVE_SHIELD_DISCOUNTS[r.shieldName] ?? 0) > 0 && enabled.has(r.shieldName)
+    );
 
   return (
     <Box borderStyle="round" borderColor="cyan" paddingX={1} flexDirection="column" width={width}>
@@ -55,11 +74,16 @@ export function ShieldsPanel({ summary, width }: Props): React.ReactElement {
 
       {hitShields.map((impact) => {
         const discount = PROTECTIVE_SHIELD_DISCOUNTS[impact.shieldName] ?? 0;
+        const isOn = enabled.has(impact.shieldName);
         const noun = `op${impact.totalCatches !== 1 ? 's' : ''}`;
         // No icon column — emoji variation-selector widths caused
         // the protective-shield row to overflow the right border on
         // some terminals. The shield name styling (bold cyan for
         // protective, dim otherwise) carries the same signal.
+        //
+        // Tense honesty (N6): an enabled shield gets `✓ enabled` — a
+        // statement about NOW. Never "blocked these" — whether PAST
+        // events were blocked is report's claim to make, not scan's.
         return (
           <Box key={impact.shieldName}>
             <Box width={16}>
@@ -70,10 +94,22 @@ export function ShieldsPanel({ summary, width }: Props): React.ReactElement {
             <Box width={20}>
               <Text dimColor>{`catches ${impact.totalCatches} ${noun}`}</Text>
             </Box>
-            {discount > 0 ? <Text bold color="green">{`→ blocks these reads in-path`}</Text> : null}
+            {isOn ? (
+              <Text bold color="green">{`✓ enabled — enforcing in-path`}</Text>
+            ) : discount > 0 ? (
+              <Text bold color="green">{`→ blocks these reads in-path`}</Text>
+            ) : null}
           </Box>
         );
       })}
+
+      {zeroHitEnabled.length > 0 ? (
+        <Box flexDirection="column">
+          <Text dimColor wrap="truncate-end">
+            {'✓ active: ' + zeroHitEnabled.join(' · ') + '  (no hits in this history)'}
+          </Text>
+        </Box>
+      ) : null}
 
       {zeroHitBuiltins.length > 0 ? (
         <Box flexDirection="column">
@@ -87,6 +123,12 @@ export function ShieldsPanel({ summary, width }: Props): React.ReactElement {
         <Box>
           <Text color="cyan" bold>
             {`→ node9 shield enable ${topRec.shieldName}   (start here — widest coverage)`}
+          </Text>
+        </Box>
+      ) : allCovered ? (
+        <Box>
+          <Text color="green" bold>
+            {'✓ recommended shields are enabled'}
           </Text>
         </Box>
       ) : null}

--- a/src/cli/render/ink/panels/ShieldsPanel.tsx
+++ b/src/cli/render/ink/panels/ShieldsPanel.tsx
@@ -20,15 +20,18 @@ import { BUILTIN_SHIELDS } from '@node9/policy-engine';
 
 interface Props {
   summary: ScanSummary;
-  blastScore: number;
   width: number;
 }
 
-export function ShieldsPanel({ summary, blastScore, width }: Props): React.ReactElement {
+export function ShieldsPanel({ summary, width }: Props): React.ReactElement {
   const impacts = rollupByShield(summary.sections);
-  const exposed = Math.max(0, 100 - blastScore);
 
-  // Sort: protective shields with score impact first, then by hit count.
+  // Option B (BUGS.md N1): no score arithmetic in the recommendation — the
+  // "+N pts" was exposed × discount, a figure the reader cannot check against
+  // anything on screen. The DISCOUNT still ranks protective shields first (it
+  // is the sort key and encodes real protective value); it is just never
+  // rendered as points.
+  // Sort: protective shields first, then by hit count.
   const ranked = [...impacts].sort((a, b) => {
     const aDiscount = PROTECTIVE_SHIELD_DISCOUNTS[a.shieldName] ?? 0;
     const bDiscount = PROTECTIVE_SHIELD_DISCOUNTS[b.shieldName] ?? 0;
@@ -43,9 +46,6 @@ export function ShieldsPanel({ summary, blastScore, width }: Props): React.React
     .sort();
 
   const topRec = hitShields.find((r) => (PROTECTIVE_SHIELD_DISCOUNTS[r.shieldName] ?? 0) > 0);
-  const topRecBonus = topRec
-    ? Math.round(exposed * (PROTECTIVE_SHIELD_DISCOUNTS[topRec.shieldName] ?? 0))
-    : 0;
 
   return (
     <Box borderStyle="round" borderColor="cyan" paddingX={1} flexDirection="column" width={width}>
@@ -55,7 +55,6 @@ export function ShieldsPanel({ summary, blastScore, width }: Props): React.React
 
       {hitShields.map((impact) => {
         const discount = PROTECTIVE_SHIELD_DISCOUNTS[impact.shieldName] ?? 0;
-        const bonus = Math.round(exposed * discount);
         const noun = `op${impact.totalCatches !== 1 ? 's' : ''}`;
         // No icon column — emoji variation-selector widths caused
         // the protective-shield row to overflow the right border on
@@ -71,12 +70,7 @@ export function ShieldsPanel({ summary, blastScore, width }: Props): React.React
             <Box width={20}>
               <Text dimColor>{`catches ${impact.totalCatches} ${noun}`}</Text>
             </Box>
-            {bonus > 0 ? (
-              <Text
-                bold
-                color="green"
-              >{`→ +${bonus} pts (${blastScore} → ${blastScore + bonus})`}</Text>
-            ) : null}
+            {discount > 0 ? <Text bold color="green">{`→ blocks these reads in-path`}</Text> : null}
           </Box>
         );
       })}
@@ -92,7 +86,7 @@ export function ShieldsPanel({ summary, blastScore, width }: Props): React.React
       {topRec ? (
         <Box>
           <Text color="cyan" bold>
-            {`→ node9 shield enable ${topRec.shieldName}   (start here — +${topRecBonus} pts)`}
+            {`→ node9 shield enable ${topRec.shieldName}   (start here — widest coverage)`}
           </Text>
         </Box>
       ) : null}

--- a/src/cli/render/ink/panels/ShieldsPanel.tsx
+++ b/src/cli/render/ink/panels/ShieldsPanel.tsx
@@ -81,9 +81,11 @@ export function ShieldsPanel({ summary, width, enabledShields = [] }: Props): Re
         // some terminals. The shield name styling (bold cyan for
         // protective, dim otherwise) carries the same signal.
         //
-        // Tense honesty (N6): an enabled shield gets `✓ enabled` — a
-        // statement about NOW. Never "blocked these" — whether PAST
-        // events were blocked is report's claim to make, not scan's.
+        // Tense honesty (N6): an enabled shield gets `✓ enabled` and
+        // nothing stronger. Not "enforcing in-path" — that claim also
+        // needs wiring + a non-observe mode, which this renderer does
+        // not know (review F2). And never "blocked these" — whether
+        // PAST events were blocked is report's claim, not scan's.
         return (
           <Box key={impact.shieldName}>
             <Box width={16}>
@@ -95,7 +97,7 @@ export function ShieldsPanel({ summary, width, enabledShields = [] }: Props): Re
               <Text dimColor>{`catches ${impact.totalCatches} ${noun}`}</Text>
             </Box>
             {isOn ? (
-              <Text bold color="green">{`✓ enabled — enforcing in-path`}</Text>
+              <Text bold color="green">{`✓ enabled`}</Text>
             ) : discount > 0 ? (
               <Text bold color="green">{`→ blocks these reads in-path`}</Text>
             ) : null}

--- a/src/cli/render/ink/panels/title-count.ts
+++ b/src/cli/render/ink/panels/title-count.ts
@@ -1,0 +1,11 @@
+// Shared "· top N of M" suffix for panel titles whose rows are capped.
+//
+// The `… +N more` overflow line was deliberately removed from these panels to
+// save a vertical row (the severity band above carries the total). That left no
+// on-screen signal that a panel shows a subset — a list of 4 under a band that
+// says 10 reads as a bug. Decision 2026-08-25: the subset signal lives in the
+// panel TITLE, which costs zero rows. One helper so four panels cannot drift in
+// phrasing.
+export function topOf(shown: number, total: number): string {
+  return total > shown ? ` · top ${shown} of ${total}` : '';
+}

--- a/src/cli/render/scan-derive.ts
+++ b/src/cli/render/scan-derive.ts
@@ -226,6 +226,37 @@ export function boxPanel(
 }
 
 /**
+ * Origin tag for a rule row in the BLOCKED / REVIEW QUEUE panels:
+ *   'default'                — built-in default rule
+ *   '✓ shield:<key>'         — shield-sourced AND that shield is enforcing
+ *   'needs shield:<key>'     — shield-sourced, shield not enabled
+ *
+ * `enabled` is the gate's testimony (policy.appliedShields, N6) — an
+ * empty set is a real answer (pre-install machine), so the caller must
+ * pass what it was given, never invent a default from disk.
+ *
+ * Was duplicated in three renderers (chalk renderPanelScorecard,
+ * BlockedPanel, ReviewQueuePanel); extracted here when it became
+ * state-aware so the phrasing cannot drift between them.
+ */
+export function originForRule(
+  ruleName: string,
+  sections: ReadonlyArray<Section>,
+  enabled: ReadonlySet<string>
+): string {
+  for (const section of sections) {
+    if (section.rules.some((r) => r.name === ruleName)) {
+      if (section.sourceType === 'default') return 'default';
+      if (section.sourceType === 'shield') {
+        const key = section.shieldKey ?? section.id;
+        return enabled.has(key) ? `✓ shield:${key}` : `needs shield:${key}`;
+      }
+    }
+  }
+  return '';
+}
+
+/**
  * Render a relative-time label for the panel renderer:
  *   "today" / "1d" / "30d" / "90d+"
  *

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -85,6 +85,17 @@ export interface Config {
     ignoredTools: string[];
     toolInspection: Record<string, string>;
     smartRules: SmartRule[];
+    /**
+     * RESOLVED output, never user input: the shields the shield layer
+     * actually applied to smartRules on this load (local ∪ cloud-mandated,
+     * minus any whose body failed to resolve — a fail-closed mandate is
+     * deliberately absent). This is the gate's own testimony of "what is
+     * running"; renderers (scan/posture) must read THIS, never
+     * shields.json or rules-cache.json directly, or local/cloud divergence
+     * re-creates the false "needs shield" (N6). Overwritten on every
+     * getConfig(); a value in a config file is ignored by construction.
+     */
+    appliedShields?: string[];
     dlp: {
       enabled: boolean;
       scanIgnoredTools: boolean;
@@ -1281,6 +1292,8 @@ export function getConfig(cwd?: string): Config {
   // Local shields ∪ cloud-managed shields (M1). Deduped so a shield enabled both
   // locally and from the dashboard is applied once.
   const activeShieldNames = [...new Set([...readActiveShields(), ...cloudManagedShields])];
+  // Filled by the apply loop below; becomes policy.appliedShields (N6).
+  const appliedShields: string[] = [];
   // B1: a cloud-mandated shield is enforced EXACTLY as the cloud defines it —
   // local per-rule overrides (`node9 shield set`) do not apply to it, weakening
   // OR tightening. This is what the comment above the union has always promised
@@ -1303,6 +1316,9 @@ export function getConfig(cwd?: string): Config {
     // locked to the fleet.
     const shield = isCloudMandated ? BUILTIN_SHIELDS[shieldName] : getShield(shieldName);
     if (!shield) continue;
+    // The applier testifies (N6): only a shield whose body resolved — and
+    // whose rules are therefore about to be injected — counts as running.
+    appliedShields.push(shieldName);
     // Deduplicate smartRules by name — prevents duplicates if the user also
     // has the same rule name in their config.
     const existingRuleNames = new Set(mergedPolicy.smartRules.map((r) => r.name));
@@ -1333,6 +1349,9 @@ export function getConfig(cwd?: string): Config {
       if (!existingWords.has(word)) mergedPolicy.dangerousWords.push(word);
     }
   }
+  // Always assigned (even when empty) so a stale value can never leak in
+  // from a config file — this field is resolver output, not user input.
+  mergedPolicy.appliedShields = appliedShields.sort();
 
   // Advisory rm rules are always appended last so user-defined rules (project/global/shield)
   // are evaluated first and can override default rm behaviour.

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { DEFAULT_CONFIG } from './config';
 
 // Shared credential + config writer — used by both `node9 login` and the
 // onboarding `node9 connect`. Writes ~/.node9/credentials.json (profile-merged,
@@ -52,26 +53,34 @@ export function writeCredentialsAndConfig(
       config.settings = {};
     }
     const s = config.settings as Record<string, unknown>;
-    const approvers = (s.approvers as Record<string, unknown>) || {
-      native: true,
-      browser: true,
-      cloud: true,
-      terminal: true,
+    // ONE approvers seed (login-v2 §5, B0). Defaults derive from DEFAULT_CONFIG
+    // so an init-written config and a login-written config can never disagree
+    // again — the old dual seed plus preserve-on-login locked cloud:false
+    // forever for anyone who ran `init` before `login`.
+    //
+    // `cloud` is ALWAYS set from the caller's intent: connecting a machine to
+    // the cloud MEANS cloud approvals unless --local says otherwise. A stale
+    // seeded value must not win; --local remains the explicit off switch.
+    //
+    // The legacy `browser` approver (local dashboard removed in v3) is dropped
+    // from the block on every write so it stops resurfacing in configs.
+    const existing =
+      s.approvers && typeof s.approvers === 'object'
+        ? (s.approvers as Record<string, unknown>)
+        : {};
+    const d = DEFAULT_CONFIG.settings.approvers;
+    s.approvers = {
+      native: typeof existing.native === 'boolean' ? existing.native : d.native,
+      terminal: typeof existing.terminal === 'boolean' ? existing.terminal : d.terminal,
+      cloud: !opts.isLocal,
     };
-    // Only force cloud off when --local is explicit; otherwise preserve the
-    // user's prior choice (re-running login to refresh a key must not silently
-    // re-enable cloud approvals for someone who turned them off).
-    if (opts.isLocal) {
-      approvers.cloud = false;
-    }
-    s.approvers = approvers;
     if (!fs.existsSync(path.dirname(configPath))) {
       fs.mkdirSync(path.dirname(configPath), { recursive: true });
     }
     fs.writeFileSync(configPath, JSON.stringify(config, null, 2), {
       mode: 0o600,
     });
-    effectiveCloud = approvers.cloud === true;
+    effectiveCloud = !opts.isLocal;
   }
 
   return { profileName, effectiveCloud };

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -1,0 +1,153 @@
+import chalk from 'chalk';
+import { writeCredentialsAndConfig } from './credentials';
+import { setupDetectedAgents } from './setup';
+import { runCloudSync, runPolicyPush } from './daemon/sync';
+import { ensureAutostartHealthy } from './daemon/service';
+import { isDaemonRunning } from './auth/daemon';
+import { isTestingMode } from './cli/daemon-starter';
+import { getConfig } from './config';
+
+// THE machine-onboarding routine (login-v2 design §2.1 step 8). Every way a
+// machine gets connected to the cloud ends here: `node9 connect` (token),
+// `node9 login` (raw key), and the upcoming device-auth login. One routine so
+// the flows can never drift apart again — the old split is exactly what let
+// `login` leave machines invisible while `connect` printed a ✅ it never
+// verified.
+//
+// Interactive onboarding is LOUD (per-step results, rendered as a scorecard by
+// the caller); only background daemon loops get to be silent-resilient.
+// Overall `ok` is claimed ONLY when the cloud acked the policy snapshot — that
+// snapshot row is what makes the machine exist in the dashboard.
+
+export interface OnboardStep {
+  name: 'credentials' | 'agents' | 'policy-sync' | 'register' | 'daemon';
+  ok: boolean;
+  detail: string;
+}
+
+export interface OnboardOutcome {
+  /** True only when credentials were written AND the cloud acked sync + snapshot. */
+  ok: boolean;
+  steps: OnboardStep[];
+  /** Agent names wired by setup (empty when none detected). */
+  wired: string[];
+}
+
+export async function onboardMachine(
+  apiKey: string,
+  opts: { profileName?: string } = {}
+): Promise<OnboardOutcome> {
+  const steps: OnboardStep[] = [];
+  const wired: string[] = [];
+  const namedProfile = !!opts.profileName && opts.profileName !== 'default';
+
+  // 1. Credentials + config (single approvers seed, cloud on — credentials.ts).
+  try {
+    writeCredentialsAndConfig(apiKey, { profileName: opts.profileName });
+    steps.push({ name: 'credentials', ok: true, detail: 'saved to ~/.node9' });
+  } catch (e) {
+    steps.push({
+      name: 'credentials',
+      ok: false,
+      detail: e instanceof Error ? e.message : String(e),
+    });
+    // Nothing downstream can work without credentials.
+    return { ok: false, steps, wired };
+  }
+
+  // 2. Wire detected agents. Non-interactive (curl|sh and CI shells have no
+  //    TTY). Best-effort: a machine with no agents installed yet is still a
+  //    valid connection, so a wiring failure doesn't fail the onboarding.
+  process.env.NODE9_NONINTERACTIVE = '1';
+  try {
+    wired.push(...(await setupDetectedAgents()));
+    steps.push({
+      name: 'agents',
+      ok: true,
+      detail: wired.length
+        ? `wired: ${wired.join(', ')}`
+        : 'none detected yet: run `node9 init` after installing one',
+    });
+  } catch (e) {
+    steps.push({ name: 'agents', ok: false, detail: e instanceof Error ? e.message : String(e) });
+  }
+
+  // 3+4. Cloud: policy pull, then the ACKED snapshot push. The cloud steps use
+  //    the default profile's credentials (readCredentials), so for a named
+  //    profile they'd verify the wrong key — skip them. Named profiles are on a
+  //    deprecation path (login-v2 §6).
+  if (namedProfile || isTestingMode()) {
+    const why = namedProfile ? 'skipped (named profile)' : 'skipped (testing mode)';
+    steps.push({ name: 'policy-sync', ok: true, detail: why });
+    steps.push({ name: 'register', ok: true, detail: why });
+  } else {
+    const sync = await runCloudSync();
+    steps.push(
+      sync.ok
+        ? {
+            name: 'policy-sync',
+            ok: true,
+            detail: `${sync.rules} cloud rule${sync.rules === 1 ? '' : 's'} active`,
+          }
+        : { name: 'policy-sync', ok: false, detail: sync.reason }
+    );
+
+    // runCloudSync already fires background pushes (blast/scan/posture and a
+    // SILENT policy mirror). runPolicyPush repeats the mirror loudly because
+    // its 2xx is the registration ack: the dashboard machines list is keyed
+    // off this snapshot row. One redundant idempotent POST beats claiming
+    // "Connected" blind — ignoring this exact failure was the old connect bug.
+    const push = await runPolicyPush();
+    steps.push(
+      push.ok
+        ? { name: 'register', ok: true, detail: 'machine visible in the dashboard' }
+        : { name: 'register', ok: false, detail: push.reason }
+    );
+
+    // 5. Daemon autostart self-heal (moved here from `login`): (re)enable the
+    //    service the moment the machine becomes cloud-enabled so policy keeps
+    //    syncing across reboots. Informational — never fails the onboarding.
+    const healed = ensureAutostartHealthy(!!getConfig().settings.autoStartDaemon);
+    const detail =
+      healed === 'repaired'
+        ? 'autostart re-enabled (survives reboot)'
+        : isDaemonRunning()
+          ? 'running'
+          : healed === 'unsupported'
+            ? 'no background service on this platform: starts on agent activity'
+            : 'starts on agent activity';
+    steps.push({ name: 'daemon', ok: true, detail });
+  }
+
+  const required: OnboardStep['name'][] = ['credentials', 'policy-sync', 'register'];
+  const ok = steps.filter((s) => required.includes(s.name)).every((s) => s.ok);
+  return { ok, steps, wired };
+}
+
+const STEP_LABELS: Record<OnboardStep['name'], string> = {
+  credentials: 'Credentials',
+  agents: 'Agents',
+  'policy-sync': 'Cloud policy',
+  register: 'Registered',
+  daemon: 'Daemon',
+};
+
+/** Render the onboarding scorecard. The headline claims success only when the
+ *  routine verified it; every failed line carries its reason. */
+export function renderOnboardOutcome(
+  out: OnboardOutcome,
+  opts: { workspaceName?: string } = {}
+): string {
+  const suffix = opts.workspaceName ? ` to ${opts.workspaceName}` : '';
+  const lines: string[] = [
+    out.ok ? chalk.green(`✅ Connected${suffix}`) : chalk.red(`✗ Connection incomplete${suffix}`),
+  ];
+  for (const s of out.steps) {
+    const mark = s.ok ? chalk.green('✓') : chalk.red('✗');
+    lines.push(`   ${mark} ${STEP_LABELS[s.name]}: ${s.detail}`);
+  }
+  if (!out.ok) {
+    lines.push(chalk.yellow('   Fix the failed step, then verify with: node9 sync'));
+  }
+  return lines.join('\n');
+}

--- a/src/posture/__tests__/enforcement-n6.spec.ts
+++ b/src/posture/__tests__/enforcement-n6.spec.ts
@@ -39,11 +39,24 @@ vi.mock('../../agent-wiring', () => ({
   getAgentWiring: () => [{ isProtected: true }],
 }));
 
+import path from 'path';
 import { annotateCoverage } from '../enforcement';
 import type { Finding } from '../types';
 
 const STATIC_FIX =
   'Fix it now: run `node9 shield enable project-jail` (blocks credential-file reads in-path).';
+
+// Platform-native paths: tildePath splits on `home + path.sep` (the same
+// boundary rule as displayPath in secrets.ts), so a hardcoded posix HOME
+// broke exactly one assertion on the Windows CI legs. Build every path
+// with path.join and derive the expected `~`-form with the same sep.
+const HOME = path.sep === '\\' ? 'C:\\Users\\u' : '/home/u';
+const P = {
+  claude: path.join(HOME, '.claude.json'),
+  codex: path.join(HOME, '.codex', 'config.toml'),
+  aws: path.join(HOME, '.aws', 'credentials'),
+};
+const TILDE_CLAUDE = '~' + path.sep + '.claude.json';
 
 function fileReadFinding(paths: string[]): Finding {
   return {
@@ -56,7 +69,7 @@ function fileReadFinding(paths: string[]): Finding {
   };
 }
 
-const CTX = { home: '/home/u', cwd: '/home/u' };
+const CTX = { home: HOME, cwd: HOME };
 
 describe('N6 — fileRead probe consults the POLICY gate, not DLP alone', () => {
   beforeEach(() => {
@@ -66,26 +79,26 @@ describe('N6 — fileRead probe consults the POLICY gate, not DLP alone', () => 
   });
 
   it('a jail-added file (DLP-silent, policy BLOCK) counts as covered — fails on pre-N6 code', async () => {
-    policyVerdicts.current.set('/home/u/.claude.json', {
+    policyVerdicts.current.set(P.claude, {
       decision: 'block',
       ruleName: 'block-path-home-u-claude-json-anytool',
     });
-    const f = fileReadFinding(['/home/u/.claude.json']);
+    const f = fileReadFinding([P.claude]);
     await annotateCoverage([f], CTX);
     expect(f.coverage?.state).toBe('covered');
     expect(f.fix).toBe(STATIC_FIX); // covered → no rewrite
   });
 
   it('a DLP-covered file is still covered via node9 DLP (no regression)', async () => {
-    dlpHits.current.add('/home/u/.aws/credentials');
-    const f = fileReadFinding(['/home/u/.aws/credentials']);
+    dlpHits.current.add(P.aws);
+    const f = fileReadFinding([P.aws]);
     await annotateCoverage([f], CTX);
     expect(f.coverage).toEqual({ state: 'covered', level: 'block', via: 'node9 DLP' });
   });
 
   it('one gated + one open path → the FINDING is open (any ungated path is the hole)', async () => {
-    dlpHits.current.add('/home/u/.aws/credentials');
-    const f = fileReadFinding(['/home/u/.aws/credentials', '/home/u/.claude.json']);
+    dlpHits.current.add(P.aws);
+    const f = fileReadFinding([P.aws, P.claude]);
     await annotateCoverage([f], CTX);
     expect(f.coverage?.state).toBe('open');
   });
@@ -100,17 +113,17 @@ describe('N6 — fix-string honesty (the founder bug)', () => {
 
   it('project-jail applied + uncovered file → fix becomes `node9 jail add <path>`, never re-enables', async () => {
     applied.current = ['project-jail'];
-    const f = fileReadFinding(['/home/u/.claude.json', '/home/u/.codex/config.toml']);
+    const f = fileReadFinding([P.claude, P.codex]);
     await annotateCoverage([f], CTX);
     expect(f.coverage?.state).toBe('open');
-    expect(f.fix).toContain('node9 jail add ~/.claude.json');
+    expect(f.fix).toContain('node9 jail add ' + TILDE_CLAUDE);
     expect(f.fix).toContain('+1 more');
     expect(f.fix).not.toContain('shield enable project-jail');
     expect(f.fix).toContain('already enabled');
   });
 
   it('project-jail NOT applied → the static enable advice stands (pre-install machines keep the right CTA)', async () => {
-    const f = fileReadFinding(['/home/u/.claude.json']);
+    const f = fileReadFinding([P.claude]);
     await annotateCoverage([f], CTX);
     expect(f.coverage?.state).toBe('open');
     expect(f.fix).toBe(STATIC_FIX);
@@ -118,7 +131,7 @@ describe('N6 — fix-string honesty (the founder bug)', () => {
 
   it('rewrite only touches findings whose fix actually recommends project-jail', async () => {
     applied.current = ['project-jail'];
-    const f = fileReadFinding(['/home/u/.claude.json']);
+    const f = fileReadFinding([P.claude]);
     f.fix = 'Rotate this credential.'; // some other finding style
     await annotateCoverage([f], CTX);
     expect(f.fix).toBe('Rotate this credential.');

--- a/src/posture/__tests__/enforcement-n6.spec.ts
+++ b/src/posture/__tests__/enforcement-n6.spec.ts
@@ -1,30 +1,33 @@
-// N6 — posture's fileRead coverage probe and fix-string honesty.
+// N6 — posture's fileRead coverage semantics and fix-string honesty.
 //
-// Two bugs, one evaluation:
-// 1. The probe consulted DLP ONLY, but `node9 jail add` creates
-//    `block-path-*` policy rules on file_path that DLP knows nothing
-//    about — a jail-added file read as "uncovered" forever.
-// 2. The static fix said "run `node9 shield enable project-jail`" even
-//    when the gate testimony (policy.appliedShields) showed it already
-//    enabled — the founder's machine recommended enabling an enabled
-//    shield for two files it doesn't even cover.
+// History matters here. The first version of this spec certified a policy
+// fallthrough that was DEAD at the real gate (evaluatePolicy('Read',…)
+// without the orchestrator's arming + skipIgnoredFastPath always answers
+// 'allow' — the engine's ignored fast path fires first). The mock hid it
+// because it keyed on file_path and discarded the tool argument. That
+// fallthrough was reverted; what this spec now pins is:
 //
-// Fully hermetic: every gate the probe consults is mocked, so results
-// do not depend on the machine's real ~/.node9 (the suite must pass
-// identically on the founder's 7-shield machine and a bare CI runner).
+//   1. fileRead coverage is DLP-only, and that UNDER-claims by design
+//      (documented limitation: a jail-added path reads as open) — the
+//      safe direction until a shared gate resolver exists
+//      (doc/n6-f1-fix-plan.md).
+//   2. The fix-string rewrite: when project-jail is already applied, the
+//      static "enable project-jail" advice is replaced by a jail-add
+//      pointer that NEVER carries a file path (ship.ts contract: `fix`
+//      ships to the SaaS; detail[], which lists files, never leaves the
+//      machine).
+//
+// Hermetic: config/dlp/agent-wiring are mocked so results are identical
+// on the founder's 7-shield machine and a bare CI runner. The REAL-gate
+// behavior (what the orchestrator actually blocks) is exercised by the
+// jail gauntlet, not here — a mock cannot testify about the gate.
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 const dlpHits = { current: new Set<string>() };
-const policyVerdicts = { current: new Map<string, { decision: string; ruleName?: string }>() };
 const applied = { current: [] as string[] };
 
 vi.mock('../../dlp', () => ({
   scanFilePath: (p: string) => (dlpHits.current.has(p) ? { severity: 'block' } : null),
-}));
-vi.mock('../../policy', () => ({
-  evaluatePolicy: vi.fn(async (_tool: string, args: { file_path?: string }) => {
-    return policyVerdicts.current.get(args.file_path ?? '') ?? { decision: 'allow' };
-  }),
 }));
 vi.mock('../../config', () => ({
   getConfig: () => ({
@@ -46,17 +49,12 @@ import type { Finding } from '../types';
 const STATIC_FIX =
   'Fix it now: run `node9 shield enable project-jail` (blocks credential-file reads in-path).';
 
-// Platform-native paths: tildePath splits on `home + path.sep` (the same
-// boundary rule as displayPath in secrets.ts), so a hardcoded posix HOME
-// broke exactly one assertion on the Windows CI legs. Build every path
-// with path.join and derive the expected `~`-form with the same sep.
 const HOME = path.sep === '\\' ? 'C:\\Users\\u' : '/home/u';
 const P = {
   claude: path.join(HOME, '.claude.json'),
   codex: path.join(HOME, '.codex', 'config.toml'),
   aws: path.join(HOME, '.aws', 'credentials'),
 };
-const TILDE_CLAUDE = '~' + path.sep + '.claude.json';
 
 function fileReadFinding(paths: string[]): Finding {
   return {
@@ -71,29 +69,27 @@ function fileReadFinding(paths: string[]): Finding {
 
 const CTX = { home: HOME, cwd: HOME };
 
-describe('N6 — fileRead probe consults the POLICY gate, not DLP alone', () => {
+describe('N6 — fileRead coverage is DLP-only and under-claims by design', () => {
   beforeEach(() => {
     dlpHits.current = new Set();
-    policyVerdicts.current = new Map();
     applied.current = [];
   });
 
-  it('a jail-added file (DLP-silent, policy BLOCK) counts as covered — fails on pre-N6 code', async () => {
-    policyVerdicts.current.set(P.claude, {
-      decision: 'block',
-      ruleName: 'block-path-home-u-claude-json-anytool',
-    });
-    const f = fileReadFinding([P.claude]);
-    await annotateCoverage([f], CTX);
-    expect(f.coverage?.state).toBe('covered');
-    expect(f.fix).toBe(STATIC_FIX); // covered → no rewrite
-  });
-
-  it('a DLP-covered file is still covered via node9 DLP (no regression)', async () => {
+  it('a DLP-covered file is covered via node9 DLP', async () => {
     dlpHits.current.add(P.aws);
     const f = fileReadFinding([P.aws]);
     await annotateCoverage([f], CTX);
     expect(f.coverage).toEqual({ state: 'covered', level: 'block', via: 'node9 DLP' });
+  });
+
+  it('a DLP-silent path is OPEN — even one the policy layer would gate (the documented limitation)', async () => {
+    // If this row starts failing because coverage became 'covered', someone
+    // re-added a policy consult. That is only correct if it goes through a
+    // SHARED gate resolver proven against dist/cli.js check (see the plan
+    // doc) — a direct evaluatePolicy call here is the dead code we removed.
+    const f = fileReadFinding([P.claude]);
+    await annotateCoverage([f], CTX);
+    expect(f.coverage?.state).toBe('open');
   });
 
   it('one gated + one open path → the FINDING is open (any ungated path is the hole)', async () => {
@@ -104,22 +100,34 @@ describe('N6 — fileRead probe consults the POLICY gate, not DLP alone', () => 
   });
 });
 
-describe('N6 — fix-string honesty (the founder bug)', () => {
+describe('N6 — fix-string honesty (the founder bug) + ship privacy contract', () => {
   beforeEach(() => {
     dlpHits.current = new Set();
-    policyVerdicts.current = new Map();
     applied.current = [];
   });
 
-  it('project-jail applied + uncovered file → fix becomes `node9 jail add <path>`, never re-enables', async () => {
+  it('project-jail applied + uncovered files → fix points at jail add, never re-enables', async () => {
     applied.current = ['project-jail'];
     const f = fileReadFinding([P.claude, P.codex]);
     await annotateCoverage([f], CTX);
     expect(f.coverage?.state).toBe('open');
-    expect(f.fix).toContain('node9 jail add ' + TILDE_CLAUDE);
-    expect(f.fix).toContain('+1 more');
-    expect(f.fix).not.toContain('shield enable project-jail');
+    expect(f.fix).toContain('node9 jail add');
     expect(f.fix).toContain('already enabled');
+    expect(f.fix).not.toContain('shield enable project-jail');
+  });
+
+  it('the rewritten fix NEVER carries a file path — fix ships to the SaaS, detail[] does not', async () => {
+    applied.current = ['project-jail'];
+    const f = fileReadFinding([P.claude, P.codex]);
+    await annotateCoverage([f], CTX);
+    // No separator-bearing path fragments: not the absolute inputs, no
+    // tilde-form, and no home fragment. `<file>` is the only allowed
+    // angle-bracket placeholder.
+    expect(f.fix).not.toContain(P.claude);
+    expect(f.fix).not.toContain(P.codex);
+    expect(f.fix).not.toContain('~' + path.sep);
+    expect(f.fix).not.toContain(HOME);
+    expect(f.fix).not.toContain('.claude.json');
   });
 
   it('project-jail NOT applied → the static enable advice stands (pre-install machines keep the right CTA)', async () => {
@@ -135,5 +143,14 @@ describe('N6 — fix-string honesty (the founder bug)', () => {
     f.fix = 'Rotate this credential.'; // some other finding style
     await annotateCoverage([f], CTX);
     expect(f.fix).toBe('Rotate this credential.');
+  });
+
+  it('covered finding → fix untouched (no rewrite on a green)', async () => {
+    applied.current = ['project-jail'];
+    dlpHits.current.add(P.aws);
+    const f = fileReadFinding([P.aws]);
+    await annotateCoverage([f], CTX);
+    expect(f.coverage?.state).toBe('covered');
+    expect(f.fix).toBe(STATIC_FIX);
   });
 });

--- a/src/posture/__tests__/enforcement-n6.spec.ts
+++ b/src/posture/__tests__/enforcement-n6.spec.ts
@@ -1,0 +1,126 @@
+// N6 — posture's fileRead coverage probe and fix-string honesty.
+//
+// Two bugs, one evaluation:
+// 1. The probe consulted DLP ONLY, but `node9 jail add` creates
+//    `block-path-*` policy rules on file_path that DLP knows nothing
+//    about — a jail-added file read as "uncovered" forever.
+// 2. The static fix said "run `node9 shield enable project-jail`" even
+//    when the gate testimony (policy.appliedShields) showed it already
+//    enabled — the founder's machine recommended enabling an enabled
+//    shield for two files it doesn't even cover.
+//
+// Fully hermetic: every gate the probe consults is mocked, so results
+// do not depend on the machine's real ~/.node9 (the suite must pass
+// identically on the founder's 7-shield machine and a bare CI runner).
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const dlpHits = { current: new Set<string>() };
+const policyVerdicts = { current: new Map<string, { decision: string; ruleName?: string }>() };
+const applied = { current: [] as string[] };
+
+vi.mock('../../dlp', () => ({
+  scanFilePath: (p: string) => (dlpHits.current.has(p) ? { severity: 'block' } : null),
+}));
+vi.mock('../../policy', () => ({
+  evaluatePolicy: vi.fn(async (_tool: string, args: { file_path?: string }) => {
+    return policyVerdicts.current.get(args.file_path ?? '') ?? { decision: 'allow' };
+  }),
+}));
+vi.mock('../../config', () => ({
+  getConfig: () => ({
+    settings: { mode: 'standard' },
+    policy: {
+      egress: { enabled: false, mode: 'off' },
+      appliedShields: applied.current,
+    },
+  }),
+}));
+vi.mock('../../agent-wiring', () => ({
+  getAgentWiring: () => [{ isProtected: true }],
+}));
+
+import { annotateCoverage } from '../enforcement';
+import type { Finding } from '../types';
+
+const STATIC_FIX =
+  'Fix it now: run `node9 shield enable project-jail` (blocks credential-file reads in-path).';
+
+function fileReadFinding(paths: string[]): Finding {
+  return {
+    category: 'Secrets',
+    severity: 'critical',
+    title: 't',
+    detail: [],
+    fix: STATIC_FIX,
+    coverageProbe: { kind: 'fileRead', paths },
+  };
+}
+
+const CTX = { home: '/home/u', cwd: '/home/u' };
+
+describe('N6 — fileRead probe consults the POLICY gate, not DLP alone', () => {
+  beforeEach(() => {
+    dlpHits.current = new Set();
+    policyVerdicts.current = new Map();
+    applied.current = [];
+  });
+
+  it('a jail-added file (DLP-silent, policy BLOCK) counts as covered — fails on pre-N6 code', async () => {
+    policyVerdicts.current.set('/home/u/.claude.json', {
+      decision: 'block',
+      ruleName: 'block-path-home-u-claude-json-anytool',
+    });
+    const f = fileReadFinding(['/home/u/.claude.json']);
+    await annotateCoverage([f], CTX);
+    expect(f.coverage?.state).toBe('covered');
+    expect(f.fix).toBe(STATIC_FIX); // covered → no rewrite
+  });
+
+  it('a DLP-covered file is still covered via node9 DLP (no regression)', async () => {
+    dlpHits.current.add('/home/u/.aws/credentials');
+    const f = fileReadFinding(['/home/u/.aws/credentials']);
+    await annotateCoverage([f], CTX);
+    expect(f.coverage).toEqual({ state: 'covered', level: 'block', via: 'node9 DLP' });
+  });
+
+  it('one gated + one open path → the FINDING is open (any ungated path is the hole)', async () => {
+    dlpHits.current.add('/home/u/.aws/credentials');
+    const f = fileReadFinding(['/home/u/.aws/credentials', '/home/u/.claude.json']);
+    await annotateCoverage([f], CTX);
+    expect(f.coverage?.state).toBe('open');
+  });
+});
+
+describe('N6 — fix-string honesty (the founder bug)', () => {
+  beforeEach(() => {
+    dlpHits.current = new Set();
+    policyVerdicts.current = new Map();
+    applied.current = [];
+  });
+
+  it('project-jail applied + uncovered file → fix becomes `node9 jail add <path>`, never re-enables', async () => {
+    applied.current = ['project-jail'];
+    const f = fileReadFinding(['/home/u/.claude.json', '/home/u/.codex/config.toml']);
+    await annotateCoverage([f], CTX);
+    expect(f.coverage?.state).toBe('open');
+    expect(f.fix).toContain('node9 jail add ~/.claude.json');
+    expect(f.fix).toContain('+1 more');
+    expect(f.fix).not.toContain('shield enable project-jail');
+    expect(f.fix).toContain('already enabled');
+  });
+
+  it('project-jail NOT applied → the static enable advice stands (pre-install machines keep the right CTA)', async () => {
+    const f = fileReadFinding(['/home/u/.claude.json']);
+    await annotateCoverage([f], CTX);
+    expect(f.coverage?.state).toBe('open');
+    expect(f.fix).toBe(STATIC_FIX);
+  });
+
+  it('rewrite only touches findings whose fix actually recommends project-jail', async () => {
+    applied.current = ['project-jail'];
+    const f = fileReadFinding(['/home/u/.claude.json']);
+    f.fix = 'Rotate this credential.'; // some other finding style
+    await annotateCoverage([f], CTX);
+    expect(f.fix).toBe('Rotate this credential.');
+  });
+});

--- a/src/posture/enforcement.ts
+++ b/src/posture/enforcement.ts
@@ -8,6 +8,7 @@
 // reads `allow` there while the real gate BLOCKS it via DLP. We mirror the
 // orchestrator's layering with the PURE functions (no side effects).
 
+import path from 'path';
 import { scanFilePath } from '../dlp';
 import { evaluatePolicy } from '../policy';
 import { getConfig } from '../config';
@@ -53,6 +54,16 @@ export function coverageFromVerdict(verdict: Verdict, env: EnforceEnv, via?: str
   return { state: 'open' };
 }
 
+/** Render an absolute path as `~/…` for a fix string (twin of
+ *  displayPath in secrets.ts — same `home + sep` boundary rule so a
+ *  sibling dir sharing the prefix is not mis-rendered as `~foo`). */
+function tildePath(p: string, home: string): string {
+  if (!home) return p;
+  if (p === home) return '~';
+  const prefix = home.endsWith(path.sep) ? home : home + path.sep;
+  return p.startsWith(prefix) ? '~' + path.sep + p.slice(prefix.length) : p;
+}
+
 /** Shorten a rule name like `shield:project-jail:block-read-ssh` → `project-jail shield`. */
 function viaFromRule(ruleName?: string): string | undefined {
   if (!ruleName) return undefined;
@@ -86,13 +97,52 @@ export async function annotateCoverage(findings: Finding[], ctx: CheckContext): 
     }
 
     if (probe.kind === 'fileRead') {
-      // DLP layer — the one that actually gates the agent's Read tool.
-      const verdicts = probe.paths.map((p) => scanFilePath(p)?.severity ?? null);
-      if (verdicts.length === 0 || verdicts.some((v) => v === null)) {
-        f.coverage = coverageFromVerdict('allow', env); // any unblocked path → open
+      // The real gate for an agent file read is DLP ∪ the policy path
+      // rules: `node9 jail add` creates `block-path-*` smartRules on
+      // file_path that DLP knows nothing about, so probing DLP alone
+      // reported a jail-added file as uncovered forever (N6). Mirror the
+      // orchestrator: DLP answers first (it gates first at runtime); a
+      // DLP-silent path falls through to the policy layer's Read verdict.
+      const perPath: Array<{ path: string; verdict: Verdict; via?: string }> = [];
+      for (const p of probe.paths) {
+        const dlpSev = scanFilePath(p)?.severity ?? null;
+        if (dlpSev) {
+          perPath.push({ path: p, verdict: dlpSev as Verdict, via: 'node9 DLP' });
+          continue;
+        }
+        const pv = await evaluatePolicy('Read', { file_path: p }, ctx.agent, ctx.cwd);
+        perPath.push({ path: p, verdict: pv.decision as Verdict, via: viaFromRule(pv.ruleName) });
+      }
+      const uncovered = perPath.filter((x) => x.verdict !== 'block' && x.verdict !== 'review');
+      if (perPath.length === 0 || uncovered.length > 0) {
+        f.coverage = coverageFromVerdict('allow', env); // any ungated path → open
+        // N6 fix-string honesty: the static fix says "enable
+        // project-jail" — if the gate testimony says it is already
+        // applied, that command is already true and the honest next step
+        // is jail-adding the specific uncovered files. Rewritten HERE,
+        // from the SAME per-path evaluation the coverage came from —
+        // never a second judge in the finding builder.
+        if (
+          uncovered.length > 0 &&
+          (config.policy.appliedShields ?? []).includes('project-jail') &&
+          f.fix?.includes('shield enable project-jail')
+        ) {
+          const first = tildePath(uncovered[0].path, ctx.home || '');
+          const rest = uncovered.length - 1;
+          f.fix =
+            `project-jail is already enabled but does not cover ${rest > 0 ? 'these files' : 'this file'}. ` +
+            `Fix it now: run \`node9 jail add ${first}\`` +
+            (rest > 0 ? ` (+${rest} more — see detail)` : '') +
+            ' to block agent reads in-path.';
+        }
       } else {
-        const worst: Verdict = verdicts.some((v) => v === 'review') ? 'review' : 'block';
-        f.coverage = coverageFromVerdict(worst, env, 'node9 DLP');
+        const worst: Verdict = perPath.some((x) => x.verdict === 'review') ? 'review' : 'block';
+        const vias = [...new Set(perPath.map((x) => x.via).filter((v): v is string => !!v))];
+        f.coverage = coverageFromVerdict(
+          worst,
+          env,
+          vias.length > 0 ? vias.join(' + ') : undefined
+        );
       }
       continue;
     }

--- a/src/posture/enforcement.ts
+++ b/src/posture/enforcement.ts
@@ -8,7 +8,6 @@
 // reads `allow` there while the real gate BLOCKS it via DLP. We mirror the
 // orchestrator's layering with the PURE functions (no side effects).
 
-import path from 'path';
 import { scanFilePath } from '../dlp';
 import { evaluatePolicy } from '../policy';
 import { getConfig } from '../config';
@@ -54,16 +53,6 @@ export function coverageFromVerdict(verdict: Verdict, env: EnforceEnv, via?: str
   return { state: 'open' };
 }
 
-/** Render an absolute path as `~/…` for a fix string (twin of
- *  displayPath in secrets.ts — same `home + sep` boundary rule so a
- *  sibling dir sharing the prefix is not mis-rendered as `~foo`). */
-function tildePath(p: string, home: string): string {
-  if (!home) return p;
-  if (p === home) return '~';
-  const prefix = home.endsWith(path.sep) ? home : home + path.sep;
-  return p.startsWith(prefix) ? '~' + path.sep + p.slice(prefix.length) : p;
-}
-
 /** Shorten a rule name like `shield:project-jail:block-read-ssh` → `project-jail shield`. */
 function viaFromRule(ruleName?: string): string | undefined {
   if (!ruleName) return undefined;
@@ -97,52 +86,38 @@ export async function annotateCoverage(findings: Finding[], ctx: CheckContext): 
     }
 
     if (probe.kind === 'fileRead') {
-      // The real gate for an agent file read is DLP ∪ the policy path
-      // rules: `node9 jail add` creates `block-path-*` smartRules on
-      // file_path that DLP knows nothing about, so probing DLP alone
-      // reported a jail-added file as uncovered forever (N6). Mirror the
-      // orchestrator: DLP answers first (it gates first at runtime); a
-      // DLP-silent path falls through to the policy layer's Read verdict.
-      const perPath: Array<{ path: string; verdict: Verdict; via?: string }> = [];
-      for (const p of probe.paths) {
-        const dlpSev = scanFilePath(p)?.severity ?? null;
-        if (dlpSev) {
-          perPath.push({ path: p, verdict: dlpSev as Verdict, via: 'node9 DLP' });
-          continue;
-        }
-        const pv = await evaluatePolicy('Read', { file_path: p }, ctx.agent, ctx.cwd);
-        perPath.push({ path: p, verdict: pv.decision as Verdict, via: viaFromRule(pv.ruleName) });
-      }
-      const uncovered = perPath.filter((x) => x.verdict !== 'block' && x.verdict !== 'review');
-      if (perPath.length === 0 || uncovered.length > 0) {
-        f.coverage = coverageFromVerdict('allow', env); // any ungated path → open
-        // N6 fix-string honesty: the static fix says "enable
-        // project-jail" — if the gate testimony says it is already
-        // applied, that command is already true and the honest next step
-        // is jail-adding the specific uncovered files. Rewritten HERE,
-        // from the SAME per-path evaluation the coverage came from —
-        // never a second judge in the finding builder.
+      // DLP layer — the one that actually gates the agent's Read tool.
+      //
+      // KNOWN LIMITATION (doc/n6-f1-fix-plan.md): a `node9 jail add` path is
+      // gated by policy `block-path-*` rules that DLP knows nothing about, so
+      // it reads as uncovered here forever. An attempted fix that consulted
+      // evaluatePolicy('Read', …) directly was REVERTED as dead code: without
+      // the orchestrator's arming + skipIgnoredFastPath the engine's ignored
+      // fast path answers 'allow' before any path rule is consulted — and
+      // copying the arming here would be a second judge that drifts (it
+      // already changed twice: tasks #20, #22). Until the gate decision is
+      // extracted into one shared resolver, DLP-only UNDER-claims, which is
+      // the safe direction: a false "open" nags, a false "covered" lies.
+      const verdicts = probe.paths.map((p) => scanFilePath(p)?.severity ?? null);
+      if (verdicts.length === 0 || verdicts.some((v) => v === null)) {
+        f.coverage = coverageFromVerdict('allow', env); // any unblocked path → open
+        // N6 fix-string honesty: when project-jail is already applied, the
+        // static "enable project-jail" advice is already true — point at
+        // `jail add` instead. ⛔ No file path in this string: `fix` ships
+        // to the SaaS and ship.ts's contract is that fix never carries
+        // paths (detail[], which lists the files, deliberately never
+        // leaves the machine).
         if (
-          uncovered.length > 0 &&
           (config.policy.appliedShields ?? []).includes('project-jail') &&
           f.fix?.includes('shield enable project-jail')
         ) {
-          const first = tildePath(uncovered[0].path, ctx.home || '');
-          const rest = uncovered.length - 1;
           f.fix =
-            `project-jail is already enabled but does not cover ${rest > 0 ? 'these files' : 'this file'}. ` +
-            `Fix it now: run \`node9 jail add ${first}\`` +
-            (rest > 0 ? ` (+${rest} more — see detail)` : '') +
-            ' to block agent reads in-path.';
+            'project-jail is already enabled but does not cover the file(s) listed here. ' +
+            'Fix it now: run `node9 jail add <file>` for each file above.';
         }
       } else {
-        const worst: Verdict = perPath.some((x) => x.verdict === 'review') ? 'review' : 'block';
-        const vias = [...new Set(perPath.map((x) => x.via).filter((v): v is string => !!v))];
-        f.coverage = coverageFromVerdict(
-          worst,
-          env,
-          vias.length > 0 ? vias.join(' + ') : undefined
-        );
+        const worst: Verdict = verdicts.some((v) => v === 'review') ? 'review' : 'block';
+        f.coverage = coverageFromVerdict(worst, env, 'node9 DLP');
       }
       continue;
     }


### PR DESCRIPTION
## What

B0 of the login-v2 plan, plus the posture/scan N6 fixes already on dev.

**Onboarding (B0)** — `node9 connect` and `node9 login` now both end in one
shared routine (`src/onboarding.ts`): credentials, agent wiring, cloud policy
sync, and an ACKED policy-snapshot push. The success headline prints only after
the cloud confirms the snapshot; any required step failing exits 1 with a
per-step scorecard.

Fixes folded in:
- connect no longer ignores `runCloudSync` failures (it printed a false green
  checkmark while the machine never registered)
- login now onboards instead of only writing a key, so manually-keyed machines
  stop being invisible in the dashboard
- ONE approvers seed derived from `DEFAULT_CONFIG`; `cloud` always follows
  caller intent (true unless `--local`), which kills the init-then-login trap
  that locked `cloud:false`. The dead `browser` approver key is dropped on write.

## Verification

- 3,988 tests pass (20 new/updated), typecheck + lint + format clean
- New integration case runs the real spawn path and proves connect fails loudly
  when the cloud never acks

## Note for the release

The previous release run (32592445760) failed at the engine-sync step with
`tag 'policy-engine-v2.0.0' already exists`, so the wrapper publish never ran
and `node9-ai` on npm is still 1.67.5 while `@node9/proxy` is 2.0.0. This
release cuts 2.1.0, whose engine tag does not exist yet, so the chain should
complete and finally republish the wrapper.