### PR TITLE
doctor: the verdict may not contradict the findings

### DIFF
--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -154,7 +154,11 @@ describe('node9 doctor — agent hooks section', () => {
 describe('node9 doctor — summary', () => {
   // runDoctor spawns a subprocess that calls `ss` for port checking — can be slow
   // on CI runners. Raise Vitest timeout to 20s to avoid flaky failures.
-  it('exits 0 and prints "All checks passed" when everything is configured', () => {
+  // Since the verdict-honesty change (founder QA 2026-08-28), a configured
+  // machine with NO RUNNING DAEMON gets the warnings verdict, not the green
+  // one — the test env can't run a daemon, so that is the expected outcome
+  // here. Exit code stays 0: warnings never flip doctor red.
+  it('exits 0 with the warnings verdict when configured but the daemon is down', () => {
     const home = path.join(tmpBase, 'all-good');
     writeJson(path.join(home, '.node9', 'config.json'), { settings: { mode: 'standard' } });
     writeJson(path.join(home, '.node9', 'credentials.json'), { default: { apiKey: 'k' } });
@@ -173,7 +177,8 @@ describe('node9 doctor — summary', () => {
     });
 
     const { output, exitCode } = runDoctor(home);
-    expect(output).toMatch(/All checks passed/);
+    expect(output).toMatch(/warning\(s\)/);
+    expect(output).not.toMatch(/All checks passed/);
     expect(exitCode).toBe(0);
   }, 20000);
 
@@ -194,5 +199,55 @@ describe('node9 doctor — summary', () => {
     fs.mkdirSync(home, { recursive: true });
     const { output } = runDoctor(home);
     expect(output).toMatch(/Node9 Doctor\s+v\d+\.\d+\.\d+/);
+  });
+});
+
+// ── Verdict honesty (founder QA 2026-08-28) ──────────────────────────────────
+// A Windows machine with no daemon and an empty dashboard got:
+//   ⚠️ Daemon not running … ⚠️ node9 not in PATH … "All checks passed."
+// The verdict may not contradict the findings, and zero ship-lag without a
+// daemon may not claim the dashboard "matches".
+describe('node9 doctor — verdict honesty', () => {
+  function cloudHome(name: string): string {
+    const home = path.join(tmpBase, name);
+    writeJson(path.join(home, '.node9', 'config.json'), {
+      settings: { approvers: { native: true, terminal: true, cloud: true } },
+    });
+    writeJson(path.join(home, '.node9', 'credentials.json'), {
+      default: { apiKey: 'n9_live_doctor_test', apiUrl: 'https://api.node9.ai/api/v1/intercept' },
+    });
+    return home;
+  }
+
+  it('never prints "All checks passed" when any warning fired', () => {
+    // Isolated HOME guarantees at least one warning (daemon not running).
+    const { output, exitCode } = runDoctor(cloudHome('verdict-warn'));
+    expect(output).toMatch(/⚠️/);
+    expect(output).not.toMatch(/All checks passed/);
+    expect(output).toMatch(/warning\(s\)/);
+    // Warnings still exit 0 — a warned machine keeps enforcing.
+    expect(exitCode).toBe(0);
+  });
+
+  it('zero ship-lag without a daemon is NOT "caught up"', () => {
+    const { output } = runDoctor(cloudHome('verdict-lag'));
+    expect(output).not.toMatch(/dashboard matches the local log/);
+    expect(output).toMatch(/daemon is not running — new activity will not reach the dashboard/);
+  });
+
+  it('with cloud on, the daemon section is not labelled optional', () => {
+    const { output } = runDoctor(cloudHome('verdict-header'));
+    expect(output).toMatch(/\nDaemon\n|\bDaemon\b(?! \(optional\))/);
+    expect(output).not.toMatch(/Daemon \(optional\)/);
+  });
+
+  it('the binary locator never leaks a missing-command shell error', () => {
+    // On win32 the old code ran `which`, which does not exist — cmd printed
+    // "'which' is not recognized" above a false "not found" warning. Runs on
+    // every platform; the Windows CI runner is the one that proves the fix.
+    const home = path.join(tmpBase, 'locator');
+    fs.mkdirSync(home, { recursive: true });
+    const { output } = runDoctor(home);
+    expect(output).not.toMatch(/is not recognized as an internal or external command/);
   });
 });

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -27,6 +27,7 @@ export function registerDoctorCommand(program: Command, version: string): void {
     .action(async () => {
       const homeDir = os.homedir();
       let failures = 0;
+      let warnings = 0;
 
       function pass(msg: string) {
         console.log(chalk.green('  ✅ ') + msg);
@@ -39,6 +40,7 @@ export function registerDoctorCommand(program: Command, version: string): void {
       function warn(msg: string, hint?: string) {
         console.log(chalk.yellow('  ⚠️  ') + msg);
         if (hint) console.log(chalk.gray('       ' + hint));
+        warnings++;
       }
       function section(title: string) {
         console.log('\n' + chalk.bold(title));
@@ -49,8 +51,15 @@ export function registerDoctorCommand(program: Command, version: string): void {
       // ── Binary ───────────────────────────────────────────────────────────────
       section('Binary');
       try {
-        const which = execSync('which node9', { encoding: 'utf-8', timeout: 3000 }).trim();
-        pass(`node9 found at ${which}`);
+        // `which` does not exist on Windows (founder QA 2026-08-28: doctor
+        // printed a cmd error and claimed node9 was missing on a machine that
+        // was literally running it). `where` may return several matches — the
+        // first is what a shell would resolve.
+        const locator = process.platform === 'win32' ? 'where node9' : 'which node9';
+        const found = execSync(locator, { encoding: 'utf-8', timeout: 3000 })
+          .split(/\r?\n/)[0]
+          .trim();
+        pass(`node9 found at ${found}`);
       } catch {
         warn('node9 not found in $PATH — hooks may not find it', 'Run: npm install -g node9-ai');
       }
@@ -158,8 +167,15 @@ export function registerDoctorCommand(program: Command, version: string): void {
         );
       }
 
-      // ── Daemon ───────────────────────────────────────────────────────────────
-      section('Daemon (optional)');
+      // ── Daemon ────────────────────────────────────────────────────────────────
+      // "(optional)" only when this machine doesn't ship to the cloud. With
+      // cloud on, the daemon carries policy sync AND the audit shipper — calling
+      // it optional next to an empty dashboard is how a real outage read as
+      // "all checks passed" (founder QA 2026-08-28).
+      const cloudOn =
+        fs.existsSync(path.join(homeDir, '.node9', 'credentials.json')) &&
+        !!getConfig().settings.approvers?.cloud;
+      section(cloudOn ? 'Daemon' : 'Daemon (optional)');
       if (isDaemonRunning()) {
         pass(
           `Daemon running on ${DAEMON_HOST}:${DAEMON_PORT} — terminal & native approvals enabled`
@@ -181,7 +197,9 @@ export function registerDoctorCommand(program: Command, version: string): void {
         }
       } else {
         warn(
-          'Daemon not running — terminal & native approvals unavailable',
+          cloudOn
+            ? 'Daemon not running — approvals unavailable AND nothing ships to the dashboard until it starts (it auto-starts on agent activity)'
+            : 'Daemon not running — terminal & native approvals unavailable',
           'Run: node9 daemon --background'
         );
         // …and WHY, if the last start attempt left a trace. Without this the crash
@@ -280,8 +298,17 @@ export function registerDoctorCommand(program: Command, version: string): void {
         } else {
           const lag = shipLagBytes();
           const wm = readWatermark(AUDIT_SHIP_WATERMARK);
-          if (lag === 0) {
+          if (lag === 0 && isDaemonRunning()) {
             pass('Audit shipping caught up — dashboard matches the local log');
+          } else if (lag === 0) {
+            // Zero lag without a daemon is NOT "caught up" — nobody is
+            // shipping. The claim "dashboard matches the local log" next to a
+            // stopped daemon is how an empty dashboard read as healthy
+            // (founder QA 2026-08-28). Say what is actually true.
+            warn(
+              'Nothing queued, but the daemon is not running — new activity will not reach the dashboard until it starts',
+              'It auto-starts on agent activity, or run: node9 daemon --background'
+            );
           } else if (wm && lag !== null) {
             const ageMin = Math.round((Date.now() - new Date(wm.updatedAt).getTime()) / 60_000);
             if (ageMin > 5 && !isDaemonRunning()) {
@@ -306,12 +333,22 @@ export function registerDoctorCommand(program: Command, version: string): void {
       }
 
       // ── Summary ───────────────────────────────────────────────────────────────
+      // Warnings must reach the verdict line. "All checks passed" above two ⚠️
+      // rows taught a founder that a machine with no daemon and no dashboard
+      // data was healthy. Warnings still exit 0 — a warned machine keeps
+      // enforcing — but the verdict may not contradict the findings.
       console.log('');
-      if (failures === 0) {
-        console.log(chalk.green.bold('  All checks passed. Node9 is ready.\n'));
-      } else {
+      if (failures > 0) {
         console.log(chalk.red.bold(`  ${failures} check(s) failed. See hints above.\n`));
         process.exit(1);
+      } else if (warnings > 0) {
+        console.log(
+          chalk.yellow.bold(
+            `  ${warnings} warning(s) — Node9 is working, but see the hints above.\n`
+          )
+        );
+      } else {
+        console.log(chalk.green.bold('  All checks passed. Node9 is ready.\n'));
       }
     });
 }


### PR DESCRIPTION
Founder QA on a fresh Windows machine produced this screen while the dashboard
sat empty:

```
'which' is not recognized as an internal or external command
  ⚠️  node9 not found in $PATH — hooks may not find it
  ⚠️  Daemon not running — terminal & native approvals unavailable
  ✅ Audit shipping caught up — dashboard matches the local log
     All checks passed. Node9 is ready.
```

Three separate lies in one output.

- **`which` does not exist on Windows.** doctor leaked a cmd error and then
  claimed node9 was missing — on the machine that was running it. The locator is
  now platform-aware (`where` on win32, first match).
- **Zero ship-lag without a daemon is not "caught up".** The audit shipper lives
  inside the daemon, so with it stopped nobody is shipping and the dashboard
  cannot "match the local log". It now says what is true: nothing queued, and
  nothing will reach the dashboard until the daemon starts.
- **Warnings never reached the verdict.** A green "All checks passed" printed
  above two yellow findings. The summary now reports `N warning(s)`. Exit code
  stays 0 — a warned machine still enforces, so warnings must not flip doctor
  red.

Also: the Daemon section drops "(optional)" when cloud is on, because there it
carries policy sync and the shipper; and the not-running warning states the
dashboard consequence outright.

## Verification

3,999 tests pass; typecheck, lint and format clean. Four new regression cases
cover each lie, including one that asserts no missing-command shell error leaks
into the output — the Windows CI runner is what proves that one.

The first live run of the fixed build immediately surfaced a real finding that
the old green verdict had buried: the daemon on our own dev box was enforcing a
stale build.