### PR TITLE
node9 logout — the machine end of Disconnect

### DIFF
--- a/src/__tests__/logout.integration.test.ts
+++ b/src/__tests__/logout.integration.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { spawn } from 'child_process';
+import * as http from 'http';
+import type { AddressInfo } from 'net';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const CLI = path.resolve(__dirname, '../../dist/cli.js');
+
+// `node9 logout` (login-v2 §5, phase C.2): revoke in the cloud, remove
+// locally, keep local enforcement. Real spawn path against a mock of
+// POST /machines/self/disconnect.
+describe('node9 logout (integration)', () => {
+  let server: http.Server;
+  let port: number;
+  let mode: 'ok' | '401' = 'ok';
+  let sawAuth: string | null = null;
+  let tmpHome: string;
+
+  beforeAll(
+    () =>
+      new Promise<void>((resolve) => {
+        server = http.createServer((req, res) => {
+          if (req.method === 'POST' && req.url === '/api/v1/intercept/machines/self/disconnect') {
+            sawAuth = req.headers.authorization ?? null;
+            if (mode === '401') {
+              res.writeHead(401);
+              res.end('{}');
+              return;
+            }
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ ok: true, name: 'MyDell' }));
+          } else {
+            res.writeHead(404);
+            res.end();
+          }
+        });
+        server.listen(0, '127.0.0.1', () => {
+          port = (server.address() as AddressInfo).port;
+          resolve();
+        });
+      })
+  );
+  afterAll(() => new Promise<void>((resolve) => server.close(() => resolve())));
+
+  beforeEach(() => {
+    sawAuth = null;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-logout-'));
+  });
+  afterEach(() => fs.rmSync(tmpHome, { recursive: true, force: true }));
+
+  const credPath = () => path.join(tmpHome, '.node9', 'credentials.json');
+  function writeCreds(profiles: Record<string, unknown>) {
+    fs.mkdirSync(path.dirname(credPath()), { recursive: true });
+    fs.writeFileSync(credPath(), JSON.stringify(profiles));
+  }
+  const apiUrl = () => `http://127.0.0.1:${port}/api/v1/intercept`;
+
+  function run(env: Record<string, string> = {}) {
+    return new Promise<{ status: number | null; out: string }>((resolve) => {
+      const child = spawn(process.execPath, [CLI, 'logout'], {
+        env: {
+          ...process.env,
+          NODE9_TESTING: '1',
+          NODE9_NO_AUTO_DAEMON: '1',
+          HOME: tmpHome,
+          USERPROFILE: tmpHome,
+          ...env,
+        },
+      });
+      let out = '';
+      child.stdout.on('data', (d) => (out += d));
+      child.stderr.on('data', (d) => (out += d));
+      child.on('close', (status) => resolve({ status, out }));
+    });
+  }
+
+  it('revokes in the cloud WITH the key, then removes it locally', async () => {
+    mode = 'ok';
+    writeCreds({ default: { apiKey: 'n9_live_bye', apiUrl: apiUrl() } });
+    const r = await run();
+    expect(r.status).toBe(0);
+    expect(sawAuth).toBe('Bearer n9_live_bye');
+    expect(r.out).toMatch(/key revoked \(MyDell\)/);
+    expect(r.out).toMatch(/credentials removed/);
+    // Local enforcement message — logout must never read as "unprotected".
+    expect(r.out).toMatch(/Local enforcement keeps running/);
+    expect(fs.existsSync(credPath())).toBe(false);
+  });
+
+  it('a key already revoked from the dashboard reads as "already disconnected"', async () => {
+    mode = '401';
+    writeCreds({ default: { apiKey: 'n9_live_bye', apiUrl: apiUrl() } });
+    const r = await run();
+    expect(r.status).toBe(0);
+    expect(r.out).toMatch(/already disconnected/);
+    expect(fs.existsSync(credPath())).toBe(false);
+  });
+
+  it('an unreachable cloud still logs out locally — and says the dashboard row remains', async () => {
+    writeCreds({
+      default: { apiKey: 'n9_live_bye', apiUrl: 'http://127.0.0.1:9/api/v1/intercept' },
+    });
+    const r = await run();
+    expect(r.status).toBe(0);
+    expect(r.out).toMatch(/Could not reach the cloud/);
+    expect(r.out).toMatch(/still listed in the dashboard/);
+    expect(fs.existsSync(credPath())).toBe(false);
+  });
+
+  it('removes ONLY the active profile; other profiles survive', async () => {
+    mode = 'ok';
+    writeCreds({
+      default: { apiKey: 'n9_live_keepme', apiUrl: apiUrl() },
+      dev: { apiKey: 'n9_live_bye', apiUrl: apiUrl() },
+    });
+    const r = await run({ NODE9_PROFILE: 'dev' });
+    expect(r.status).toBe(0);
+    expect(sawAuth).toBe('Bearer n9_live_bye');
+    const left = JSON.parse(fs.readFileSync(credPath(), 'utf-8'));
+    expect(left.default.apiKey).toBe('n9_live_keepme');
+    expect(left.dev).toBeUndefined();
+  });
+
+  it('not logged in → says so, exits 0, touches nothing', async () => {
+    const r = await run();
+    expect(r.status).toBe(0);
+    expect(r.out).toMatch(/Not logged in/);
+    expect(sawAuth).toBeNull();
+  });
+});

--- a/src/auth/device-login.ts
+++ b/src/auth/device-login.ts
@@ -1,11 +1,9 @@
-import * as http from 'http';
-import * as https from 'https';
 import * as os from 'os';
-import { URL } from 'url';
 import chalk from 'chalk';
 import { resolveCloudEndpoint } from './cloud-endpoints';
 import { getMachineId } from '../machine-id';
 import { openBrowser } from '../utils/open-browser';
+import { postJson } from '../utils/post-json';
 
 // The CLI half of device-auth login (login-v2 B1). Start an authorization,
 // hand the human a URL + short code, then poll until the browser approves —
@@ -32,52 +30,6 @@ interface PollResponse {
 export type DeviceLoginResult =
   | { ok: true; apiKey: string; workspaceName: string; machineName: string }
   | { ok: false; reason: string };
-
-// Plain JSON POST; http for tests, https in production (same pattern as
-// connect's postConnect — the URL's protocol picks the lib).
-function postJson<T>(url: string, body: unknown): Promise<T> {
-  return new Promise((resolve, reject) => {
-    const payload = JSON.stringify(body);
-    const u = new URL(url);
-    const lib = u.protocol === 'http:' ? http : https;
-    const req = lib.request(
-      {
-        method: 'POST',
-        hostname: u.hostname,
-        port: u.port || (u.protocol === 'http:' ? 80 : 443),
-        path: u.pathname + u.search,
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': Buffer.byteLength(payload),
-        },
-        timeout: 15000,
-      },
-      (res) => {
-        let data = '';
-        res.on('data', (c) => (data += c));
-        res.on('end', () => {
-          const code = res.statusCode ?? 0;
-          if (code >= 200 && code < 300) {
-            try {
-              resolve(JSON.parse(data) as T);
-            } catch {
-              reject(new Error('Unexpected response from the server.'));
-            }
-          } else {
-            reject(new Error(`Server returned HTTP ${code}.`));
-          }
-        });
-      }
-    );
-    req.on('error', (e) => reject(e));
-    req.on('timeout', () => {
-      req.destroy();
-      reject(new Error('Connection timed out.'));
-    });
-    req.write(payload);
-    req.end();
-  });
-}
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,7 @@ import { runProxy } from './proxy';
 import { autoStartDaemonAndWait } from './cli/daemon-starter';
 import { onboardMachine, renderOnboardOutcome } from './onboarding';
 import { runDeviceLogin } from './auth/device-login';
+import { registerLogoutCommand, revokeSelf } from './cli/commands/logout';
 import { openBrowser } from './utils/open-browser';
 import { registerCheckCommand } from './cli/commands/check';
 import { registerLogCommand } from './cli/commands/log';
@@ -314,6 +315,41 @@ program
   .action(async (options: { purge?: boolean }) => {
     console.log(chalk.cyan('\n🛡️  Node9 Uninstall\n'));
 
+    // 0. Cloud disconnect — FIRST, while the key still exists locally
+    //    (--purge deletes credentials below; a machine that uninstalls without
+    //    this stays listed in the dashboard forever). Best-effort: an offline
+    //    uninstall proceeds, but says what remains.
+    try {
+      const credRaw = fs.readFileSync(
+        path.join(os.homedir(), '.node9', 'credentials.json'),
+        'utf-8'
+      );
+      const prof = (JSON.parse(credRaw) as Record<string, { apiKey?: string; apiUrl?: string }>)[
+        process.env.NODE9_PROFILE || 'default'
+      ];
+      if (prof?.apiKey) {
+        console.log(chalk.bold('Disconnecting from the cloud...'));
+        const r = await revokeSelf({
+          apiKey: prof.apiKey,
+          apiUrl: prof.apiUrl || 'https://api.node9.ai/api/v1/intercept',
+        });
+        if (r.outcome === 'revoked') {
+          console.log(chalk.green('  ✅ Machine disconnected — its key is revoked'));
+        } else if (r.outcome === 'already') {
+          console.log(chalk.blue('  ℹ️  Machine was already disconnected'));
+        } else {
+          console.log(
+            chalk.yellow(
+              '  ⚠️  Could not reach the cloud — the machine is still listed in the dashboard.'
+            )
+          );
+          console.log(chalk.gray('     Disconnect it there: Enforcement › Devices › Disconnect.'));
+        }
+      }
+    } catch {
+      /* no credentials — nothing to disconnect */
+    }
+
     // 1. Stop the daemon
     console.log(chalk.bold('Stopping daemon...'));
     try {
@@ -528,6 +564,7 @@ program
 registerInitCommand(program);
 registerHealCommand(program);
 registerConnectCommand(program);
+registerLogoutCommand(program);
 
 // 4. AUDIT
 registerAuditCommand(program);

--- a/src/cli/commands/logout.ts
+++ b/src/cli/commands/logout.ts
@@ -1,0 +1,103 @@
+import type { Command } from 'commander';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import chalk from 'chalk';
+import { postJson } from '../../utils/post-json';
+
+// node9 logout (login-v2 §5, phase C.2) — the machine end of Disconnect.
+// Revokes this machine's key in the cloud (best-effort) and removes it
+// locally. Deliberately does NOT touch config.json and does NOT stop the
+// daemon: local enforcement is not tied to the cloud connection, and logging
+// out must never mean "unprotected".
+
+/**
+ * Revoke the given key against its own cloud. Exported so `node9 uninstall`
+ * runs the same step before tearing down. Never throws.
+ *  - revoked: the cloud confirmed (returns the machine name when it says)
+ *  - already: 401 — the key was revoked before (dashboard Disconnect, an
+ *    admin removing the member, or a prior logout)
+ *  - unreachable: network/server trouble; the caller decides what that means
+ */
+export async function revokeSelf(creds: {
+  apiKey: string;
+  apiUrl: string;
+}): Promise<
+  | { outcome: 'revoked'; name?: string }
+  | { outcome: 'already' }
+  | { outcome: 'unreachable'; detail: string }
+> {
+  // credentials.json stores the intercept BASE (…/api/v1/intercept); the
+  // self-disconnect endpoint is its child.
+  const url = creds.apiUrl.replace(/\/$/, '') + '/machines/self/disconnect';
+  try {
+    const r = await postJson<{ ok: boolean; name?: string }>(url, {}, creds.apiKey);
+    return { outcome: 'revoked', name: r.name };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/HTTP 401/.test(msg)) return { outcome: 'already' };
+    return { outcome: 'unreachable', detail: msg };
+  }
+}
+
+export function registerLogoutCommand(program: Command): void {
+  program
+    .command('logout')
+    .description(
+      'Disconnect this machine from the cloud (revokes its key; local enforcement keeps running)'
+    )
+    .action(async () => {
+      const profile = process.env.NODE9_PROFILE || 'default';
+      const credPath = path.join(os.homedir(), '.node9', 'credentials.json');
+
+      let all: Record<string, { apiKey?: string; apiUrl?: string }> = {};
+      try {
+        all = JSON.parse(fs.readFileSync(credPath, 'utf-8'));
+      } catch {
+        /* missing or unreadable → not logged in */
+      }
+      const entry = all[profile];
+      if (!entry?.apiKey) {
+        console.log(chalk.gray('Not logged in — nothing to disconnect.'));
+        return;
+      }
+
+      // 1. Cloud first, while we still hold the key. Best-effort: an offline
+      //    logout still logs out locally, but says so honestly.
+      const res = await revokeSelf({
+        apiKey: entry.apiKey,
+        apiUrl: entry.apiUrl || 'https://api.node9.ai/api/v1/intercept',
+      });
+      if (res.outcome === 'revoked') {
+        console.log(
+          chalk.green(
+            `✓ Cloud: key revoked${res.name ? ` (${res.name})` : ''} — this machine left the workspace.`
+          )
+        );
+      } else if (res.outcome === 'already') {
+        console.log(chalk.gray('✓ Cloud: this machine was already disconnected.'));
+      } else {
+        console.log(chalk.yellow(`⚠ Could not reach the cloud (${res.detail}).`));
+        console.log(
+          chalk.yellow('  The key was removed locally, but is still listed in the dashboard —')
+        );
+        console.log(chalk.yellow('  disconnect it there: Enforcement › Devices › Disconnect.'));
+      }
+
+      // 2. Local removal — the profile only; other profiles stay.
+      delete all[profile];
+      if (Object.keys(all).length === 0) {
+        try {
+          fs.unlinkSync(credPath);
+        } catch {
+          /* already gone */
+        }
+      } else {
+        fs.writeFileSync(credPath, JSON.stringify(all, null, 2), { mode: 0o600 });
+      }
+      console.log(chalk.green('✓ Local: credentials removed.'));
+      console.log(
+        chalk.gray('  Local enforcement keeps running. Reconnect any time with: node9 login')
+      );
+    });
+}

--- a/src/utils/post-json.ts
+++ b/src/utils/post-json.ts
@@ -1,0 +1,50 @@
+import * as http from 'http';
+import * as https from 'https';
+import { URL } from 'url';
+
+// Plain JSON POST; http for tests, https in production (same pattern as
+// connect's postConnect — the URL's protocol picks the lib).
+export function postJson<T>(url: string, body: unknown, bearer?: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(body);
+    const u = new URL(url);
+    const lib = u.protocol === 'http:' ? http : https;
+    const req = lib.request(
+      {
+        method: 'POST',
+        hostname: u.hostname,
+        port: u.port || (u.protocol === 'http:' ? 80 : 443),
+        path: u.pathname + u.search,
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(payload),
+          ...(bearer && { Authorization: `Bearer ${bearer}` }),
+        },
+        timeout: 15000,
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (c) => (data += c));
+        res.on('end', () => {
+          const code = res.statusCode ?? 0;
+          if (code >= 200 && code < 300) {
+            try {
+              resolve(JSON.parse(data) as T);
+            } catch {
+              reject(new Error('Unexpected response from the server.'));
+            }
+          } else {
+            reject(new Error(`Server returned HTTP ${code}.`));
+          }
+        });
+      }
+    );
+    req.on('error', (e) => reject(e));
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('Connection timed out.'));
+    });
+    req.write(payload);
+    req.end();
+  });
+}


### PR DESCRIPTION
Phase C.2 of login-v2. Pairs with node9Firewall#247, which adds the endpoint.

Until now a connected machine had no exit: leaving meant hand-deleting files,
and the key stayed valid in the cloud forever.

## `node9 logout`

1. **Revokes this machine's key** against its own cloud, authenticated by the
   key itself — a machine has no browser session, and a stolen key revoking
   itself is the safe direction.
2. **Removes only the active profile** from `credentials.json`; other profiles
   survive.
3. **Keeps `config.json` and the daemon.** Local enforcement is not tied to the
   cloud connection, and logging out must never mean unprotected — the output
   says so.

An offline logout still logs out locally and states exactly what remains: the
dashboard row, and where to disconnect it.

## `node9 uninstall` closes the same hole

It now runs the same revoke **first**, while the key still exists locally
(`--purge` deletes credentials moments later). A machine that uninstalled used
to stay listed in the dashboard forever.

## Shape

`postJson` moved to `utils/post-json.ts` with bearer support, and `device-login`
imports it back, rather than growing a third copy of the JSON-POST helper.

## Verification

4,030 tests pass; typecheck, lint, format clean.

Verified with the **real binary against the live dev stack**: a throwaway key
was revoked by `node9 logout` — exit 0, cloud confirmed it by machine name,
local file gone, DB row tombstoned — and a second logout on the dead key
printed "already disconnected". Plus five spawn-path integration cases covering
the 401 path, unreachable-cloud honesty, and profile isolation.