### PR TITLE
Report machineId in the config mirror — the healing channel for duplicate keys

### DIFF
--- a/src/__tests__/policy-snapshot-identity.unit.test.ts
+++ b/src/__tests__/policy-snapshot-identity.unit.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { buildPolicySnapshot } from '../policy-snapshot/build';
+import { DEFAULT_CONFIG } from '../config';
+
+// Machine identity in the config mirror (login-v2 duplicate-key healing).
+// The SaaS binds the reported machineId to a legacy key whose column is NULL —
+// so the field must ride every snapshot, and its ABSENCE must leave the body
+// byte-compatible with what pre-2.4 servers expect.
+describe('buildPolicySnapshot — machine identity', () => {
+  it('carries machineId + platform when the caller passes them', () => {
+    const body = buildPolicySnapshot(DEFAULT_CONFIG, [], {}, {}, [], undefined, {
+      machineId: '55dd7d61-0c92-44e3-a572-926295c83ca5',
+      platform: 'win32',
+    });
+    expect(body.machineId).toBe('55dd7d61-0c92-44e3-a572-926295c83ca5');
+    expect(body.platform).toBe('win32');
+  });
+
+  it('omits BOTH keys entirely when no identity is passed (old call sites)', () => {
+    const body = buildPolicySnapshot(DEFAULT_CONFIG, [], {});
+    expect('machineId' in body).toBe(false);
+    expect('platform' in body).toBe(false);
+  });
+});

--- a/src/daemon/sync.ts
+++ b/src/daemon/sync.ts
@@ -29,6 +29,7 @@ import {
 import { tickScanWatcher, markUploadComplete, tickForensicBroadcast } from './scan-watermark.js';
 import { broadcastForensic } from './state.js';
 import { appendToLog, HOOK_DEBUG_LOG } from '../audit/index.js';
+import { getMachineId } from '../machine-id.js';
 
 // One row per session delta sent on /scan/report. The BE stores
 // these in ScanSessionSignals using INSERT-ON-CONFLICT INCREMENT, so
@@ -918,7 +919,10 @@ async function pushPolicySnapshot(creds: { apiKey: string; apiUrl: string }): Pr
       resolveMcpStatus(),
       // fleet-ship Step 2: ship this machine's sync health so the dashboard can
       // show "sync failing" badges. readSyncHealth is local (same module, no circular).
-      readSyncHealth()
+      readSyncHealth(),
+      // Machine identity — heals legacy machineId-less keys on the SaaS side
+      // (login-v2 duplicate-key fix). getMachineId mints on first need.
+      { machineId: getMachineId(), platform: process.platform }
     );
     await shipPolicySnapshot(body, creds);
   } catch {
@@ -945,7 +949,8 @@ export async function runPolicyPush(): Promise<{ ok: true } | { ok: false; reaso
       // resolve ${VAR} placeholders — so this push reflects THIS process's env
       // (daemon here, user shell in runPolicyPush); see the P2 design's two-env note.
       resolveMcpStatus(),
-      readSyncHealth()
+      readSyncHealth(),
+      { machineId: getMachineId(), platform: process.platform }
     );
     const sent = await shipPolicySnapshot(body, creds);
     return sent ? { ok: true } : { ok: false, reason: 'Push failed (network or server error)' };

--- a/src/policy-snapshot/build.ts
+++ b/src/policy-snapshot/build.ts
@@ -61,6 +61,13 @@ export interface PolicySnapshotBody {
     lastError?: string;
     consecutiveFailures: number;
   };
+  // Machine identity (login-v2, duplicate-key healing). Keys minted before the
+  // machineId era have machineId NULL in the cloud, so a re-login MINTS a new
+  // key instead of rotating — a ghost machine per legacy key. Shipping the
+  // durable local id here lets the SaaS bind it to the reporting key, healing
+  // every legacy machine on its next snapshot with no migration guesswork.
+  machineId?: string;
+  platform?: string;
 }
 
 export function buildPolicySnapshot(
@@ -75,7 +82,10 @@ export function buildPolicySnapshot(
   // fleet-ship Step 2: the proxy's own sync health. Passed in by the caller
   // (readSyncHealth() in sync.ts) — build.ts imports nothing runtime from sync
   // (sync imports build → circular if reversed). undefined = old call site / omit.
-  syncHealth?: SyncHealth
+  syncHealth?: SyncHealth,
+  // Machine identity, passed by the caller (getMachineId() does disk I/O and
+  // build.ts stays pure). undefined = omit, the SaaS then changes nothing.
+  identity?: { machineId: string; platform: string }
 ): PolicySnapshotBody {
   const p = config.policy;
 
@@ -169,5 +179,7 @@ export function buildPolicySnapshot(
         consecutiveFailures: syncHealth.consecutiveFailures,
       },
     }),
+    // Machine identity — heals legacy machineId-less keys on the SaaS side.
+    ...(identity && { machineId: identity.machineId, platform: identity.platform }),
   };
 }


### PR DESCRIPTION
The reporting half of the duplicate-machines fix. Pairs with
node9Firewall#246, which does the binding; order does not matter, since each
side tolerates the other being older.

## Why

Keys minted before the `machineId` era carry NULL in the cloud, so a re-login
mints a new key instead of rotating one — a ghost machine per legacy key, and
the old key stays valid. The founder's own laptop demonstrated it.

Rather than a migration that guesses which key belongs to which machine, the
machine tells the truth about itself: `machineId` and `platform` now ride the
policy snapshot the proxy already ships every sync tick. The SaaS binds the id
to the reporting key the first time it sees one, so every legacy machine heals
on its next tick with no user action.

## Shape

`build.ts` stays a pure builder — identity is passed in by the two callers in
`sync.ts`, because `getMachineId()` does disk I/O. When no identity is passed,
both keys are **omitted entirely**, so the body stays byte-compatible with
pre-2.4 servers and with any older call site.

## Deliberately not in scope

`costSync` and `scan-upload-history` still send their own `hostname:username`
machineId. That value is part of a composite unique key on `CostEntry`, so
switching it forks attribution history — unifying the three needs its own
migration design, and quietly "finishing the job" here would have split a
customer's cost data.

## Verification

4,025 tests pass; typecheck, lint, format clean. New coverage asserts both that
the identity rides the body when passed and that both keys are absent when it
is not.

The end-to-end proof lives on the server side (node9Firewall#246): a real
snapshot POST from this shape binds a NULL-machineId key, and a second POST
with a different id does not move it.