### PR TITLE
Browser device-auth login + machine identity (login-v2 B1, CLI)

### DIFF
--- a/src/__tests__/connect.integration.test.ts
+++ b/src/__tests__/connect.integration.test.ts
@@ -123,3 +123,20 @@ describe('node9 connect (integration)', () => {
     expect(fs.existsSync(credsPath())).toBe(true);
   });
 });
+
+// ── node9 login: CI guard (real spawn path) ───────────────────────────────
+// Appended here to reuse the built-CLI harness rather than duplicating it.
+describe('node9 login CI guard (integration)', () => {
+  it('refuses interactive login when CI is detected, points at service keys', async () => {
+    const { spawnSync } = await import('child_process');
+    const r = spawnSync(process.execPath, [CLI, 'login'], {
+      env: { ...process.env, CI: 'true', NODE9_TESTING: '1' },
+      encoding: 'utf-8',
+      timeout: 15000,
+    });
+    expect(r.error).toBeUndefined();
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/CI environment detected/);
+    expect(r.stderr).toMatch(/NODE9_API_KEY/);
+  });
+});

--- a/src/__tests__/device-login.test.ts
+++ b/src/__tests__/device-login.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import * as http from 'http';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { AddressInfo } from 'net';
+import { getMachineId } from '../machine-id';
+import { runDeviceLogin } from '../auth/device-login';
+
+// ── machine-id ────────────────────────────────────────────────────────────
+describe('getMachineId', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-mid-'));
+  });
+  afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  it('mints once and stays stable across calls (the no-ghost-machines property)', () => {
+    const a = getMachineId(tmp);
+    const b = getMachineId(tmp);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f-]{36}$/);
+    expect(fs.readFileSync(path.join(tmp, '.node9', 'machine-id'), 'utf-8').trim()).toBe(a);
+  });
+
+  it('re-mints over corrupt content instead of trusting garbage', () => {
+    fs.mkdirSync(path.join(tmp, '.node9'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, '.node9', 'machine-id'), 'not-a-uuid\n');
+    const id = getMachineId(tmp);
+    expect(id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(getMachineId(tmp)).toBe(id);
+  });
+});
+
+// ── device login flow against a mock server ───────────────────────────────
+describe('runDeviceLogin', () => {
+  let server: http.Server;
+  let base: string;
+  // Scripted poll outcomes, shifted per request.
+  let pollScript: Array<Record<string, unknown>>;
+  let startCount = 0;
+  let lastStartBody: Record<string, unknown> | null = null;
+
+  beforeAll(
+    () =>
+      new Promise<void>((resolve) => {
+        server = http.createServer((req, res) => {
+          let body = '';
+          req.on('data', (c) => (body += c));
+          req.on('end', () => {
+            const parsed = body ? (JSON.parse(body) as Record<string, unknown>) : {};
+            if (req.url === '/device/start') {
+              startCount++;
+              lastStartBody = parsed;
+              res.writeHead(200, { 'Content-Type': 'application/json' });
+              res.end(
+                JSON.stringify({
+                  userCode: 'ABCD-EFGH',
+                  pollToken: 'n9_poll_test',
+                  verificationUrl: 'https://node9.ai/device?code=ABCD-EFGH',
+                  intervalSec: 0.01,
+                  expiresInSec: 2,
+                })
+              );
+            } else if (req.url === '/device/poll') {
+              const next = pollScript.shift() ?? { status: 'pending' };
+              res.writeHead(200, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify(next));
+            } else {
+              res.writeHead(404);
+              res.end();
+            }
+          });
+        });
+        server.listen(0, '127.0.0.1', () => {
+          base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+          resolve();
+        });
+      })
+  );
+  afterAll(() => new Promise<void>((resolve) => server.close(() => resolve())));
+
+  beforeEach(() => {
+    pollScript = [];
+    startCount = 0;
+    lastStartBody = null;
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  const opts = () => ({ apiUrl: `${base}/device/start`, noBrowser: true, cliVersion: '9.9.9' });
+
+  it('sends machine metadata, waits through pending, returns the key on approval', async () => {
+    pollScript = [
+      { status: 'pending' },
+      { status: 'pending' },
+      {
+        status: 'approved',
+        apiKey: 'n9_live_won',
+        workspaceId: 'ws-1',
+        workspaceName: 'Acme',
+        machineName: 'Named-In-Browser',
+      },
+    ];
+    const r = await runDeviceLogin(opts());
+    expect(r).toEqual({
+      ok: true,
+      apiKey: 'n9_live_won',
+      workspaceName: 'Acme',
+      machineName: 'Named-In-Browser',
+    });
+    expect(startCount).toBe(1);
+    expect(lastStartBody).toMatchObject({
+      hostname: os.hostname(),
+      platform: process.platform,
+      cliVersion: '9.9.9',
+    });
+    expect(typeof lastStartBody?.machineId).toBe('string');
+  });
+
+  it('a browser denial ends the flow with a clear reason', async () => {
+    pollScript = [{ status: 'denied' }];
+    const r = await runDeviceLogin(opts());
+    expect(r).toEqual({ ok: false, reason: expect.stringContaining('denied') });
+  });
+
+  it('an expired code tells the user to rerun login', async () => {
+    pollScript = [{ status: 'expired' }];
+    const r = await runDeviceLogin(opts());
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toContain('node9 login');
+  });
+
+  it('an unreachable server fails the start step, not a hang', async () => {
+    const r = await runDeviceLogin({ apiUrl: 'http://127.0.0.1:9/device/start', noBrowser: true });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toContain('Could not reach');
+  });
+});

--- a/src/auth/cloud-endpoints.ts
+++ b/src/auth/cloud-endpoints.ts
@@ -1,0 +1,11 @@
+// One resolver for cloud API endpoints outside the /intercept namespace.
+// Precedence: explicit override → NODE9_API_URL (the intercept base, so a dev
+// pointing the daemon at staging reaches the same host) → prod default.
+const PROD_BASE = 'https://api.node9.ai/api/v1';
+
+export function resolveCloudEndpoint(pathSuffix: string, override?: string): string {
+  if (override) return override;
+  const base = process.env.NODE9_API_URL;
+  if (base) return base.replace(/\/intercept\/?$/, '') + pathSuffix;
+  return PROD_BASE + pathSuffix;
+}

--- a/src/auth/device-login.ts
+++ b/src/auth/device-login.ts
@@ -1,0 +1,163 @@
+import * as http from 'http';
+import * as https from 'https';
+import * as os from 'os';
+import { URL } from 'url';
+import chalk from 'chalk';
+import { resolveCloudEndpoint } from './cloud-endpoints';
+import { getMachineId } from '../machine-id';
+import { openBrowser } from '../utils/open-browser';
+
+// The CLI half of device-auth login (login-v2 B1). Start an authorization,
+// hand the human a URL + short code, then poll until the browser approves —
+// the claiming poll is the ONLY delivery of the machine key. The human never
+// sees a key or token; the code on screen exists so they can match terminal
+// to browser tab.
+
+interface StartResponse {
+  userCode: string;
+  pollToken: string;
+  verificationUrl: string;
+  intervalSec: number;
+  expiresInSec: number;
+}
+
+interface PollResponse {
+  status: 'pending' | 'approved' | 'denied' | 'expired';
+  apiKey?: string;
+  workspaceId?: string;
+  workspaceName?: string;
+  machineName?: string;
+}
+
+export type DeviceLoginResult =
+  | { ok: true; apiKey: string; workspaceName: string; machineName: string }
+  | { ok: false; reason: string };
+
+// Plain JSON POST; http for tests, https in production (same pattern as
+// connect's postConnect — the URL's protocol picks the lib).
+function postJson<T>(url: string, body: unknown): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(body);
+    const u = new URL(url);
+    const lib = u.protocol === 'http:' ? http : https;
+    const req = lib.request(
+      {
+        method: 'POST',
+        hostname: u.hostname,
+        port: u.port || (u.protocol === 'http:' ? 80 : 443),
+        path: u.pathname + u.search,
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(payload),
+        },
+        timeout: 15000,
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (c) => (data += c));
+        res.on('end', () => {
+          const code = res.statusCode ?? 0;
+          if (code >= 200 && code < 300) {
+            try {
+              resolve(JSON.parse(data) as T);
+            } catch {
+              reject(new Error('Unexpected response from the server.'));
+            }
+          } else {
+            reject(new Error(`Server returned HTTP ${code}.`));
+          }
+        });
+      }
+    );
+    req.on('error', (e) => reject(e));
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('Connection timed out.'));
+    });
+    req.write(payload);
+    req.end();
+  });
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/**
+ * Run the interactive device login. Prints the URL + code, opens the browser
+ * when one is plausibly present, and polls until approved/denied/expired.
+ * Returns the machine key on success — the caller feeds it to onboardMachine.
+ */
+export async function runDeviceLogin(
+  opts: { apiUrl?: string; noBrowser?: boolean; cliVersion?: string } = {}
+): Promise<DeviceLoginResult> {
+  // opts.apiUrl overrides the START endpoint (tests / self-host); poll is
+  // always its sibling.
+  const startUrl = resolveCloudEndpoint('/device/start', opts.apiUrl);
+  const pollUrl = startUrl.replace(/\/device\/start$/, '/device/poll');
+
+  let start: StartResponse;
+  try {
+    start = await postJson<StartResponse>(startUrl, {
+      machineId: getMachineId(),
+      hostname: os.hostname(),
+      platform: process.platform,
+      cliVersion: opts.cliVersion,
+    });
+  } catch (e) {
+    return {
+      ok: false,
+      reason: `Could not reach the node9 cloud: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+
+  console.log('');
+  console.log(`  Open this link to approve the connection:`);
+  console.log(`  ${chalk.cyan.underline(start.verificationUrl)}`);
+  console.log('');
+  console.log(`  Code: ${chalk.bold(start.userCode)} ${chalk.gray('(match it in the browser)')}`);
+  console.log('');
+  const opened = opts.noBrowser ? false : openBrowser(start.verificationUrl);
+  console.log(
+    chalk.gray(
+      opened
+        ? '  Waiting for approval in your browser…'
+        : '  Open the link on any device (phone works) — waiting for approval…'
+    )
+  );
+
+  const deadline = Date.now() + start.expiresInSec * 1000;
+  // Floor at 10ms: guards 0/NaN from a misbehaving server without flooring
+  // legitimate sub-second intervals (tests use 0.01s).
+  const intervalMs = Math.max(10, (Number(start.intervalSec) || 5) * 1000);
+  let consecutiveErrors = 0;
+
+  while (Date.now() < deadline) {
+    await sleep(intervalMs);
+    let poll: PollResponse;
+    try {
+      poll = await postJson<PollResponse>(pollUrl, { pollToken: start.pollToken });
+      consecutiveErrors = 0;
+    } catch {
+      // Transient network blips must not kill a login mid-approval; give up
+      // only when the failures look structural.
+      consecutiveErrors += 1;
+      if (consecutiveErrors >= 5) {
+        return { ok: false, reason: 'Lost contact with the server while waiting for approval.' };
+      }
+      continue;
+    }
+    if (poll.status === 'pending') continue;
+    if (poll.status === 'approved' && poll.apiKey) {
+      return {
+        ok: true,
+        apiKey: poll.apiKey,
+        workspaceName: poll.workspaceName ?? '',
+        machineName: poll.machineName ?? os.hostname(),
+      };
+    }
+    if (poll.status === 'denied') {
+      return { ok: false, reason: 'The request was denied in the browser.' };
+    }
+    return { ok: false, reason: 'The code expired — run `node9 login` again.' };
+  }
+  return { ok: false, reason: 'Timed out waiting for approval — run `node9 login` again.' };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,12 +30,13 @@ import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { spawn } from 'child_process';
 import { confirm } from '@inquirer/prompts';
 import { parseDuration } from './utils/duration';
 import { runProxy } from './proxy';
 import { autoStartDaemonAndWait } from './cli/daemon-starter';
 import { onboardMachine, renderOnboardOutcome } from './onboarding';
+import { runDeviceLogin } from './auth/device-login';
+import { openBrowser } from './utils/open-browser';
 import { registerCheckCommand } from './cli/commands/check';
 import { registerLogCommand } from './cli/commands/log';
 import { registerShieldCommand, registerConfigShowCommand } from './cli/commands/shield';
@@ -76,39 +77,97 @@ const { version } = JSON.parse(
 const program = new Command();
 program.name('node9').description('The Sudo Command for AI Agents').version(version);
 
-// 1. LOGIN
+// 1. LOGIN — with no argument, the browser device-auth flow (login-v2 B1):
+// auth + workspace choice happen in the browser and the machine key is
+// delivered over the wire, never through a human. With a raw key argument,
+// the legacy/service path.
 program
   .command('login')
-  .argument('<apiKey>')
+  .argument('[apiKey]', 'Service/legacy key. Omit to log in via your browser.')
   .option('--local', 'Save key for audit/logging only — local config still controls all decisions')
   .option('--profile <name>', 'Save as a named profile (default: "default")')
-  .action(async (apiKey, options: { local?: boolean; profile?: string }) => {
-    // Named profile / --local keep their narrow legacy behavior: write the key,
-    // say what happened, no cloud onboarding. Profiles are on a deprecation
-    // path (login-v2 §6); --local is the explicit privacy-mode switch.
-    if (options.profile && options.profile !== 'default') {
-      const { profileName } = writeCredentialsAndConfig(apiKey, {
-        profileName: options.profile,
-        isLocal: options.local,
-      });
-      console.log(chalk.green(`✅ Profile "${profileName}" saved`));
-      console.log(chalk.gray(`   Switch to it per-session:  NODE9_PROFILE=${profileName} claude`));
-      return;
+  .option('--no-browser', "Don't auto-open the browser — just print the link")
+  .option('--force', 'Allow interactive login even when CI is detected')
+  .option('--api-url <url>', 'Override the device-auth endpoint (self-host / dev)')
+  .action(
+    async (
+      apiKey: string | undefined,
+      options: {
+        local?: boolean;
+        profile?: string;
+        browser?: boolean;
+        force?: boolean;
+        apiUrl?: string;
+      }
+    ) => {
+      if (!apiKey) {
+        // CI runners must not device-login: no browser, no human, and an
+        // ephemeral "machine". They get service keys via NODE9_API_KEY.
+        if (
+          (process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true') &&
+          !options.force
+        ) {
+          console.error(chalk.red('✗ CI environment detected.'));
+          console.error(
+            chalk.gray(
+              '  Interactive login is for human machines. In CI, create a service key in\n' +
+                '  the dashboard and set it as the NODE9_API_KEY secret. (Override: --force)'
+            )
+          );
+          process.exitCode = 1;
+          return;
+        }
+        if (options.local) {
+          console.error(chalk.red('✗ --local needs a key: node9 login <apiKey> --local'));
+          process.exitCode = 1;
+          return;
+        }
+        const res = await runDeviceLogin({
+          apiUrl: options.apiUrl,
+          noBrowser: options.browser === false,
+          cliVersion: version,
+        });
+        if (!res.ok) {
+          console.error(chalk.red(`✗ ${res.reason}`));
+          process.exitCode = 1;
+          return;
+        }
+        const outcome = await onboardMachine(res.apiKey);
+        console.log(renderOnboardOutcome(outcome, { workspaceName: res.workspaceName }));
+        if (!outcome.ok) process.exitCode = 1;
+        return;
+      }
+      await runKeyLogin(apiKey, options);
     }
-    if (options.local) {
-      writeCredentialsAndConfig(apiKey, { isLocal: true });
-      console.log(chalk.green(`✅ Key saved — Privacy mode 🛡️`));
-      console.log(chalk.gray(`   All decisions stay on this machine. Nothing syncs to the cloud.`));
-      return;
-    }
+  );
 
-    // Default profile, cloud mode: run THE shared onboarding routine
-    // (onboarding.ts) — same steps and same scorecard as `node9 connect`, so a
-    // manually-entered key ends with a machine the dashboard can actually see.
-    const outcome = await onboardMachine(apiKey);
-    console.log(renderOnboardOutcome(outcome));
-    if (!outcome.ok) process.exitCode = 1;
-  });
+async function runKeyLogin(apiKey: string, options: { local?: boolean; profile?: string }) {
+  // Named profile / --local keep their narrow legacy behavior: write the key,
+  // say what happened, no cloud onboarding. Profiles are on a deprecation
+  // path (login-v2 §6); --local is the explicit privacy-mode switch.
+  if (options.profile && options.profile !== 'default') {
+    const { profileName } = writeCredentialsAndConfig(apiKey, {
+      profileName: options.profile,
+      isLocal: options.local,
+    });
+    console.log(chalk.green(`✅ Profile "${profileName}" saved`));
+    console.log(chalk.gray(`   Switch to it per-session:  NODE9_PROFILE=${profileName} claude`));
+    return;
+  }
+  if (options.local) {
+    writeCredentialsAndConfig(apiKey, { isLocal: true });
+    console.log(chalk.green(`✅ Key saved — Privacy mode 🛡️`));
+    console.log(chalk.gray(`   All decisions stay on this machine. Nothing syncs to the cloud.`));
+    return;
+  }
+
+  // Default profile, cloud mode: run THE shared onboarding routine
+  // (onboarding.ts) — same steps and same scorecard as `node9 connect`, so a
+  // manually-entered key ends with a machine the dashboard can actually see.
+  const outcome = await onboardMachine(apiKey);
+  console.log(renderOnboardOutcome(outcome));
+  if (!outcome.ok) process.exitCode = 1;
+}
 
 // 1b. SIGNUP — open the node9 dashboard signup/login in the browser (Phase-1 capture).
 program
@@ -120,22 +179,8 @@ program
     const url = `https://node9.ai/${route}?ref=cli_cmd`;
     console.log('');
     console.log('  ' + chalk.dim('Opening ') + chalk.cyan.underline(url));
-    // Best-effort open — must never fail. On headless/SSH/VM the printed URL is the fallback.
-    const opener =
-      process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
-    try {
-      const child = spawn(opener, [url], {
-        stdio: 'ignore',
-        detached: true,
-        shell: process.platform === 'win32',
-      });
-      child.on('error', () => {
-        /* no browser available — the URL above is the fallback */
-      });
-      child.unref();
-    } catch {
-      /* headless — URL already printed */
-    }
+    // Best-effort open — on headless/SSH/VM the printed URL is the fallback.
+    openBrowser(url);
     console.log('');
   });
 

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -4,6 +4,7 @@ import https from 'https';
 import { URL } from 'url';
 import chalk from 'chalk';
 import { onboardMachine, renderOnboardOutcome } from '../../onboarding';
+import { resolveCloudEndpoint } from '../../auth/cloud-endpoints';
 
 // node9 connect <token> — the onboarding bridge. Exchanges a dashboard connect
 // token for a workspace key (POST /cli/connect), then hands off to THE shared
@@ -11,7 +12,6 @@ import { onboardMachine, renderOnboardOutcome } from '../../onboarding';
 // and the acked snapshot push that makes the machine exist in the dashboard.
 // No raw key is ever copy-pasted by the user. Exit 1 when any required step
 // fails — a machine the cloud never acked must not hear "Connected".
-const DEFAULT_CONNECT_URL = 'https://api.node9.ai/api/v1/cli/connect';
 
 interface ConnectResponse {
   apiKey: string;
@@ -22,10 +22,7 @@ interface ConnectResponse {
 // --api-url wins; else derive from NODE9_API_URL (the intercept base) so a dev
 // pointing the daemon at staging also connects there; else prod default.
 export function resolveConnectUrl(apiUrl?: string): string {
-  if (apiUrl) return apiUrl;
-  const base = process.env.NODE9_API_URL;
-  if (base) return base.replace(/\/intercept\/?$/, '') + '/cli/connect';
-  return DEFAULT_CONNECT_URL;
+  return resolveCloudEndpoint('/cli/connect', apiUrl);
 }
 
 function postConnect(url: string, token: string): Promise<ConnectResponse> {

--- a/src/machine-id.ts
+++ b/src/machine-id.ts
@@ -1,0 +1,35 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// The machine's durable local identity (login-v2 B1): a UUID minted once and
+// kept in ~/.node9/machine-id. The cloud upserts the machine row by
+// (workspaceId, machineId), so as long as this file survives, re-logins and
+// reinstalls keep the same dashboard identity instead of minting ghosts.
+// Deliberately NOT hostname-derived: hostnames change, collide, and are
+// PII-adjacent — this file ships nothing about the machine by itself.
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+export function getMachineId(homeDir: string = os.homedir()): string {
+  const file = path.join(homeDir, '.node9', 'machine-id');
+  try {
+    const existing = fs.readFileSync(file, 'utf-8').trim();
+    if (UUID_RE.test(existing)) return existing;
+    // Corrupt content falls through to re-mint — a stable-but-garbage id
+    // would collide across machines that copied the same broken file.
+  } catch {
+    // Missing — first run.
+  }
+  const id = crypto.randomUUID();
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, id + '\n', { mode: 0o600 });
+  } catch {
+    // Unwritable home: still return a usable id for this session. The next
+    // login mints a fresh one, which the server treats as a new machine —
+    // imperfect, but never blocks the login itself.
+  }
+  return id;
+}

--- a/src/utils/open-browser.ts
+++ b/src/utils/open-browser.ts
@@ -1,0 +1,31 @@
+import { spawn } from 'child_process';
+
+/**
+ * Best-effort browser open — must never fail or block. On headless machines
+ * (SSH, no display) the caller's printed URL is the fallback, so this returns
+ * false and stays silent. Shared by `node9 signup` and the device-login flow.
+ */
+export function openBrowser(url: string): boolean {
+  // Headless heuristics: no display server on Linux, or an SSH session
+  // anywhere — opening would either fail or open on the wrong machine.
+  if (process.env.SSH_CONNECTION || process.env.SSH_TTY) return false;
+  if (process.platform === 'linux' && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
+    return false;
+  }
+  const opener =
+    process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
+  try {
+    const child = spawn(opener, [url], {
+      stdio: 'ignore',
+      detached: true,
+      shell: process.platform === 'win32',
+    });
+    child.on('error', () => {
+      /* no browser available — the printed URL is the fallback */
+    });
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## What

`node9 login` with no argument now runs the browser device flow: POST
/device/start with machine metadata, print the URL + short code, open a browser
when one is plausibly present (SSH/headless prints the link so any device can
approve), then poll until the browser approves. The claiming poll is the single
delivery of the machine key, and it feeds straight into the shared onboarding
routine and its scorecard from B0. A raw-key argument keeps the legacy/service
behavior unchanged.

- `machine-id.ts` — durable UUID at `~/.node9/machine-id`. The cloud upserts the
  machine row by it, so re-logins rotate the secret in place instead of minting
  ghost machines.
- CI guard — argument-less login refuses under `CI`/`GITHUB_ACTIONS` and points
  at dashboard service keys (`--force` overrides).
- `cloud-endpoints.ts` — one resolver for non-intercept endpoints; connect's
  `resolveConnectUrl` delegates to it instead of duplicating the logic.
- `open-browser.ts` — shared best-effort opener, extracted from `signup`.

## Verification

3,995 tests pass; typecheck, lint and format clean. New coverage: machine-id
stability and corrupt-file re-mint, the full device flow against a mock server
(approved / denied / expired / unreachable), and the CI guard on the real spawn
path. The mock-server test caught a real bug before it shipped: a 1-second floor
on the poll interval that silently overrode the server's value.

## Release order

**This must reach npm before the matching dashboard PR deploys.** The new
WelcomeBanner tells users to run bare `node9 login`, which older CLIs reject.
The reverse (new CLI, old backend) is safe — `/device/start` simply 404s and the
command fails with a clear message.

Server side is node9Firewall#244.