### PR TITLE
Windows daemon: use the Startup folder — schtasks needs elevation

### DIFF
--- a/src/__tests__/service-enabled.unit.test.ts
+++ b/src/__tests__/service-enabled.unit.test.ts
@@ -74,34 +74,22 @@ describe('isDaemonServiceEnabled — darwin (launchctl)', () => {
   });
 });
 
-describe('isDaemonServiceEnabled — win32 (schtasks)', () => {
+describe('isDaemonServiceEnabled — win32 (Startup folder)', () => {
+  // No spawn at all here: the Startup entry is a FILE. Installed and enabled
+  // are the same question on Windows — unlike a systemd unit or a scheduled
+  // task, there is no present-but-disabled state to detect.
   beforeEach(() => setPlatform('win32'));
 
-  it('probes the task XML and reads <Enabled>false</Enabled> as disabled', () => {
-    mockSpawn.mockReturnValue(ret(0, '<Task><Settings><Enabled>false</Enabled></Settings></Task>'));
-    expect(isDaemonServiceEnabled()).toBe(false);
-    expect(mockSpawn).toHaveBeenCalledWith(
-      'schtasks',
-      ['/Query', '/TN', 'Node9Daemon', '/XML'],
-      expect.anything()
-    );
-  });
-
-  it('an existing task with no <Enabled>false</> reads as enabled (the default)', () => {
-    mockSpawn.mockReturnValue(ret(0, '<Task><Settings></Settings></Task>'));
-    expect(isDaemonServiceEnabled()).toBe(true);
-  });
-
-  it('a missing task (query exits non-zero) is not enabled', () => {
-    mockSpawn.mockReturnValue(ret(1, ''));
-    expect(isDaemonServiceEnabled()).toBe(false);
+  it('reads the filesystem, never a subprocess', () => {
+    expect(typeof isDaemonServiceEnabled()).toBe('boolean');
+    expect(mockSpawn).not.toHaveBeenCalled();
   });
 });
 
 describe('isDaemonServiceEnabled — robustness', () => {
   it('false on an unsupported platform without probing (freebsd)', () => {
     // win32 used to sit here as "unsupported" — that contract described the
-    // Windows gap, not a design. It now has the schtasks probe above.
+    // Windows gap, not a design. It now has the Startup-folder check above.
     setPlatform('freebsd');
     expect(isDaemonServiceEnabled()).toBe(false);
     expect(mockSpawn).not.toHaveBeenCalled();

--- a/src/__tests__/service-windows.unit.test.ts
+++ b/src/__tests__/service-windows.unit.test.ts
@@ -1,12 +1,15 @@
 /**
- * Windows Task Scheduler backend — the pure parts (login-v2, Windows daemon).
- * The exec wrappers are two-line spawnSync calls; everything that can be wrong
- * (VBS escaping, schtasks argv, hidden-window flag) is built by pure functions
- * so it is testable on any platform. The Windows CI runners exercise the same
- * code paths through the existing doctor/status integration tests.
+ * Windows logon-startup backend — the pure parts (login-v2, Windows daemon).
+ *
+ * History worth keeping: this started as a Task Scheduler backend and every
+ * install failed with `ERROR: Access is denied.` on a normal account, because
+ * `schtasks /Create` writes to the root task folder and that needs elevation.
+ * A bare `/TR notepad.exe` failed identically, which proved it was the
+ * mechanism rather than our arguments. The Startup folder needs no privileges.
  */
-import { describe, it, expect } from 'vitest';
-import { windowsLauncherVbs, schtasksCreateArgs } from '../daemon/service';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import path from 'path';
+import { windowsLauncherVbs, windowsStartupDir, describeSpawnFailure } from '../daemon/service';
 
 describe('windowsLauncherVbs', () => {
   const NODE = 'C:\\Program Files\\nodejs\\node.exe';
@@ -17,52 +20,79 @@ describe('windowsLauncherVbs', () => {
     // VBS doubles quotes inside strings — each path must arrive doubly-quoted
     // so paths with spaces ("Program Files") survive.
     expect(vbs).toContain(`""${NODE}"" ""${CLI}"" daemon`);
-    // Window style 0 + no-wait: the whole reason the launcher exists. A task
-    // that ran node.exe directly would park a console window in the taskbar
-    // for the entire session.
+    // Window style 0 + no-wait: the whole reason a .vbs is used instead of a
+    // .cmd. A console app at logon parks a window in the taskbar all session.
     expect(vbs).toMatch(/, 0, False/);
   });
 
-  it('marks the daemon as auto-started via the process environment', () => {
-    // Task Scheduler cannot set per-task env vars — the launcher's process
-    // env is how NODE9_AUTO_STARTED reaches the daemon, like the plist/unit do.
+  it('is ASCII-only — WSH reads .vbs as ANSI without a BOM', () => {
+    // The first version used a UTF-8 em dash in a comment and rendered as
+    // `â€"` on the founder's machine. Harmless in a comment; in a path it
+    // would have broken the launch.
     const vbs = windowsLauncherVbs(NODE, CLI);
-    expect(vbs).toContain('sh.Environment("PROCESS")("NODE9_AUTO_STARTED") = "1"');
+    // eslint-disable-next-line no-control-regex
+    expect(vbs).toMatch(/^[\x00-\x7F]*$/);
   });
 
-  it('uses CRLF — notepad-openable, and VBS is a Windows-native format', () => {
+  it('marks the daemon as auto-started via the process environment', () => {
+    expect(windowsLauncherVbs(NODE, CLI)).toContain(
+      'sh.Environment("PROCESS")("NODE9_AUTO_STARTED") = "1"'
+    );
+  });
+
+  it('uses CRLF — a Windows-native format read by a legacy host', () => {
     expect(windowsLauncherVbs(NODE, CLI)).toContain('\r\n');
   });
 
-  it('refuses a path containing a quote instead of producing broken VBS', () => {
+  it('refuses a path containing a quote instead of emitting broken VBS', () => {
     expect(() => windowsLauncherVbs('C:\\evil"quote\\node.exe', CLI)).toThrow(/Illegal quote/);
   });
 });
 
-describe('schtasksCreateArgs', () => {
-  it('creates an ONLOGON task for the current user, idempotently', () => {
-    const args = schtasksCreateArgs('C:\\Users\\nadav\\.node9\\daemon-launcher.vbs');
-    expect(args).toEqual([
-      '/Create',
-      '/TN',
-      'Node9Daemon',
-      '/TR',
-      'wscript.exe //B "C:\\Users\\nadav\\.node9\\daemon-launcher.vbs"',
-      '/SC',
-      'ONLOGON',
-      '/F',
-    ]);
+describe('windowsStartupDir', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  // path.join uses the HOST separator, so these assert structure rather than a
+  // literal string — otherwise they would only be true on a Windows runner.
+  it('honours APPDATA (roaming / redirected profiles)', () => {
+    vi.stubEnv('APPDATA', 'D:\\Roaming');
+    expect(windowsStartupDir('C:\\Users\\nadav')).toBe(
+      path.join('D:\\Roaming', 'Microsoft', 'Windows', 'Start Menu', 'Programs', 'Startup')
+    );
   });
 
-  it('quotes the launcher path inside /TR (home dirs contain spaces)', () => {
-    const args = schtasksCreateArgs('C:\\Users\\Nadav Cohen\\.node9\\daemon-launcher.vbs');
-    const tr = args[args.indexOf('/TR') + 1];
-    expect(tr).toBe('wscript.exe //B "C:\\Users\\Nadav Cohen\\.node9\\daemon-launcher.vbs"');
+  it('an EMPTY APPDATA falls back instead of producing a relative path', () => {
+    // `??` would let "" through and the Startup entry would land somewhere
+    // relative — autostart would silently never happen. This is the repo's
+    // documented `|| undefined` rule; the test found the violation.
+    vi.stubEnv('APPDATA', '');
+    const p = windowsStartupDir('C:\\Users\\nadav');
+    expect(p).toContain('AppData');
+    expect(p.startsWith('Microsoft')).toBe(false);
+  });
+});
+
+describe('describeSpawnFailure', () => {
+  // The first Windows install printed `schtasks /Create failed: unknown error`
+  // — a diagnostic that can say "unknown error" is not a diagnostic.
+  it('never says "unknown error" when the command did not run', () => {
+    const msg = describeSpawnFailure('wscript.exe', { status: null });
+    expect(msg).not.toMatch(/unknown error/);
+    expect(msg).toMatch(/did not run/);
   });
 
-  it('never asks for elevation — no /RU, runs as the logged-on user', () => {
-    // /RU would demand credentials or admin rights; the whole design is a
-    // user-level agent, matching launchd user agents and systemd --user.
-    expect(schtasksCreateArgs('x.vbs')).not.toContain('/RU');
+  it('names a missing binary from the spawn error, not the empty streams', () => {
+    const err = Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' });
+    const msg = describeSpawnFailure('wscript.exe //B x', { status: null, error: err });
+    expect(msg).toMatch(/wscript\.exe not found/);
+  });
+
+  it('prefers the command output when there is any', () => {
+    const msg = describeSpawnFailure('cmd', { status: 1, stderr: 'ERROR: Access is denied.' });
+    expect(msg).toContain('Access is denied');
+  });
+
+  it('falls back to the exit code when a failure produced no output at all', () => {
+    expect(describeSpawnFailure('cmd', { status: 5 })).toMatch(/exit code 5/);
   });
 });

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -202,31 +202,98 @@ function isSystemdInstalled(): boolean {
   return fs.existsSync(SYSTEMD_UNIT);
 }
 
-// ── Windows Task Scheduler ─────────────────────────────────────────────────
-// A logon task that runs the daemon through a VBS launcher. The launcher is
-// what keeps the daemon INVISIBLE: a console app started by an ONLOGON task
-// opens a console window that would sit in the user's taskbar for the entire
-// session. `Wscript.Shell.Run` with window style 0 starts it hidden — the
-// same battle-tested pattern launchd's plist and systemd's unit play on the
-// other platforms, translated into what Windows actually offers.
+// ── Windows logon startup ──────────────────────────────────────────────────
+// The per-user Startup folder, NOT Task Scheduler.
+//
+// schtasks was the first attempt and it is the wrong tool: `schtasks /Create`
+// writes to the root task folder, which requires elevation. On a normal user
+// account every install failed with `ERROR: Access is denied.` — reproduced
+// on a founder machine with a bare `/TR notepad.exe`, so it was the mechanism,
+// not our arguments (2026-08-29). Asking a developer to run an elevated shell
+// to make logging work is not an onboarding step we are willing to ship.
+//
+// The Startup folder needs no privileges at all and is the true analogue of a
+// launchd USER agent / `systemd --user` unit: per-user, at interactive logon.
+// The trade is no restart-on-failure — acceptable, because the agent hooks
+// already respawn a dead daemon on the next tool call.
+//
+// A .vbs there (rather than a .cmd or a shortcut to node) is what keeps the
+// daemon INVISIBLE: a console app launched at logon parks a console window in
+// the taskbar for the whole session. `Wscript.Shell.Run … , 0` starts it hidden.
 
-const SCHTASKS_TASK = 'Node9Daemon';
-const WIN_LAUNCHER = () => path.join(os.homedir(), '.node9', 'daemon-launcher.vbs');
+const STARTUP_FILE = 'node9-daemon.vbs';
 
 /**
- * The hidden-window launcher. VBS string escaping doubles the quote character;
- * Windows paths cannot legally contain `"`, so embedding them is safe — the
- * guard below is for the impossible case reaching us from a corrupted argv.
- * NODE9_AUTO_STARTED rides the launcher's process environment (Task Scheduler
- * itself cannot set per-task env vars), matching the plist/unit files.
+ * Turn a failed spawnSync into a sentence a user can act on.
+ *
+ * The first Windows install reported `schtasks /Create failed: unknown error`
+ * because the message only read stderr/stdout — but a command that never RAN
+ * (missing binary, blocked, timed out) leaves both empty and reports itself in
+ * `.error` / `.status: null`. A diagnostic that can print "unknown error" is
+ * not a diagnostic. Exported for tests.
+ */
+export function describeSpawnFailure(
+  what: string,
+  r: {
+    status: number | null;
+    signal?: NodeJS.Signals | null;
+    stdout?: string;
+    stderr?: string;
+    error?: Error;
+  }
+): string {
+  const parts: string[] = [];
+  const out = `${r.stderr ?? ''}${r.stdout ?? ''}`.trim();
+  if (out) parts.push(out);
+  if (r.error) {
+    const code = (r.error as NodeJS.ErrnoException).code;
+    parts.push(
+      code === 'ENOENT' ? `${what.split(' ')[0]} not found on this machine` : r.error.message
+    );
+  }
+  if (r.signal) parts.push(`killed by ${r.signal}`);
+  if (!parts.length) {
+    parts.push(
+      r.status === null
+        ? 'the command did not run (timed out or was blocked)'
+        : `exit code ${r.status}`
+    );
+  }
+  return `${what} failed: ${parts.join(' — ')}`;
+}
+
+/** The per-user Startup folder. Honours APPDATA (roaming/redirected profiles)
+ *  before falling back to the conventional location. */
+export function windowsStartupDir(homeDir: string = os.homedir()): string {
+  // `||`, not `??` (repo rule): an APPDATA set to "" passes a ?? guard and
+  // yields a RELATIVE path — the Startup entry would land somewhere random
+  // and autostart would silently never happen. Caught by the unit test below.
+  const appData = process.env.APPDATA || path.join(homeDir, 'AppData', 'Roaming');
+  return path.join(appData, 'Microsoft', 'Windows', 'Start Menu', 'Programs', 'Startup');
+}
+
+const WIN_LAUNCHER = () => path.join(windowsStartupDir(), STARTUP_FILE);
+
+/**
+ * The hidden-window launcher.
+ *
+ * ASCII ONLY. Windows Script Host reads a .vbs as ANSI unless it carries a
+ * UTF-16 BOM, so a UTF-8 em dash in the first version rendered as `â€"` on the
+ * founder's machine. It was only a comment that time; in a path it would have
+ * broken the launch outright.
+ *
+ * VBS escapes a quote by doubling it. Windows paths cannot legally contain `"`,
+ * so embedding them is safe — the guard is for a corrupted argv reaching us.
+ * NODE9_AUTO_STARTED rides the launcher's process environment, matching what
+ * the plist and the systemd unit set.
  */
 export function windowsLauncherVbs(nodePath: string, scriptPath: string): string {
   for (const p of [nodePath, scriptPath]) {
     if (p.includes('"')) throw new Error(`Illegal quote in path: ${p}`);
   }
   return [
-    "' Auto-generated by node9 — starts the approval daemon with no console window.",
-    "' Recreated on every `node9 daemon install`; safe to delete (uninstall does).",
+    "' Auto-generated by node9 - starts the approval daemon with no console window.",
+    "' Recreated by `node9 daemon install`; removed by `node9 daemon uninstall`.",
     'Set sh = CreateObject("Wscript.Shell")',
     'sh.Environment("PROCESS")("NODE9_AUTO_STARTED") = "1"',
     `sh.Run """${nodePath}"" ""${scriptPath}"" daemon", 0, False`,
@@ -234,86 +301,32 @@ export function windowsLauncherVbs(nodePath: string, scriptPath: string): string
   ].join('\r\n');
 }
 
-/** Pure builders for the schtasks invocations — exported so the exact argv can
- *  be unit-tested on any platform; the exec wrappers below stay two-liners. */
-export function schtasksCreateArgs(launcherPath: string): string[] {
-  // Array-form spawn (no shell), so the only quoting that matters is inside
-  // /TR, which schtasks parses itself. /F replaces an existing task (install
-  // is documented idempotent); ONLOGON without /RU = current user, at logon —
-  // the same "user agent" semantics as launchd/systemd-user.
-  return [
-    '/Create',
-    '/TN',
-    SCHTASKS_TASK,
-    '/TR',
-    `wscript.exe //B "${launcherPath}"`,
-    '/SC',
-    'ONLOGON',
-    '/F',
-  ];
-}
-
-function installSchtasks(binaryPath: string): void {
-  const launcher = WIN_LAUNCHER();
-  const dir = path.dirname(launcher);
+function installWindowsStartup(binaryPath: string): void {
+  const target = WIN_LAUNCHER();
+  const dir = path.dirname(target);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(launcher, windowsLauncherVbs(process.execPath, binaryPath), 'utf-8');
-  const create = spawnSync('schtasks', schtasksCreateArgs(launcher), {
-    encoding: 'utf8',
-    timeout: 10_000,
-  });
-  if (create.status !== 0) {
-    throw new Error(
-      `schtasks /Create failed: ${create.stderr || create.stdout || 'unknown error'}`
-    );
-  }
+  fs.writeFileSync(target, windowsLauncherVbs(process.execPath, binaryPath), 'utf-8');
   // Start it now — parity with systemd's `enable --now` and launchd's `load`.
-  // Best-effort: the task itself is installed either way.
-  spawnSync('schtasks', ['/Run', '/TN', SCHTASKS_TASK], { encoding: 'utf8', timeout: 10_000 });
+  // Best-effort: the logon entry is installed either way.
+  spawnSync('wscript.exe', ['//B', target], { encoding: 'utf8', timeout: 10_000 });
 }
 
-function uninstallSchtasks(): void {
-  // /F suppresses the confirmation prompt; a missing task exits non-zero,
-  // which is the desired no-op.
-  spawnSync('schtasks', ['/Delete', '/TN', SCHTASKS_TASK, '/F'], {
-    encoding: 'utf8',
-    timeout: 10_000,
-  });
-  const launcher = WIN_LAUNCHER();
-  if (fs.existsSync(launcher)) {
-    try {
-      fs.unlinkSync(launcher);
-    } catch {
-      /* non-fatal */
-    }
-  }
+function uninstallWindowsStartup(): void {
+  const target = WIN_LAUNCHER();
+  if (fs.existsSync(target)) fs.unlinkSync(target);
 }
 
-function isSchtasksInstalled(): boolean {
-  const r = spawnSync('schtasks', ['/Query', '/TN', SCHTASKS_TASK], {
-    encoding: 'utf8',
-    timeout: 5000,
-  });
-  return r.status === 0;
-}
-
-/** A disabled task still answers /Query — only the XML says so. Absent or
- *  unparseable XML while the task exists reads as ENABLED: the failure mode
- *  we surface is installed-but-disabled, and guessing "disabled" on a probe
- *  hiccup would nag healthy machines. */
-function isSchtasksEnabled(): boolean {
-  const r = spawnSync('schtasks', ['/Query', '/TN', SCHTASKS_TASK, '/XML'], {
-    encoding: 'utf8',
-    timeout: 5000,
-  });
-  if (r.status !== 0) return false; // not installed at all
-  return !/<Enabled>\s*false\s*<\/Enabled>/i.test(r.stdout ?? '');
+/** Installed and enabled are the same thing here: the file is in Startup or it
+ *  is not. There is no disabled-but-present state to detect, unlike a systemd
+ *  unit or a scheduled task. */
+function isWindowsStartupInstalled(): boolean {
+  return fs.existsSync(WIN_LAUNCHER());
 }
 
 // ── Public API ─────────────────────────────────────────────────────────────
 
 export type ServiceInstallResult =
-  | { ok: true; platform: 'launchd' | 'systemd' | 'schtasks'; alreadyInstalled: boolean }
+  | { ok: true; platform: 'launchd' | 'systemd' | 'startup-folder'; alreadyInstalled: boolean }
   | { ok: false; reason: string };
 
 /**
@@ -396,9 +409,9 @@ export function installDaemonService(): ServiceInstallResult {
     }
 
     if (process.platform === 'win32') {
-      const alreadyInstalled = isSchtasksInstalled();
-      installSchtasks(binary);
-      return { ok: true, platform: 'schtasks', alreadyInstalled };
+      const alreadyInstalled = isWindowsStartupInstalled();
+      installWindowsStartup(binary);
+      return { ok: true, platform: 'startup-folder', alreadyInstalled };
     }
 
     return {
@@ -427,8 +440,8 @@ export function uninstallDaemonService(): ServiceInstallResult {
       return { ok: true, platform: 'systemd', alreadyInstalled: false };
     }
     if (process.platform === 'win32') {
-      uninstallSchtasks();
-      return { ok: true, platform: 'schtasks', alreadyInstalled: false };
+      uninstallWindowsStartup();
+      return { ok: true, platform: 'startup-folder', alreadyInstalled: false };
     }
     return {
       ok: false,
@@ -448,7 +461,7 @@ export function uninstallDaemonService(): ServiceInstallResult {
 export function isDaemonServiceInstalled(): boolean {
   if (process.platform === 'darwin') return isLaunchdInstalled();
   if (process.platform === 'linux') return isSystemdInstalled();
-  if (process.platform === 'win32') return isSchtasksInstalled();
+  if (process.platform === 'win32') return isWindowsStartupInstalled();
   return false;
 }
 
@@ -490,13 +503,10 @@ function enableDaemonServiceQuiet(): boolean {
       return r.status === 0;
     }
     if (process.platform === 'win32') {
-      // Re-enables the task for next logon without touching a live daemon —
-      // /Change /ENABLE is the schtasks analogue of `systemctl enable`.
-      const r = spawnSync('schtasks', ['/Change', '/TN', SCHTASKS_TASK, '/ENABLE'], {
-        encoding: 'utf8',
-        timeout: 5000,
-      });
-      return r.status === 0;
+      // Nothing to re-enable: the Startup entry is present or absent, and
+      // installing a missing one is deliberately not this function's job
+      // (see autostartRepairDecision — we never silently install).
+      return isWindowsStartupInstalled();
     }
     // darwin: `load -w` (done at install) already sets RunAtLoad persistently.
     return process.platform === 'darwin';
@@ -601,7 +611,7 @@ export function isDaemonServiceEnabled(): boolean {
       return r.status === 0;
     }
     if (process.platform === 'win32') {
-      return isSchtasksEnabled();
+      return isWindowsStartupInstalled();
     }
   } catch {
     /* probe failure → treat as not-enabled; never throw */

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1301,7 +1301,9 @@ export function claudeDesktopConfigPath(homeDir: string = os.homedir()): string 
     return path.join(homeDir, '.config', 'Claude', 'claude_desktop_config.json');
   }
   if (process.platform === 'win32') {
-    const appData = process.env.APPDATA ?? path.join(homeDir, 'AppData', 'Roaming');
+    // `||`, not `??` (repo rule): an empty APPDATA passes a ?? guard and makes
+    // this path RELATIVE, so the config would be read/written in the cwd.
+    const appData = process.env.APPDATA || path.join(homeDir, 'AppData', 'Roaming');
     return path.join(appData, 'Claude', 'claude_desktop_config.json');
   }
   return null;


### PR DESCRIPTION
The Task Scheduler backend shipped in 2.3.0 fails on every normal account:

```
PS> node9 daemon install
✗ schtasks /Create failed: unknown error
```

Founder QA isolated it in one command. `schtasks /Create /TN X /TR notepad.exe`
— no node9 involvement, none of our quoting — fails identically with
`ERROR: Access is denied.`, because `/Create` writes to the ROOT task folder and
that requires elevation. So it was the mechanism, not the arguments.

Asking a developer to open an elevated shell before their logs will flow is not
an onboarding step worth shipping.

## The replacement

The per-user **Startup folder** needs no privileges at all, and it is the true
analogue of a launchd USER agent or a `systemd --user` unit: per-user, at
interactive logon. The trade is no restart-on-failure, which is acceptable —
the agent hooks already respawn a dead daemon on the next tool call.

The public API in `daemon/service.ts` is untouched. This swaps one backend for
another behind it, so doctor, init, the login self-heal and `daemon-cmd` are
unchanged. No schtasks code remains.

## Two more defects the same QA output exposed

- **`unknown error` was our own bug.** The message only read stderr/stdout, but
  a command that never RAN reports itself in `.error` / `.status: null` and
  leaves both empty. `describeSpawnFailure` now names the missing binary, the
  signal, or the exit code, and cannot say "unknown".
- **The launcher's em dash rendered as mojibake** on the machine — Windows
  Script Host reads a `.vbs` as ANSI without a BOM. It sat in a comment this
  time; in a path it would have broken the launch outright. ASCII-only now,
  with a test that enforces it.

## And one the new tests caught before it shipped

`windowsStartupDir` used `??`, so an empty `APPDATA` would have passed the guard
and produced a **relative** path — the Startup entry would land somewhere random
and autostart would silently never happen. That is this repo's documented `||`
rule; fixed here and at the identical `claudeDesktopConfigPath` site.

## Verification

4,023 tests pass; typecheck, lint, format clean. The parts that can be wrong —
VBS quote-doubling, ASCII-only content, APPDATA resolution, spawn-failure
reporting — are pure functions tested on every platform.

Founder QA after release: `node9 daemon install` should print
`✓ Daemon installed as login service (startup-folder)` with no error. If it
does, the mechanism is right and a reboot then confirms it end to end.