### PR TITLE
Windows: run the platform's shell instead of a hardcoded /bin/bash

### DIFF
--- a/src/__tests__/platform-shell.unit.test.ts
+++ b/src/__tests__/platform-shell.unit.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { locatorCommand, shellInvocation } from '../utils/platform-shell';
+
+// Founder QA 2026-08-28 on Windows: `node9 <cmd>` died with
+//   Error: spawn /bin/bash ENOENT
+// because the proxy hardcoded a POSIX shell, and the executable probe ran
+// `which`, which does not exist there either. Both are one definition now.
+// process.platform is read-only, so each case redefines it and restores after.
+function withPlatform(value: NodeJS.Platform, fn: () => void) {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+  try {
+    fn();
+  } finally {
+    Object.defineProperty(process, 'platform', original);
+  }
+}
+
+describe('locatorCommand', () => {
+  it('uses where on Windows and which elsewhere', () => {
+    withPlatform('win32', () => expect(locatorCommand()).toBe('where'));
+    withPlatform('linux', () => expect(locatorCommand()).toBe('which'));
+    withPlatform('darwin', () => expect(locatorCommand()).toBe('which'));
+  });
+});
+
+describe('shellInvocation', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('never returns a POSIX shell path on Windows (the ENOENT crash)', () => {
+    withPlatform('win32', () => {
+      const { file, args } = shellInvocation('echo hi');
+      expect(file).not.toContain('/bin/');
+      expect(args).toContain('echo hi');
+    });
+  });
+
+  it('honours ComSpec, falling back to cmd.exe', () => {
+    withPlatform('win32', () => {
+      vi.stubEnv('ComSpec', 'C:\\Windows\\System32\\cmd.exe');
+      expect(shellInvocation('dir').file).toBe('C:\\Windows\\System32\\cmd.exe');
+      vi.stubEnv('ComSpec', '');
+      expect(shellInvocation('dir').file).toBe('cmd.exe');
+    });
+  });
+
+  it('passes /d on Windows so registry AutoRun cannot run first', () => {
+    withPlatform('win32', () => {
+      // AutoRun executes before the user's command — a governed shell must not
+      // hand it an unexamined pre-command.
+      expect(shellInvocation('dir').args[0]).toBe('/d');
+    });
+  });
+
+  it('uses bash on POSIX — sh is dash on many systems', () => {
+    withPlatform('linux', () => {
+      expect(shellInvocation('echo hi')).toEqual({
+        file: '/bin/bash',
+        args: ['-c', 'echo hi'],
+      });
+    });
+  });
+
+  it('keeps the command as ONE argument so quoting survives', () => {
+    const cmd = 'echo "a b" && ls';
+    withPlatform('win32', () =>
+      expect(shellInvocation(cmd).args.filter((a) => a === cmd)).toHaveLength(1)
+    );
+    withPlatform('linux', () =>
+      expect(shellInvocation(cmd).args.filter((a) => a === cmd)).toHaveLength(1)
+    );
+  });
+});

--- a/src/__tests__/proxy-spawn.integration.test.ts
+++ b/src/__tests__/proxy-spawn.integration.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const CLI = path.resolve(__dirname, '../../dist/cli.js');
+
+// `node9 <anything-not-a-subcommand>` is treated as a shell command to govern
+// and wrap (cli.ts catch-all → runProxy). On Windows that path spawned a
+// hardcoded /bin/bash and died with an unhandled 'error' event — a raw stack
+// trace, exit code 1, no explanation (founder QA 2026-08-28).
+//
+// Runs on every platform; the Windows CI runner is what proves the fix. The
+// POSIX assertions still guard the crash-handling contract everywhere.
+describe('node9 <command> — proxy spawn (integration)', () => {
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-proxy-spawn-'));
+
+  function run(args: string[], timeout = 20000) {
+    return spawnSync(process.execPath, [CLI, ...args], {
+      env: {
+        ...process.env,
+        HOME: tmpHome,
+        USERPROFILE: tmpHome,
+        NODE9_TESTING: '1',
+        NODE9_NO_AUTO_DAEMON: '1',
+      },
+      encoding: 'utf-8',
+      timeout,
+    });
+  }
+
+  it('runs an approved command through the platform shell', () => {
+    // `echo` exists as a shell builtin on both cmd.exe and bash, so this
+    // exercises the shell fallback path on either platform.
+    const r = run(['echo', 'node9-spawn-ok']);
+    expect(r.error).toBeUndefined();
+    expect(`${r.stdout}${r.stderr}`).toContain('node9-spawn-ok');
+  });
+
+  it('never leaks a POSIX shell path or an unhandled error event', () => {
+    const r = run(['echo', 'hello']);
+    const out = `${r.stdout}${r.stderr}`;
+    expect(out).not.toContain('spawn /bin/bash ENOENT');
+    expect(out).not.toContain("Unhandled 'error' event");
+    expect(out).not.toMatch(/at ChildProcess\._handle\.onexit/);
+  });
+
+  it('spawns a WORKING shell for a command that is not a binary', () => {
+    // The load-bearing case: `which`/`where` fails for this name, so the code
+    // takes the shell fallback — the branch that hardcoded /bin/bash. The
+    // SHELL must be the one that reports the missing command, which proves it
+    // launched. If the shell path itself were wrong, our own spawn-error
+    // handler would answer instead, so asserting its ABSENCE is what
+    // distinguishes a working shell from a missing one.
+    const r = run(['n9-definitely-not-a-real-binary-xyz']);
+    expect(r.error).toBeUndefined();
+    const out = `${r.stdout}${r.stderr}`;
+    expect(out).not.toContain('Node9 could not run');
+    // …and the shell said its piece.
+    expect(out).toMatch(/not found|not recognized/i);
+  });
+
+  it('a broken spawn is reported cleanly, never as Node internals', () => {
+    const r = run(['n9-definitely-not-a-real-binary-xyz']);
+    const out = `${r.stdout}${r.stderr}`;
+    expect(out).not.toContain("Unhandled 'error' event");
+    expect(out).not.toMatch(/node:internal\/child_process/);
+  });
+});

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -19,6 +19,7 @@ import {
 import { agoLabel } from '../../lib/relative-time';
 import { readStartupCause } from '../../daemon/startup-log';
 import { undoLeftoverPaths } from '../../utils/undo-leftovers';
+import { locatorCommand } from '../../utils/platform-shell';
 
 export function registerDoctorCommand(program: Command, version: string): void {
   program
@@ -55,8 +56,10 @@ export function registerDoctorCommand(program: Command, version: string): void {
         // printed a cmd error and claimed node9 was missing on a machine that
         // was literally running it). `where` may return several matches — the
         // first is what a shell would resolve.
-        const locator = process.platform === 'win32' ? 'where node9' : 'which node9';
-        const found = execSync(locator, { encoding: 'utf-8', timeout: 3000 })
+        const found = execSync(`${locatorCommand()} node9`, {
+          encoding: 'utf-8',
+          timeout: 3000,
+        })
           .split(/\r?\n/)[0]
           .trim();
         pass(`node9 found at ${found}`);

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -9,6 +9,7 @@ import { execa } from 'execa';
 import { parseCommandString } from 'execa';
 import { authorizeHeadless } from '../auth/orchestrator';
 import { buildNegotiationMessage } from '../policy/negotiation';
+import { locatorCommand, shellInvocation } from '../utils/platform-shell';
 
 function sanitize(value: string): string {
   // eslint-disable-next-line no-control-regex
@@ -23,8 +24,13 @@ export async function runProxy(targetCommand: string) {
   let executable = cmd;
   let useShell = false;
   try {
-    const { stdout } = await execa('which', [cmd]);
-    if (stdout) executable = stdout.trim();
+    // `where` on Windows, `which` elsewhere — a hardcoded `which` there fails
+    // for EVERY command, sending all of them down the shell path.
+    const { stdout } = await execa(locatorCommand(), [cmd]);
+    // `where` can return several matches, one per line; the first is what a
+    // shell would resolve.
+    const first = stdout.split(/\r?\n/)[0]?.trim();
+    if (first) executable = first;
   } catch {
     // Command not found as a standalone binary — may be a shell builtin or alias.
     // Fall back to shell mode so the system shell can resolve it.
@@ -34,12 +40,13 @@ export async function runProxy(targetCommand: string) {
   // stderr only — stdout must stay clean for stdio protocols (JSON-RPC, MCP)
   console.error(chalk.green(`🚀 Node9 Proxy Active: Monitoring [${targetCommand}]`));
 
-  // Spawn the MCP Server / Shell command.
-  // Use bash (not /bin/sh) for shell fallback so that bash builtins and
-  // bash-specific syntax work correctly — /bin/sh is dash on many systems.
+  // Spawn the MCP Server / Shell command. The shell is platform-resolved:
+  // bash on POSIX (not /bin/sh — that is dash on many systems), ComSpec on
+  // Windows, where a hardcoded /bin/bash was a guaranteed ENOENT crash.
   const spawnEnv = { ...process.env, FORCE_COLOR: '1' };
+  const shell = shellInvocation(targetCommand);
   const child = useShell
-    ? spawn('/bin/bash', ['-c', targetCommand], {
+    ? spawn(shell.file, shell.args, {
         stdio: ['pipe', 'pipe', 'inherit'],
         shell: false,
         env: spawnEnv,
@@ -134,6 +141,23 @@ export async function runProxy(targetCommand: string) {
   // ── FORWARD OUTPUT (Server -> Agent) ──
   // We just pass the server's responses back to the agent as-is
   child.stdout.pipe(process.stdout);
+
+  // A failed spawn arrives as an 'error' EVENT, never as a throw from spawn().
+  // With no listener Node re-raises it as an unhandled 'error' and the process
+  // dies with a raw stack trace — which is exactly what a Windows user saw
+  // ("Error: spawn /bin/bash ENOENT" plus 12 lines of internals). Report the
+  // command that failed and exit like a shell would for "not found".
+  child.on('error', (err: NodeJS.ErrnoException) => {
+    const what = useShell ? shell.file : executable;
+    console.error(
+      chalk.red(
+        err.code === 'ENOENT'
+          ? `\n❌ Node9 could not run "${targetCommand}": ${what} was not found on this machine.`
+          : `\n❌ Node9 could not run "${targetCommand}": ${err.message}`
+      )
+    );
+    process.exit(127); // conventional shell exit code for command-not-found
+  });
 
   child.on('exit', (code) => process.exit(code || 0));
 }

--- a/src/utils/platform-shell.ts
+++ b/src/utils/platform-shell.ts
@@ -1,0 +1,32 @@
+// Platform primitives for locating a command and invoking a shell.
+//
+// Both existed inline in more than one place and both were Unix-only, which is
+// the same bug twice: `which` does not exist on Windows (cmd printed
+// "'which' is not recognized" and callers read the failure as "not found"), and
+// `/bin/bash` does not exist there at all — `node9 <cmd>` crashed with
+// `spawn /bin/bash ENOENT` on every Windows machine (founder QA 2026-08-28).
+// One definition each, so a third caller cannot reintroduce either.
+
+/** The command that resolves an executable's path on this platform. */
+export function locatorCommand(): string {
+  return process.platform === 'win32' ? 'where' : 'which';
+}
+
+/**
+ * How to run `command` through a shell here.
+ *
+ * POSIX: bash, not /bin/sh — sh is dash on many systems and drops bash
+ * builtins and bash-specific syntax.
+ * Windows: ComSpec (cmd.exe). `/d` skips AutoRun commands from the registry,
+ * which would otherwise execute before the user's command; `/s /c` keeps the
+ * rest of the line intact so quoting survives.
+ */
+export function shellInvocation(command: string): { file: string; args: string[] } {
+  if (process.platform === 'win32') {
+    return {
+      file: process.env.ComSpec || 'cmd.exe',
+      args: ['/d', '/s', '/c', command],
+    };
+  }
+  return { file: '/bin/bash', args: ['-c', command] };
+}


### PR DESCRIPTION
`node9 <cmd>` crashes on every Windows machine. Founder QA, verbatim:

```
PS C:\Users\nadav> node9 start
✅ Approved — running command...
🚀 Node9 Proxy Active: Monitoring [start]
node:events:497
      throw er; // Unhandled 'error' event
Error: spawn /bin/bash ENOENT
```

Any argument that is not a known subcommand is treated as a shell command to
govern and wrap, so this is not an edge case — it is the whole
`node9 <anything>` surface on Windows.

## Three defects in one path, all Unix-only assumptions

- The executable probe ran `which`, which does not exist on Windows. Every
  command therefore failed the lookup and fell through to the shell branch.
- That branch spawned a hardcoded `/bin/bash` — guaranteed ENOENT there.
- The child had no `'error'` listener. A failed spawn arrives as an **event**,
  never as a throw, so Node re-raised it and the process died with a raw stack
  trace instead of a sentence.

## The fix

Locator and shell become one definition each in `utils/platform-shell.ts`
(`where`/`which`; ComSpec with `/d /s /c`, or bash with `-c`). `doctor`'s own
locator — added hours earlier for the same `which` reason — now calls it rather
than keeping a second copy, so a third caller cannot reintroduce the split.

Windows gets `/d` deliberately: without it, registry AutoRun commands execute
ahead of the user's command, which a governed shell must not permit.

Spawn failures now report the command and the missing file and exit 127, the
conventional shell code for command-not-found.

## On the test

The first version of the integration test passed against a deliberately broken
shell path. `echo` is a real binary on Linux, so it never reached the fallback
branch — the test was green for the wrong reason. It is rewritten around a name
that forces the shell branch, asserting that the **shell** reported the missing
command rather than our spawn handler. Mutation now fails it, as it should.

## Verification

4,009 tests pass (10 new); typecheck, lint and format clean. The Windows CI
runners are what prove this one.