### PR TITLE
doctor: a stalled queue is not 'in progress', and 401 means disconnected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **A machine connected to a workspace now follows the workspace configuration for policy — one configuration, one place to change it.** Previously a connected machine merged its local files with the workspace's and kept whichever was stricter. Now, if the machine is logged in with a workspace key, its policy is the workspace configuration plus node9's shipped defaults; the local files stop deciding policy. `node9 status`, `doctor`, `explain`, `shield list/status`, `egress`, `jail list` and the node9 MCP tools all name the source and mark local files "present — ignored", and local policy commands (`shield enable/disable/set`, `egress watch/lock/allow/deny/off`, `jail add/remove`, `trust add/remove`) refuse with a non-zero exit and point at the dashboard instead of writing a file nobody reads.
+
+  **Read this before upgrading a connected machine.** Anything your local files add that the workspace does not say is dropped, and some of it is invisible because there is no dashboard field for it yet. What goes away on a connected machine:
+  - **shields you enabled locally** (`~/.node9/shields.json`) — only workspace-mandated shields run, _including the credential jails_ (`project-jail`, `user-jail`)
+  - **jail paths** added with `node9 jail add`, and **trusted hosts** added with `node9 trust add`
+  - **local egress settings** — if the workspace has no egress policy, egress control is off
+  - **rules and word lists in your local config**: `smartRules`, `dangerousWords`, `ignoredTools`, `sandboxPaths`, `toolInspection`, `environments` — none of these are expressible in the workspace configuration today, so they are dropped with no dashboard equivalent
+  - `NODE9_MODE` no longer overrides the mode on a connected machine
+
+  **Do this first:** open the dashboard → Devices → **"Add this device's setup to the workspace"** on the machine whose setup should govern the fleet, and confirm the workspace carries your shields and egress settings. Then upgrade. Verify with `node9 status` (it names the policy source) and `node9 shield status` (it lists what is actually enforced).
+
+  **Want a machine to keep deciding for itself?** Connect it with `node9 login --local`. It ships audit and telemetry to the dashboard as before, and its policy stays local. Named profiles (`NODE9_PROFILE`) behave the same way. `node9 logout` also returns full local control.
+
 - **Review prompts are inline by default for Claude Code + GitHub Copilot** (see above). Existing users get this on upgrade with no re-setup; add `--no-ask` or set `"reviewChannel":"approver"` to keep node9's own approver. No change for any other agent or for cloud-approver setups.
 
 - **GitHub Copilot CLI integration** (`node9 agents add copilot`). Adds the GitHub Copilot CLI (`copilot`, npm `@github/copilot`) — the terminal agent, distinct from the VS Code Copilot extension which stays under the `vscode` MCP target — to the protected agents at the hooks tier. node9 writes a dedicated `~/.copilot/hooks/node9.json` with PreToolUse/PostToolUse/UserPromptSubmit hooks (`node9 check/log --agent copilot`, `timeoutSec: 600`) and adds/wraps the node9 MCP server in `~/.copilot/mcp-config.json`. All verified live against Copilot CLI 1.0.60:

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "fix": "npm run format && npm run lint:fix",
     "validate": "npm run format && npm run lint && npm run typecheck && npm run test && npm run test:e2e && npm run build",
     "test:e2e": "cross-env NODE9_TESTING=1 bash scripts/e2e.sh",
+    "pretest": "npm run build",
     "test": "cross-env NODE9_TESTING=1 vitest --run",
     "test:coverage": "cross-env NODE9_TESTING=1 vitest --run --coverage",
     "test:watch": "cross-env NODE9_TESTING=1 vitest",

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -106,34 +106,50 @@ check_allowed() {
   fi
 }
 
-echo -e "\n  ${YELLOW}MCP tool names:${RESET}"
-check_blocked "delete_user"         '{"tool_name":"delete_user","tool_input":{"id":1}}'
-check_blocked "drop_table"          '{"tool_name":"drop_table","tool_input":{"table":"users"}}'
-check_blocked "remove_file"         '{"tool_name":"remove_file","tool_input":{"path":"/tmp/x"}}'
-check_blocked "aws.rds.rm_database" '{"tool_name":"aws.rds.rm_database","tool_input":{}}'
-check_blocked "purge_queue"         '{"tool_name":"purge_queue","tool_input":{}}'
-check_blocked "destroy_cluster"     '{"tool_name":"destroy_cluster","tool_input":{}}'
+# Review-tier verdicts surface as an inline ASK since inline-ask v2
+# (permissionDecision:"ask") — the agent UI shows the approval prompt. The old
+# expectation here (decision:"block") predates that release; only Layer-1
+# block rules (e.g. rm -rf /) still hard-deny.
+check_review() {
+  local label="$1"
+  local payload="$2"
+  local out
+  out=$(echo "$payload" | $NODE9 check 2>/dev/null) || true
+  if echo "$out" | grep -q '"permissionDecision":"ask"'; then
+    pass "REVIEW   → $label"
+  else
+    fail "Expected inline ask for: $label  (got: '$out')"
+  fi
+}
 
-echo -e "\n  ${YELLOW}Claude Code Bash tool — dangerous commands:${RESET}"
+echo -e "\n  ${YELLOW}MCP tool names:${RESET}"
+check_review "delete_user"         '{"tool_name":"delete_user","tool_input":{"id":1}}'
+check_review "drop_table"          '{"tool_name":"drop_table","tool_input":{"table":"users"}}'
+check_review "remove_file"         '{"tool_name":"remove_file","tool_input":{"path":"/tmp/x"}}'
+check_review "aws.rds.rm_database" '{"tool_name":"aws.rds.rm_database","tool_input":{}}'
+check_review "purge_queue"         '{"tool_name":"purge_queue","tool_input":{}}'
+check_review "destroy_cluster"     '{"tool_name":"destroy_cluster","tool_input":{}}'
+
+echo -e "\n  ${YELLOW}Claude Code Bash tool — dangerous commands (review-tier → inline ask):${RESET}"
 
 # 1. Test 'rm' on a SENSITIVE path (not in allowPaths and not in /tmp)
-check_blocked "Bash: rm /etc/passwd"    '{"tool_name":"Bash","tool_input":{"command":"rm /etc/passwd"}}'
+check_review "Bash: rm /etc/passwd"    '{"tool_name":"Bash","tool_input":{"command":"rm /etc/passwd"}}'
 
 # 2. Test a "Nuke" word (drop) inside the sandbox (Nukes should be blocked everywhere)
-check_blocked "Bash: drop /tmp/db"      '{"tool_name":"Bash","tool_input":{"command":"psql -c \"drop table users\""}}'
+check_review "Bash: drop /tmp/db"      '{"tool_name":"Bash","tool_input":{"command":"psql -c \"drop table users\""}}'
 
 # 3. Existing passing tests
 check_blocked "Bash: rm -rf /"          '{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}'
-check_blocked "Bash: sudo rm -rf /home" '{"tool_name":"Bash","tool_input":{"command":"sudo rm -rf /home/user"}}'
+check_review "Bash: sudo rm -rf /home" '{"tool_name":"Bash","tool_input":{"command":"sudo rm -rf /home/user"}}'
 
 # 4. Test 'docker' (a Nuke word)
-check_blocked "Bash: docker rm -f"      '{"tool_name":"Bash","tool_input":{"command":"docker rm -f container_id"}}'
+check_review "Bash: docker rm -f"      '{"tool_name":"Bash","tool_input":{"command":"docker rm -f container_id"}}'
 
 # 5. Test 'purge' (a Nuke word)
-check_blocked "Bash: purge /opt/data"   '{"tool_name":"Bash","tool_input":{"command":"purge /opt/data"}}'
+check_review "Bash: purge /opt/data"   '{"tool_name":"Bash","tool_input":{"command":"purge /opt/data"}}'
 
 # 6. Test 'find -delete' (the parser finds the "delete" token which is often a rule action)
-check_blocked "Bash: find . -delete"    '{"tool_name":"Bash","tool_input":{"command":"find . -name tmp -delete"}}'
+check_review "Bash: find . -delete"    '{"tool_name":"Bash","tool_input":{"command":"find . -name tmp -delete"}}'
 
 
 echo -e "\n  ${YELLOW}Claude Code Bash tool — safe commands (must NOT be blocked):${RESET}"
@@ -212,19 +228,26 @@ fi
 # =============================================================================
 section "Part 4 · Response format"
 
-RESPONSE=$(echo '{"tool_name":"delete_user","tool_input":{"id":1}}' | $NODE9 check 2>/dev/null) || true
+# The DENY wire shape needs a Layer-1 block rule (delete_user is review-tier
+# and surfaces as an inline ask since inline-ask v2).
+RESPONSE=$(echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}' | $NODE9 check 2>/dev/null) || true
 
 echo "$RESPONSE" | grep -q '"decision":"block"' \
-  && pass 'Response has decision:"block"' \
-  || fail 'Response missing decision field'
+  && pass 'Block response has decision:"block"' \
+  || fail 'Block response missing decision field'
 
 echo "$RESPONSE" | grep -q '"hookSpecificOutput"' \
-  && pass "Response has hookSpecificOutput (Claude Code field)" \
-  || fail "Response missing hookSpecificOutput"
+  && pass "Block response has hookSpecificOutput (Claude Code field)" \
+  || fail "Block response missing hookSpecificOutput"
 
 echo "$RESPONSE" | grep -q '"permissionDecision":"deny"' \
-  && pass 'Response has permissionDecision:"deny" (Claude Code field)' \
-  || fail "Response missing permissionDecision"
+  && pass 'Block response has permissionDecision:"deny" (Claude Code field)' \
+  || fail "Block response missing permissionDecision"
+
+ASK_RESPONSE=$(echo '{"tool_name":"delete_user","tool_input":{"id":1}}' | $NODE9 check 2>/dev/null) || true
+echo "$ASK_RESPONSE" | grep -q '"permissionDecision":"ask"' \
+  && pass 'Review response has permissionDecision:"ask" (inline-ask v2 wire)' \
+  || fail "Review response missing permissionDecision:ask"
 
 # =============================================================================
 # PART 5 — Global config (~/.node9/config.json)
@@ -252,10 +275,10 @@ EOF
 NOPROJECT=$(mktemp -d)
 
 out=$(cd "$NOPROJECT" && echo '{"tool_name":"nuke_everything","tool_input":{}}' | HOME="$GLOBAL_HOME" $NODE9 check 2>/dev/null) || true
-if echo "$out" | grep -q '"decision":"block"'; then
-  pass "Global config: custom dangerous word 'nuke' is blocked"
+if echo "$out" | grep -q '"permissionDecision":"ask"'; then
+  pass "Global config: custom dangerous word 'nuke' flags for review (inline ask)"
 else
-  fail "Global config not applied: 'nuke_everything' not blocked (got: '$out')"
+  fail "Global config not applied: 'nuke_everything' not flagged (got: '$out')"
 fi
 
 out=$(cd "$NOPROJECT" && echo '{"tool_name":"list_users","tool_input":{}}' | HOME="$GLOBAL_HOME" $NODE9 check 2>/dev/null) || true
@@ -286,6 +309,122 @@ else
 fi
 
 rm -rf "$GLOBAL_HOME" "$NOPROJECT"
+
+# =============================================================================
+# PART 6 — Keyed machine (PR-2 replace-mode): the workspace config governs
+# Fixture = credentials.json with an UNROUTABLE apiUrl (no network) + a
+# rules-cache.json standing in for the synced workspace config. The local
+# config.json carries a 'nuke' dangerous word that MUST be inert while keyed
+# and MUST come back under login --local (localOnly).
+# =============================================================================
+section "Part 6 · Keyed machine — workspace config governs (PR-2)"
+
+KEYED_HOME=$(mktemp -d)
+KEYED_DIR=$(mktemp -d)   # run dir with NO project config
+mkdir -p "$KEYED_HOME/.node9"
+
+cat > "$KEYED_HOME/.node9/credentials.json" << 'EOF'
+{ "default": { "apiKey": "n9_live_e2e_keyed_fixture", "apiUrl": "http://127.0.0.1:1" } }
+EOF
+
+# The synced workspace policy: one org block rule; managed settings keep the
+# run deterministic (all approver channels off + 50ms timeout → no waits).
+cat > "$KEYED_HOME/.node9/rules-cache.json" << 'EOF'
+{
+  "fetchedAt": "2026-08-01T00:00:00Z",
+  "rules": [
+    {
+      "name": "org-block-frobnicate",
+      "tool": "bash",
+      "conditions": [{ "field": "command", "op": "contains", "value": "frobnicate" }],
+      "conditionMode": "all",
+      "verdict": "block",
+      "reason": "org rule (e2e keyed fixture)"
+    }
+  ],
+  "shields": [],
+  "managedConfig": {
+    "mode": "standard",
+    "approvalTimeoutMs": 50,
+    "approvers": { "native": false, "browser": false, "cloud": false, "terminal": false },
+    "locked": []
+  }
+}
+EOF
+
+cat > "$KEYED_HOME/.node9/config.json" << 'EOF'
+{
+  "settings": { "mode": "standard" },
+  "policy": { "dangerousWords": ["nuke"] }
+}
+EOF
+
+# 6.1 — the workspace rule is enforced (the K13c bug, live at the real gate)
+out=$(cd "$KEYED_DIR" && echo '{"tool_name":"Bash","tool_input":{"command":"frobnicate --all"}}' | HOME="$KEYED_HOME" $NODE9 check 2>/dev/null) || true
+if echo "$out" | grep -q '"decision":"block"'; then
+  pass "Keyed: workspace (cloud cache) rule blocks at the gate"
+else
+  fail "Keyed: workspace rule NOT enforced (got: '$out')"
+fi
+
+# 6.2 — the local dangerousWords list is INERT while keyed
+out=$(cd "$KEYED_DIR" && echo '{"tool_name":"nuke_everything","tool_input":{}}' | HOME="$KEYED_HOME" $NODE9 check 2>/dev/null) || true
+if [ -z "$out" ]; then
+  pass "Keyed: local config.json dangerousWords are inert"
+else
+  fail "Keyed: local dangerousWords still enforced (got: '$out')"
+fi
+
+# 6.3 — local policy writes are refused with a non-zero exit and touch nothing
+guard_refused() {
+  local label="$1"; shift
+  local ec=0
+  local out
+  out=$(cd "$KEYED_DIR" && HOME="$KEYED_HOME" $NODE9 "$@" 2>&1) || ec=$?
+  if [ "$ec" -ne 0 ] && echo "$out" | grep -qi "workspace configuration"; then
+    pass "Keyed write-guard: '$label' refused (exit $ec, points at the dashboard)"
+  else
+    fail "Keyed write-guard: '$label' NOT refused (exit $ec, out: '$out')"
+  fi
+}
+guard_refused "shield enable postgres" shield enable postgres
+guard_refused "egress off"             egress off
+guard_refused "trust add"              trust add api.example.com
+guard_refused "jail add"               jail add /tmp/e2e-jail-probe
+
+if [ ! -f "$KEYED_HOME/.node9/shields.json" ] && [ ! -f "$KEYED_HOME/.node9/trusted-hosts.json" ]; then
+  pass "Keyed write-guard: refused writes left no store files behind"
+else
+  fail "Keyed write-guard: a refused write still created a store file"
+fi
+
+# 6.4 — introspection tells the truth
+out=$(cd "$KEYED_DIR" && HOME="$KEYED_HOME" $NODE9 status 2>/dev/null) || true
+if echo "$out" | grep -q "Workspace config"; then
+  pass "Keyed: 'node9 status' names the workspace as the policy source"
+else
+  fail "Keyed: 'node9 status' does not name the workspace source"
+fi
+
+# 6.5 — the localOnly promise (login --local): same key, local policy governs again
+cat > "$KEYED_HOME/.node9/credentials.json" << 'EOF'
+{ "default": { "apiKey": "n9_live_e2e_keyed_fixture", "apiUrl": "http://127.0.0.1:1", "localOnly": true } }
+EOF
+out=$(cd "$KEYED_DIR" && echo '{"tool_name":"nuke_everything","tool_input":{}}' | HOME="$KEYED_HOME" $NODE9 check 2>/dev/null) || true
+if echo "$out" | grep -q '"permissionDecision":"ask"'; then
+  pass "localOnly: local dangerousWords govern again (the --local promise)"
+else
+  fail "localOnly: local config still inert (got: '$out')"
+fi
+ec=0
+out=$(cd "$KEYED_DIR" && HOME="$KEYED_HOME" $NODE9 trust add api.example.com 2>&1) || ec=$?
+if [ "$ec" -eq 0 ] && [ -f "$KEYED_HOME/.node9/trusted-hosts.json" ]; then
+  pass "localOnly: local policy writes proceed (trust add wrote the store)"
+else
+  fail "localOnly: trust add refused or wrote nothing (exit $ec, out: '$out')"
+fi
+
+rm -rf "$KEYED_HOME" "$KEYED_DIR"
 
 # =============================================================================
 # SUMMARY

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -69,6 +69,10 @@ export NODE9_NO_AUTO_DAEMON=1
 node "$REPO_ROOT/dist/cli.js" daemon stop 2>/dev/null || true
 # Use an isolated HOME so credentials.json and decisions.json don't affect results
 export HOME="$TEST_HOME"
+# Keyedness hygiene (PR-2 §0.12): never inherit the developer machine's real
+# key — a keyed run would build policy from the CLOUD and test a different
+# config source depending on whose machine runs this script.
+unset NODE9_API_KEY NODE9_API_URL NODE9_PROFILE
 
 # =============================================================================
 # PART 1 — node9 check  (simulates Claude Code's PreToolUse hook)

--- a/src/__tests__/app-permissions.spec.ts
+++ b/src/__tests__/app-permissions.spec.ts
@@ -184,6 +184,28 @@ describe('managed appPermissions apply + enforce (P3 Phase 2)', () => {
     _resetCore();
   };
 
+  // PR-2 replace-mode (§F disposition): the cloud-approver tests set
+  // NODE9_API_KEY, which makes the process KEYED — local config.json policy
+  // (approvers, approvalTimeoutMs) is inert. Those knobs must ride in the
+  // CLOUD cache's managedConfig instead (what a real keyed machine gets from
+  // sync). The appPermissions block from beforeEach is preserved; the timeout
+  // is a short POSITIVE value (a managed 0 is rejected by design, index.ts).
+  const writeManagedSettings = (managed: Record<string, unknown> = {}) => {
+    const cachePath = path.join(tmpHome, '.node9', 'rules-cache.json');
+    const cache = JSON.parse(fs.readFileSync(cachePath, 'utf-8')) as {
+      managedConfig: Record<string, unknown>;
+    };
+    cache.managedConfig = {
+      ...cache.managedConfig,
+      approvalTimeoutMs: 50,
+      approvers: { native: false, browser: false, cloud: true, terminal: false },
+      ...managed,
+    };
+    fs.writeFileSync(cachePath, JSON.stringify(cache));
+    _resetConfigCache();
+    _resetCore();
+  };
+
   it('review on an IGNORED-pattern tool (read_*) still races — not auto-allowed', async () => {
     // read_email matches the read_* ignoredTools fast path, which would
     // auto-allow before the race — the same failure class as the dead gate.
@@ -201,8 +223,8 @@ describe('managed appPermissions apply + enforce (P3 Phase 2)', () => {
   });
 
   it('human APPROVAL via the cloud approver allows the call through', async () => {
-    writeSettings({ approvers: { native: false, browser: false, cloud: true, terminal: false } });
-    process.env.NODE9_API_KEY = 'test-key';
+    writeManagedSettings();
+    process.env.NODE9_API_KEY = 'test-key'; // env key => KEYED process
     mockInitSaaS.mockResolvedValue({ pending: true, requestId: 'req-1' });
     mockPollSaaS.mockResolvedValue({ approved: true });
     const r = await call('edit_file');
@@ -213,8 +235,8 @@ describe('managed appPermissions apply + enforce (P3 Phase 2)', () => {
   });
 
   it('human DENIAL via the cloud approver blocks the call', async () => {
-    writeSettings({ approvers: { native: false, browser: false, cloud: true, terminal: false } });
-    process.env.NODE9_API_KEY = 'test-key';
+    writeManagedSettings();
+    process.env.NODE9_API_KEY = 'test-key'; // env key => KEYED process
     mockInitSaaS.mockResolvedValue({ pending: true, requestId: 'req-2' });
     mockPollSaaS.mockResolvedValue({ approved: false, reason: 'denied by admin' });
     const r = await call('edit_file');
@@ -223,13 +245,16 @@ describe('managed appPermissions apply + enforce (P3 Phase 2)', () => {
   });
 
   it('a stale BE answering immediate-allow cannot bypass the review', async () => {
-    writeSettings({ approvers: { native: false, browser: false, cloud: true, terminal: false } });
-    process.env.NODE9_API_KEY = 'test-key';
+    writeManagedSettings();
+    process.env.NODE9_API_KEY = 'test-key'; // env key => KEYED process
     // An older BE that ignores forceReview: pending:false + approved:true.
     mockInitSaaS.mockResolvedValue({ pending: false, approved: true });
     const r = await call('edit_file');
-    expect(r.approved).toBe(false); // falls to the race; no channel → denied
-    expect(r.noApprovalMechanism).toBe(true);
+    expect(r.approved).toBe(false); // falls to the race → denied
+    // PR-2: a keyed machine always runs the timeout racer (approvalTimeoutMs
+    // is always > 0 keyed — managed 0 rejected, default 120s), so the deny is
+    // an auto-deny timeout, not the old no-approval-mechanism instant return.
+    expect(r.blockedBy).toBe('timeout');
   });
 
   it('panic mode upgrades review to a hard block (no race)', async () => {
@@ -322,12 +347,13 @@ describe('managed appPermissions apply + enforce (P3 Phase 2)', () => {
   });
 
   it('fix #2: a SaaS shadowMode response does NOT bypass a review (review > shadow)', async () => {
-    writeSettings({ approvers: { native: false, browser: false, cloud: true, terminal: false } });
-    process.env.NODE9_API_KEY = 'test-key';
+    writeManagedSettings();
+    process.env.NODE9_API_KEY = 'test-key'; // env key => KEYED process
     mockInitSaaS.mockResolvedValue({ pending: false, shadowMode: true });
     const r = await call('edit_file');
-    expect(r.approved).toBe(false); // falls to the race; no channel → denied
-    expect(r.noApprovalMechanism).toBe(true);
+    expect(r.approved).toBe(false); // falls to the race → denied
+    // PR-2: keyed ⇒ the timeout racer always exists (see 'stale BE' above).
+    expect(r.blockedBy).toBe('timeout');
   });
 
   it('fix #4: an approver-less review deny still WRITES an audit row (not invisible)', async () => {
@@ -348,8 +374,8 @@ describe('managed appPermissions apply + enforce (P3 Phase 2)', () => {
   });
 
   it('fix #6: a race-resolved deny row carries app-permission attribution', async () => {
-    writeSettings({ approvers: { native: false, browser: false, cloud: true, terminal: false } });
-    process.env.NODE9_API_KEY = 'test-key';
+    writeManagedSettings();
+    process.env.NODE9_API_KEY = 'test-key'; // env key => KEYED process
     mockInitSaaS.mockResolvedValue({ pending: true, requestId: 'req-9' });
     mockPollSaaS.mockResolvedValue({ approved: false, reason: 'denied by admin' });
     const spy = vi.spyOn(fs, 'appendFileSync');

--- a/src/__tests__/autostart-doctor.integration.test.ts
+++ b/src/__tests__/autostart-doctor.integration.test.ts
@@ -72,9 +72,14 @@ function installUnitFile() {
 }
 
 function cloudEnabled(enabled = true) {
+  // PR-2 §0.1: cloud-disabled = privacy mode = `node9 login --local`, which
+  // persists localOnly so the machine stays unkeyed-for-policy and its local
+  // approvers.cloud:false keeps governing. A bare key would be KEYED, and the
+  // keyed defaults force approvers.cloud=true (matrix §0.3) — the machine this
+  // row describes no longer exists without the flag.
   fs.writeFileSync(
     path.join(home, '.node9', 'credentials.json'),
-    JSON.stringify({ default: { apiKey: 'fake' } }),
+    JSON.stringify({ default: { apiKey: 'fake', ...(enabled ? {} : { localOnly: true }) } }),
     'utf-8'
   );
   fs.writeFileSync(

--- a/src/__tests__/autostart-doctor.integration.test.ts
+++ b/src/__tests__/autostart-doctor.integration.test.ts
@@ -20,6 +20,7 @@ import { spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { keySafeEnv } from './helpers/env';
 
 const CLI = path.resolve(__dirname, '../../dist/cli.js');
 // Linux only, not merely "not Windows": the fixtures below fake systemd
@@ -92,7 +93,7 @@ const seedStartupState = (state: object, msAgo = 60_000) =>
   );
 
 function runDoctor() {
-  const baseEnv = { ...process.env };
+  const baseEnv = keySafeEnv();
   delete baseEnv.NODE9_API_KEY;
   delete baseEnv.NODE9_API_URL;
   const r = spawnSync(process.execPath, [CLI, 'doctor'], {

--- a/src/__tests__/autostart-skip.integration.test.ts
+++ b/src/__tests__/autostart-skip.integration.test.ts
@@ -20,6 +20,7 @@ import { spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { keySafeEnv } from './helpers/env';
 
 const CLI = path.resolve(__dirname, '../../dist/cli.js');
 const PAYLOAD = JSON.stringify({
@@ -43,7 +44,7 @@ afterEach(() => {
 
 /** Run `node9 check` against the isolated HOME. NODE9_TESTING is intentionally absent. */
 function runCheck(env: Record<string, string> = {}) {
-  const baseEnv = { ...process.env };
+  const baseEnv = keySafeEnv();
   delete baseEnv.NODE9_API_KEY;
   delete baseEnv.NODE9_API_URL;
   delete baseEnv.NODE9_TESTING; // would short-circuit the branch under test

--- a/src/__tests__/check-skill-pin.integration.test.ts
+++ b/src/__tests__/check-skill-pin.integration.test.ts
@@ -18,11 +18,12 @@ import { spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { keySafeEnv } from './helpers/env';
 
 const CLI = path.resolve(__dirname, '../../dist/cli.js');
 
 function runCheck(payload: object, env: Record<string, string>, cwd: string) {
-  const baseEnv = { ...process.env };
+  const baseEnv = keySafeEnv();
   delete baseEnv.NODE9_API_KEY;
   delete baseEnv.NODE9_API_URL;
   const r = spawnSync(process.execPath, [CLI, 'check', JSON.stringify(payload)], {

--- a/src/__tests__/check.integration.test.ts
+++ b/src/__tests__/check.integration.test.ts
@@ -916,6 +916,18 @@ describe('audit mode + cloud gating', () => {
   });
 
   it('audit mode + cloud:true → no decision-time POST; row lands in the outbox and SHIPS', async () => {
+    // PR-2 replace-mode: the mock credentials above make this machine KEYED,
+    // so the LOCAL settings.mode:'audit' is inert. The workspace mandates
+    // audit mode through the synced cache instead (matrix K1c — a cloud mode
+    // applies verbatim on a keyed machine).
+    fs.writeFileSync(
+      path.join(tmpHome, '.node9', 'rules-cache.json'),
+      JSON.stringify({
+        fetchedAt: new Date().toISOString(),
+        rules: [],
+        managedConfig: { mode: 'audit', locked: [] },
+      })
+    );
     const r = await runCheckAsync(
       { tool_name: 'bash', tool_input: { command: 'mkfs.ext4 /dev/sda' } },
       // NODE9_TESTING=0: the suite wrapper sets it to 1, which would mark the
@@ -965,6 +977,19 @@ describe('audit mode + cloud gating', () => {
           approvers: { native: false, browser: false, cloud: false, terminal: false },
         },
         policy: { dangerousWords: ['mkfs'] },
+      })
+    );
+    // PR-2 §0.1: "keyed but never POSTs" is privacy mode — `node9 login
+    // --local` persists localOnly, which keeps the machine unkeyed-for-policy
+    // so the local audit mode + approvers.cloud:false above keep governing.
+    // Without it, replace-mode would force the keyed defaults (cloud:true,
+    // mode standard) and this row would test a machine that no longer exists.
+    fs.writeFileSync(
+      path.join(tmpHome, '.node9', 'credentials.json'),
+      JSON.stringify({
+        apiKey: 'test-key-123',
+        apiUrl: `http://127.0.0.1:${serverPort}`,
+        localOnly: true,
       })
     );
 
@@ -1096,6 +1121,26 @@ describe('cloud race engine', () => {
   let mockServer: http.Server;
   let serverPort: number;
 
+  /** PR-2 replace-mode: a keyed machine ignores its local approval knobs, so
+   *  the workspace mandates the cloud-racer routing through the synced cache
+   *  (reviewChannel 'approver', short timeout, cloud-only approvers). */
+  function writeCloudRacerCache(home: string): void {
+    fs.writeFileSync(
+      path.join(home, '.node9', 'rules-cache.json'),
+      JSON.stringify({
+        fetchedAt: new Date().toISOString(),
+        rules: [],
+        managedConfig: {
+          mode: 'standard',
+          reviewChannel: 'approver',
+          approvalTimeoutMs: 3000,
+          approvers: { native: false, browser: false, cloud: true, terminal: false },
+          locked: [],
+        },
+      })
+    );
+  }
+
   function startMockSaas(decision: 'allow' | 'deny'): Promise<void> {
     return new Promise((resolve) => {
       mockServer = http.createServer((req, res) => {
@@ -1150,6 +1195,11 @@ describe('cloud race engine', () => {
       JSON.stringify({ apiKey: 'test-key', apiUrl: `http://127.0.0.1:${serverPort}` })
     );
 
+    // PR-2 replace-mode: the mock credentials make this machine KEYED, so the
+    // LOCAL approval knobs above (reviewChannel/approvalTimeoutMs/approvers)
+    // are inert. This suite exercises the routed CLOUD RACER, so the workspace
+    // pins the same knobs through the synced cache (matrix K5b/K5d/K5e).
+    writeCloudRacerCache(tmpHome);
     const r = await runCheckAsync(
       { tool_name: 'bash', tool_input: { command: 'mkfs.ext4 /dev/sda' } },
       { HOME: tmpHome, NODE9_DEBUG: '1' },
@@ -1183,6 +1233,9 @@ describe('cloud race engine', () => {
       JSON.stringify({ apiKey: 'test-key', apiUrl: `http://127.0.0.1:${serverPort}` })
     );
 
+    // PR-2 replace-mode: same as the approve variant — the workspace, not the
+    // (inert) local config, pins the cloud-racer approval knobs.
+    writeCloudRacerCache(tmpHome);
     const r = await runCheckAsync(
       { tool_name: 'bash', tool_input: { command: 'mkfs.ext4 /dev/sda' } },
       { HOME: tmpHome },

--- a/src/__tests__/daemon-takeover.integration.test.ts
+++ b/src/__tests__/daemon-takeover.integration.test.ts
@@ -18,6 +18,7 @@ import fs from 'fs';
 import net from 'net';
 import os from 'os';
 import path from 'path';
+import { keySafeEnv } from './helpers/env';
 
 const CLI = path.resolve(__dirname, '../../dist/cli.js');
 const PORT = 7391;
@@ -44,13 +45,12 @@ function makeTempHome(): string {
 
 function startDaemon(home: string, buildOverride: string): ChildProcess {
   return spawn(process.execPath, [CLI, 'daemon'], {
-    env: {
-      ...process.env,
+    env: keySafeEnv({
       HOME: home,
       USERPROFILE: home,
       NODE9_TESTING: '1',
       NODE9_BUILD_ID_OVERRIDE: buildOverride,
-    },
+    }),
     stdio: 'ignore',
     detached: false,
   });

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -251,3 +251,134 @@ describe('node9 doctor — verdict honesty', () => {
     expect(output).not.toMatch(/is not recognized as an internal or external command/);
   });
 });
+
+// ── Stalled shipping + rejected key (founder QA 2026-08-29) ──────────────────
+// A running daemon that CANNOT ship printed "Shipping in progress" over 334 KB
+// stuck for 12 hours, while Policy sync showed "API returned 401" — the raw
+// code, leaving the reader to work out it meant "this machine is disconnected".
+describe('node9 doctor — stalled shipping and rejected keys', () => {
+  /** A cloud-enabled HOME with an audit log, a watermark of a given age, and
+   *  an optional sync-health record. `lagBytes` sits past the watermark
+   *  offset, which is exactly how shipLagBytes computes a real lag. */
+  function stalledHome(
+    name: string,
+    opts: {
+      ageMin: number;
+      lagBytes: number;
+      lastError?: string;
+      /** Fake a LIVE daemon: isDaemonRunning() reads this pid file and probes
+       *  the pid with signal 0, so our own (definitely alive) pid satisfies it.
+       *  Without this the suite can only ever observe a DEAD daemon, which is
+       *  how the first version of these tests passed against the old
+       *  daemon-coupled condition. */
+      daemonRunning?: boolean;
+    }
+  ): string {
+    const home = path.join(tmpBase, name);
+    const dir = path.join(home, '.node9');
+    fs.mkdirSync(dir, { recursive: true });
+    writeJson(path.join(dir, 'config.json'), {
+      settings: { approvers: { native: true, terminal: true, cloud: true } },
+    });
+    writeJson(path.join(dir, 'credentials.json'), {
+      default: { apiKey: 'n9_live_probe', apiUrl: 'https://api.node9.ai/api/v1/intercept' },
+    });
+    const auditLog = path.join(dir, 'audit.log');
+    fs.writeFileSync(auditLog, 'x'.repeat(opts.lagBytes));
+    // fileSig must match what the shipper computes, else lag = whole file —
+    // which is still a lag, and is the state we want either way.
+    writeJson(path.join(dir, 'audit-ship.json'), {
+      fileSig: 'stale-signature',
+      offset: 0,
+      updatedAt: new Date(Date.now() - opts.ageMin * 60_000).toISOString(),
+    });
+    if (opts.daemonRunning) {
+      writeJson(path.join(dir, 'daemon.pid'), { pid: process.pid, port: 7391 });
+    }
+    if (opts.lastError) {
+      writeJson(path.join(dir, 'sync-health.json'), {
+        lastCheckedAt: new Date(Date.now() - opts.ageMin * 60_000).toISOString(),
+        consecutiveFailures: 2,
+        lastError: opts.lastError,
+      });
+    }
+    return home;
+  }
+
+  it('a long-stalled queue is a WARNING even though the queue is moving-looking', () => {
+    const { output } = runDoctor(stalledHome('stalled', { ageMin: 765, lagBytes: 40_000 }));
+    expect(output).not.toMatch(/Shipping in progress/);
+    expect(output).toMatch(/NOT shipped \(last ship 765m ago\)/);
+  });
+
+  it('warns on a stalled queue even when the daemon IS running (the founder case)', () => {
+    // The exact reported state: daemon up, 334 KB queued, last ship 765m ago,
+    // and doctor said "Shipping in progress". The old condition only warned
+    // when the daemon was DOWN, so this is the case that proves the fix.
+    const { output } = runDoctor(
+      stalledHome('stalled-live-daemon', {
+        ageMin: 765,
+        lagBytes: 40_000,
+        daemonRunning: true,
+      })
+    );
+    expect(output).not.toMatch(/Shipping in progress/);
+    expect(output).toMatch(/NOT shipped/);
+    // …and the hint addresses a RUNNING daemon, not "start it".
+    expect(output).toMatch(/daemon is running but/i);
+    expect(output).not.toMatch(/start it: node9 daemon --background/);
+  });
+
+  it('names the revoked key as the reason when the daemon is up and shipping fails', () => {
+    const { output } = runDoctor(
+      stalledHome('stalled-401-live', {
+        ageMin: 765,
+        lagBytes: 40_000,
+        lastError: 'API returned 401',
+        daemonRunning: true,
+      })
+    );
+    expect(output).toMatch(/rejects this machine's key/);
+    expect(output).toMatch(/node9 login/);
+  });
+
+  it('a FRESH lag still reads as in-progress — no nagging a healthy machine', () => {
+    const { output } = runDoctor(stalledHome('fresh-lag', { ageMin: 2, lagBytes: 40_000 }));
+    expect(output).toMatch(/Shipping in progress/);
+  });
+
+  it('a 401 in sync-health is named: disconnected, with `node9 login` as the fix', () => {
+    const { output } = runDoctor(
+      stalledHome('rejected', { ageMin: 765, lagBytes: 40_000, lastError: 'API returned 401' })
+    );
+    // Policy sync stops calling it merely STALE…
+    expect(output).toMatch(/DISCONNECTED/);
+    expect(output).toMatch(/node9 login/);
+    // …and never suggests the command that cannot fix a revoked key.
+    expect(output).not.toMatch(/Run: node9 policy sync/);
+  });
+
+  it('a non-401 failure is NOT called disconnected — 401 is the only special case', () => {
+    // 12h of ETIMEDOUT is a network problem, not a revoked key. (It is also
+    // under the staleness threshold, so Policy sync stays green here — the
+    // point of this case is that the DISCONNECTED verdict is reserved.)
+    const { output } = runDoctor(
+      stalledHome('etimedout', { ageMin: 765, lagBytes: 40_000, lastError: 'ETIMEDOUT' })
+    );
+    expect(output).not.toMatch(/DISCONNECTED/);
+    expect(output).not.toMatch(/node9 login/);
+    // The stalled QUEUE is still reported — that half does not depend on why.
+    expect(output).toMatch(/NOT shipped/);
+  });
+
+  it('a 401 is called out even when the sync is too RECENT to be stale', () => {
+    // The first version of this fix nested the check inside the staleness
+    // branch, so a machine disconnected an hour ago still read "Cloud policy
+    // fresh" until the staleness clock (up to 15h) caught up.
+    const { output } = runDoctor(
+      stalledHome('fresh-401', { ageMin: 20, lagBytes: 40_000, lastError: 'API returned 401' })
+    );
+    expect(output).toMatch(/DISCONNECTED/);
+    expect(output).not.toMatch(/Cloud policy fresh/);
+  });
+});

--- a/src/__tests__/explain-cli.integration.test.ts
+++ b/src/__tests__/explain-cli.integration.test.ts
@@ -7,6 +7,7 @@ import { spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { keySafeEnv } from './helpers/env';
 
 const CLI = path.resolve(__dirname, '../../dist/cli.js');
 
@@ -15,7 +16,7 @@ function explain(command: string): string {
     encoding: 'utf-8',
     timeout: 60000,
     cwd: os.tmpdir(), // no project node9.config.json — built-in gates only
-    env: { ...process.env, NODE9_NO_AUTO_DAEMON: '1', NODE9_TESTING: '1', NO_COLOR: '1' },
+    env: keySafeEnv({ NODE9_NO_AUTO_DAEMON: '1', NODE9_TESTING: '1', NO_COLOR: '1' }),
   });
   return `${r.stdout ?? ''}${r.stderr ?? ''}`;
 }

--- a/src/__tests__/helpers/env.ts
+++ b/src/__tests__/helpers/env.ts
@@ -1,0 +1,48 @@
+// Keyedness hygiene for subprocess-spawning tests (PR-2 matrix §0.12).
+//
+// A spawner that inherits `...process.env` verbatim inherits the DEVELOPER
+// MACHINE'S real NODE9_API_KEY / NODE9_PROFILE / NODE9_API_URL — and once
+// replace-mode lands, a keyed subprocess builds its policy from the cloud,
+// silently flipping entire suites to a different config source depending on
+// whose machine runs them. Four suites already deleted the key by hand;
+// the rest leaked. ONE helper, no hand-rolled deletes.
+//
+// Keyed fixtures never come from the environment: a test that WANTS a keyed
+// subprocess writes a `credentials.json` into its temp HOME (file-keyed —
+// subprocess-safe and Windows-safe), via `writeKeyedHome` below.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** process.env minus every keyedness channel. Overrides apply on top. */
+export function keySafeEnv(
+  overrides: Record<string, string | undefined> = {}
+): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = { ...process.env };
+  delete env.NODE9_API_KEY;
+  delete env.NODE9_API_URL;
+  delete env.NODE9_PROFILE;
+  return { ...env, ...overrides };
+}
+
+/** Make a temp HOME keyed by FILE (the machine-wide channel): a test that
+ *  wants a keyed subprocess opts in explicitly — never by inheritance. */
+export function writeKeyedHome(
+  home: string,
+  opts: { apiKey?: string; apiUrl?: string; localOnly?: boolean } = {}
+): void {
+  const dir = path.join(home, '.node9');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'credentials.json'),
+    JSON.stringify(
+      {
+        apiKey: opts.apiKey ?? 'n9_live_' + 'f'.repeat(40),
+        apiUrl: opts.apiUrl ?? 'http://127.0.0.1:1', // unroutable — no network
+        ...(opts.localOnly ? { localOnly: true } : {}),
+      },
+      null,
+      2
+    )
+  );
+}

--- a/src/__tests__/helpers/gauntlet.ts
+++ b/src/__tests__/helpers/gauntlet.ts
@@ -22,6 +22,7 @@ import { spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { keySafeEnv } from './env';
 
 export const CLI = path.resolve(__dirname, '../../../dist/cli.js');
 
@@ -60,14 +61,13 @@ export function runCli(home: string, args: string[], timeoutMs = 60000) {
     encoding: 'utf-8',
     timeout: timeoutMs,
     cwd: os.tmpdir(),
-    env: {
-      ...process.env,
+    env: keySafeEnv({
       HOME: home,
       USERPROFILE: home,
       NODE9_TESTING: '1',
       NODE9_NO_AUTO_DAEMON: '1',
       NO_COLOR: '1',
-    },
+    }),
   });
 }
 
@@ -95,8 +95,7 @@ export function probe(
     encoding: 'utf-8',
     timeout: opts.timeoutMs ?? 15000,
     cwd: os.tmpdir(),
-    env: {
-      ...process.env,
+    env: keySafeEnv({
       HOME: home,
       USERPROFILE: home,
       NODE9_TESTING: '1',
@@ -105,7 +104,7 @@ export function probe(
       // No GUI/tail → no human approver reachable, so a review resolves
       // deterministically (fail-closed) instead of waiting on a dialog.
       ...opts.env,
-    },
+    }),
   });
   // A killed-by-timeout probe means the gate held the call for a human.
   const held = r.signal !== null || r.status === null;

--- a/src/__tests__/inline-ask-outcome.integration.test.ts
+++ b/src/__tests__/inline-ask-outcome.integration.test.ts
@@ -14,6 +14,7 @@ import { spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { keySafeEnv } from './helpers/env';
 
 const CLI = path.resolve(__dirname, '../../dist/cli.js');
 
@@ -24,7 +25,7 @@ function run(
   args: string[],
   payload: object
 ): { status: number | null; stdout: string } {
-  const baseEnv = { ...process.env };
+  const baseEnv = keySafeEnv();
   delete baseEnv.NODE9_API_KEY;
   delete baseEnv.NODE9_API_URL;
   const r = spawnSync(process.execPath, [CLI, cmd, ...args, JSON.stringify(payload)], {

--- a/src/__tests__/inline-ask-v2-defer.spec.ts
+++ b/src/__tests__/inline-ask-v2-defer.spec.ts
@@ -50,7 +50,16 @@ describe('inline-ask v2: the defer guard has ONE exclusion (downgraded hard bloc
     reason: 'git push sends changes to a shared remote',
   };
 
-  function writeHome(opts: { cloud?: boolean; appPermissions?: Record<string, unknown> }): void {
+  // PR-2 replace-mode (§F disposition): when a test sets NODE9_API_KEY the
+  // process is KEYED and the local config.json policy below is inert — a keyed
+  // test passes `keyed: true` so the review rule and the approval knobs ride
+  // in the CLOUD cache instead (rules + managedConfig), exactly what a real
+  // keyed machine gets from sync. Unkeyed tests keep the local delivery.
+  function writeHome(opts: {
+    cloud?: boolean;
+    appPermissions?: Record<string, unknown>;
+    keyed?: boolean;
+  }): void {
     fs.writeFileSync(
       path.join(tmpHome, '.node9', 'config.json'),
       JSON.stringify({
@@ -72,9 +81,22 @@ describe('inline-ask v2: the defer guard has ONE exclusion (downgraded hard bloc
       path.join(tmpHome, '.node9', 'rules-cache.json'),
       JSON.stringify({
         fetchedAt: '2026-07-01T00:00:00Z',
-        rules: [],
+        rules: opts.keyed ? [reviewGitPushRule] : [],
         managedConfig: {
           ...(opts.appPermissions ? { appPermissions: opts.appPermissions } : {}),
+          ...(opts.keyed
+            ? {
+                // A managed 0 is rejected by design (index.ts) — 50ms keeps a
+                // race, if ever reached, deterministic instead of hanging.
+                approvalTimeoutMs: 50,
+                approvers: {
+                  native: false,
+                  browser: false,
+                  cloud: opts.cloud === true,
+                  terminal: false,
+                },
+              }
+            : {}),
           locked: [],
         },
       })
@@ -109,9 +131,14 @@ describe('inline-ask v2: the defer guard has ONE exclusion (downgraded hard bloc
   });
 
   it('CLOUD-ENFORCED + ordinary review → defers inline; no SaaS pending entry is created', async () => {
-    writeHome({ cloud: true });
-    process.env.NODE9_API_KEY = 'nk_test_v2';
-    const r = await authorizeHeadless('Bash', { command: 'git push origin dev' }, undefined, {
+    writeHome({ cloud: true, keyed: true });
+    process.env.NODE9_API_KEY = 'nk_test_v2'; // env key => KEYED process
+    // PR-2: keyed drops the local review-git-push rule, and cloud cache
+    // `rules` are currently dropped keyed too (prod bug pinned as K13c in
+    // keyed-replace.spec.ts) — so the probe rides the SHIPPED DEFAULT
+    // `review-sudo` rule, which survives keyed by construction. The property
+    // under test is unchanged: cloud-enforced + ordinary review defers inline.
+    const r = await authorizeHeadless('Bash', { command: 'sudo make install' }, undefined, {
       deferReview: true,
     });
     expect(r.review).toBe(true);

--- a/src/__tests__/keyed-explain-waterfall.spec.ts
+++ b/src/__tests__/keyed-explain-waterfall.spec.ts
@@ -1,0 +1,177 @@
+// src/__tests__/keyed-explain-waterfall.spec.ts
+// PR-2 §I row I4 — the explain waterfall tells the replace-mode truth.
+//
+// THE LAW UNDER TEST (matrix §0.13): on a workspace-governed machine the tier
+// list must invert its story — tier 2 is relabeled 'Workspace config' and
+// marked authoritative; the local tiers (3 project / 4 global) say "present —
+// ignored"; tier 1 says the env-var mode override is ignored. Unkeyed keeps
+// today's labels byte-for-byte ('Cloud policy', no ignored notes) — explain
+// stays not-ground-truth, so these rows assert LABELS only, never verdicts.
+//
+// In-process unit rows at the explainPolicy() seam (same harness as
+// keyed-replace.spec.ts: temp HOME, file-keyed fixture, mocked shields store —
+// the shields.json path is a module-load const frozen to the real home).
+//
+// MUTATION PREP:
+//   - dropping the wsGoverned branch in deriveExplainTrace → every keyed row
+//   - inverting it (labeling unkeyed machines workspace)   → every unkeyed row
+//   - keyed notes added only when files are MISSING        → 'no ignored notes
+//     when the local files do not exist'
+//   - tier-2 label keyed off credentials presence instead
+//     of policySource                                      → localOnly row
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const shieldState = vi.hoisted(() => ({
+  active: [] as string[],
+}));
+
+vi.mock('../shields', async () => {
+  const actual = await vi.importActual<typeof import('../shields')>('../shields');
+  return {
+    ...actual,
+    readActiveShields: () => shieldState.active,
+    readShieldOverrides: () => ({}),
+  };
+});
+
+import { _resetConfigCache } from '../config';
+import { explainPolicy, type WaterfallTier } from '../policy';
+
+describe('I4 — explain waterfall labels under replace-mode', () => {
+  let home: string;
+  let proj: string;
+  const savedEnv: Record<string, string | undefined> = {};
+  const ENV_KEYS = ['NODE9_API_KEY', 'NODE9_API_URL', 'NODE9_PROFILE', 'NODE9_MODE'];
+  let cwdSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-explain-'));
+    proj = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-explain-proj-'));
+    savedEnv.HOME = process.env.HOME;
+    savedEnv.USERPROFILE = process.env.USERPROFILE;
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    for (const k of ENV_KEYS) delete process.env[k];
+    fs.mkdirSync(path.join(home, '.node9'), { recursive: true });
+    // deriveExplainTrace resolves the project tier from process.cwd() — pin it
+    // to the temp project dir so the repo's own node9.config.json never leaks in.
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(proj) as ReturnType<typeof vi.spyOn>;
+    shieldState.active = [];
+    _resetConfigCache();
+  });
+
+  afterEach(() => {
+    cwdSpy?.mockRestore();
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v !== undefined) process.env[k] = v;
+      else delete process.env[k];
+    }
+    fs.rmSync(home, { recursive: true, force: true });
+    fs.rmSync(proj, { recursive: true, force: true });
+    _resetConfigCache();
+  });
+
+  const keyed = () => {
+    fs.writeFileSync(
+      path.join(home, '.node9', 'credentials.json'),
+      JSON.stringify({ default: { apiKey: 'n9_test_matrix' } })
+    );
+  };
+  const writeGlobal = () => {
+    fs.writeFileSync(
+      path.join(home, '.node9', 'config.json'),
+      JSON.stringify({ version: '1.0', settings: {} })
+    );
+  };
+  const writeRepo = () => {
+    fs.writeFileSync(
+      path.join(proj, 'node9.config.json'),
+      JSON.stringify({ version: '1.0', settings: {} })
+    );
+  };
+
+  const tiers = async (): Promise<Record<number, WaterfallTier>> => {
+    _resetConfigCache();
+    const r = await explainPolicy('bash', { command: 'ls -la' });
+    const byTier: Record<number, WaterfallTier> = {};
+    for (const t of r.waterfall) byTier[t.tier] = t;
+    return byTier;
+  };
+
+  describe('keyed', () => {
+    it("tier 2 is relabeled 'Workspace config' and marked authoritative", async () => {
+      keyed();
+      const t = await tiers();
+      expect(t[2].label).toBe('Workspace config');
+      expect(t[2].status).toBe('active');
+      expect(t[2].note).toContain('authoritative');
+      expect(t[2].note).toContain('app.node9.ai');
+    });
+
+    it("tiers 3 and 4 say 'present — ignored' when the files exist", async () => {
+      keyed();
+      writeGlobal();
+      writeRepo();
+      const t = await tiers();
+      expect(t[3].note).toContain('ignored');
+      expect(t[4].note).toContain('ignored');
+    });
+
+    it('no ignored notes when the local files do not exist (nothing to disclaim)', async () => {
+      keyed();
+      const t = await tiers();
+      expect(t[3].status).toBe('missing');
+      expect(t[4].status).toBe('missing');
+      expect(t[3].note ?? '').not.toContain('ignored');
+      expect(t[4].note ?? '').not.toContain('ignored');
+    });
+
+    it("tier 1 marks NODE9_MODE 'ignored (workspace config controls mode)'", async () => {
+      keyed();
+      process.env.NODE9_MODE = 'observe';
+      const t = await tiers();
+      expect(t[1].note).toContain('NODE9_MODE=observe');
+      expect(t[1].note).toContain('ignored');
+      expect(t[1].note).toContain('workspace config controls mode');
+    });
+  });
+
+  describe('unkeyed — labels unchanged byte-for-byte', () => {
+    it("tier 2 stays 'Cloud policy' (missing) and no tier carries an ignored note", async () => {
+      writeGlobal();
+      writeRepo();
+      const t = await tiers();
+      expect(t[2].label).toBe('Cloud policy');
+      for (const n of [1, 2, 3, 4, 5]) {
+        expect(t[n].note ?? '').not.toContain('ignored');
+      }
+    });
+
+    it('NODE9_MODE renders plain (no ignored suffix) unkeyed', async () => {
+      process.env.NODE9_MODE = 'observe';
+      const t = await tiers();
+      expect(t[1].note).toBe('NODE9_MODE=observe');
+    });
+
+    it("a localOnly key renders the UNKEYED story: 'Cloud policy' active, credentials note, no ignored notes", async () => {
+      // Mutant kill: labeling keyed off credentials-file presence instead of
+      // policySource would flip this machine to the workspace story while its
+      // policy is fully local (`node9 login --local`'s printed promise).
+      fs.writeFileSync(
+        path.join(home, '.node9', 'credentials.json'),
+        JSON.stringify({ default: { apiKey: 'n9_local', localOnly: true } })
+      );
+      writeGlobal();
+      const t = await tiers();
+      expect(t[2].label).toBe('Cloud policy');
+      expect(t[2].status).toBe('active');
+      expect(t[2].note).toContain('credentials found');
+      expect(t[4].note ?? '').not.toContain('ignored');
+    });
+  });
+});

--- a/src/__tests__/keyed-guard.unit.spec.ts
+++ b/src/__tests__/keyed-guard.unit.spec.ts
@@ -1,0 +1,172 @@
+// src/__tests__/keyed-guard.unit.spec.ts
+// PR-2 §G — unit rows on the write-guard seam itself (src/config/keyed-guard.ts).
+//
+// THE LAW UNDER TEST: `isKeyedForPolicy()` delegates to the ONE introspection
+// truth (`getConfig().policySource === 'workspace'`) — it never re-derives
+// keyedness from credentials. `cliGuardPolicyWrite(action)` is the shared CLI
+// seam: keyed → print the refusal, set a NON-ZERO exit code, return false;
+// unkeyed → return true, print nothing, leave the exit code alone.
+//
+// MUTATION PREP (which row kills which mutant):
+//   - inverting isKeyedForPolicy                 → 'true when keyed' + 'false unkeyed'
+//   - guard re-derives keyedness from creds
+//     (ignoring localOnly / named profiles)      → localOnly + named-profile rows
+//   - guard checks rules-cache presence instead
+//     of policySource                            → 'keyed with NO rules-cache still guards'
+//   - "guard prints but exits 0" (the DECISIONS
+//     dead-DO rule)                              → exitCode assertions
+//   - refusal message loses the dashboard pointer→ message-content assertions
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { _resetConfigCache } from '../config';
+import {
+  isKeyedForPolicy,
+  cliGuardPolicyWrite,
+  keyedPolicyWriteMessage,
+  KEYED_POLICY_WRITE_REASON,
+} from '../config/keyed-guard';
+
+describe('§G unit — keyed-guard seam', () => {
+  let home: string;
+  const savedEnv: Record<string, string | undefined> = {};
+  const ENV_KEYS = ['NODE9_API_KEY', 'NODE9_API_URL', 'NODE9_PROFILE', 'NODE9_MODE'];
+  let savedExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-guard-'));
+    savedEnv.HOME = process.env.HOME;
+    savedEnv.USERPROFILE = process.env.USERPROFILE;
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    for (const k of ENV_KEYS) delete process.env[k];
+    fs.mkdirSync(path.join(home, '.node9'), { recursive: true });
+    // The guard sets process.exitCode — save it so a passing refusal row can
+    // never leak exit 1 into the vitest process itself.
+    savedExitCode = process.exitCode;
+    _resetConfigCache();
+  });
+
+  afterEach(() => {
+    process.exitCode = savedExitCode;
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v !== undefined) process.env[k] = v;
+      else delete process.env[k];
+    }
+    fs.rmSync(home, { recursive: true, force: true });
+    _resetConfigCache();
+  });
+
+  const keyed = () => {
+    fs.writeFileSync(
+      path.join(home, '.node9', 'credentials.json'),
+      JSON.stringify({ default: { apiKey: 'n9_test_matrix' } })
+    );
+    _resetConfigCache();
+  };
+
+  describe('isKeyedForPolicy — delegates to policySource, never re-derived', () => {
+    it('false on a plain unkeyed machine (policySource local)', () => {
+      expect(isKeyedForPolicy()).toBe(false);
+    });
+
+    it('true with a default-profile credentials.json (policySource workspace)', () => {
+      keyed();
+      expect(isKeyedForPolicy()).toBe(true);
+    });
+
+    it('true with NO rules-cache present — keyedness = credentials, not cache (mutant: keyed=cache-exists)', () => {
+      keyed();
+      expect(fs.existsSync(path.join(home, '.node9', 'rules-cache.json'))).toBe(false);
+      expect(isKeyedForPolicy()).toBe(true);
+    });
+
+    it('false for a localOnly key (`node9 login --local` — the printed promise, §0.1)', () => {
+      fs.writeFileSync(
+        path.join(home, '.node9', 'credentials.json'),
+        JSON.stringify({ default: { apiKey: 'n9_local', localOnly: true } })
+      );
+      _resetConfigCache();
+      expect(isKeyedForPolicy()).toBe(false);
+    });
+
+    it('false for a NAMED profile key (§0.11 — profiles never policy-sync)', () => {
+      fs.writeFileSync(
+        path.join(home, '.node9', 'credentials.json'),
+        JSON.stringify({ work: { apiKey: 'n9_work' } })
+      );
+      process.env.NODE9_PROFILE = 'work';
+      _resetConfigCache();
+      expect(isKeyedForPolicy()).toBe(false);
+    });
+
+    it('true for an env key (CI service keys have no localOnly channel)', () => {
+      process.env.NODE9_API_KEY = 'n9_ci_key';
+      _resetConfigCache();
+      expect(isKeyedForPolicy()).toBe(true);
+    });
+  });
+
+  describe('cliGuardPolicyWrite — refusal contract', () => {
+    it('unkeyed: returns true, prints NOTHING, leaves the exit code untouched', () => {
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const before = process.exitCode;
+      expect(cliGuardPolicyWrite('egress lock')).toBe(true);
+      expect(errSpy).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(before);
+      errSpy.mockRestore();
+    });
+
+    it('keyed: returns false, sets exitCode=1, and the message names the workspace + dashboard', () => {
+      keyed();
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      expect(cliGuardPolicyWrite('shield enable postgres')).toBe(false);
+      // "guard prints but exits 0" mutant — a script that believes it hardened
+      // a keyed machine must fail loudly.
+      expect(process.exitCode).toBe(1);
+      const printed = errSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(printed).toContain('workspace configuration');
+      expect(printed).toContain('app.node9.ai');
+      expect(printed).toContain('shield enable postgres');
+      errSpy.mockRestore();
+    });
+
+    it('keyed with NO rules-cache: still refuses (mutant: guard keyed on cache presence)', () => {
+      keyed();
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      expect(cliGuardPolicyWrite('trust add x.com')).toBe(false);
+      expect(process.exitCode).toBe(1);
+      errSpy.mockRestore();
+    });
+
+    it('localOnly key: the guard lets the write proceed (unkeyed-for-policy)', () => {
+      fs.writeFileSync(
+        path.join(home, '.node9', 'credentials.json'),
+        JSON.stringify({ default: { apiKey: 'n9_local', localOnly: true } })
+      );
+      _resetConfigCache();
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      expect(cliGuardPolicyWrite('egress lock')).toBe(true);
+      expect(errSpy).not.toHaveBeenCalled();
+      errSpy.mockRestore();
+    });
+  });
+
+  describe('keyedPolicyWriteMessage — one message, shared by CLI and MCP', () => {
+    it('carries the shared reason, the action, and both paved paths back (logout / login --local)', () => {
+      const msg = keyedPolicyWriteMessage('jail add /tmp/x');
+      expect(msg).toContain(KEYED_POLICY_WRITE_REASON);
+      expect(msg).toContain('jail add /tmp/x');
+      expect(msg).toContain('app.node9.ai');
+      expect(msg).toContain('node9 logout');
+      expect(msg).toContain('node9 login --local');
+    });
+
+    it('the shared reason names the workspace configuration (the gauntlet asserts on this string)', () => {
+      expect(KEYED_POLICY_WRITE_REASON).toContain('workspace configuration');
+    });
+  });
+});

--- a/src/__tests__/keyed-introspection.integration.test.ts
+++ b/src/__tests__/keyed-introspection.integration.test.ts
@@ -1,0 +1,234 @@
+// src/__tests__/keyed-introspection.integration.test.ts
+// PR-2 §I — introspection tells the ONE truth (getConfig().policySource),
+// end to end over the real dist/cli.js (requires `npm run build`).
+//
+// Rows covered here: I1 (status), I2 (status cloud line — keyed default
+// approvers.cloud=true renders Agent mode), I3 (doctor), I5 (egress status
+// source line), I8 (shield list / status / config show), I10 (jail list).
+// I4 (explain waterfall) is unit-covered in keyed-explain-waterfall.spec.ts.
+//
+// Rows SKIPPED here, with reasons:
+//   - I6 (check fallback label 'Workspace Policy'): the fallback only renders
+//     for a verdict with neither blockedByLabel nor blockedBy — the engine
+//     always labels its verdicts, so the branch is unreachable from a spawned
+//     `node9 check` without a daemon-approval fixture. Left to the daemon lane.
+//   - I7 / I11 (MCP node9_status / node9_config_get): covered in
+//     keyed-mcp-guard.integration.test.ts (same spawn, MCP transport).
+//   - I9 (HUD GET /status mode): needs a LIVE daemon serving HTTP.
+//   - I12 (posture scores under cloud policy): posture has its own suite
+//     (posture-governance.spec) — the keyed lane there needs scorecard
+//     fixtures out of scope for this write-guard PR.
+//
+// MUTATION PREP:
+//   - dropping a wsGoverned branch on any surface   → its keyed row
+//   - inverting the branch (unkeyed says ignored)   → the unkeyed twin rows
+//   - swapping appliedShields back to
+//     readActiveShields in shield status            → 'mandated redis renders'
+//   - shield list keyed cloud column losing the
+//     enforced set                                  → the it.fails pin below
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { keySafeEnv, writeKeyedHome } from './helpers/env';
+
+const CLI = path.resolve(__dirname, '../../dist/cli.js');
+
+function runCli(home: string, args: string[]): { status: number | null; out: string } {
+  const result = spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf-8',
+    timeout: 60000,
+    cwd: home,
+    env: keySafeEnv({
+      HOME: home,
+      USERPROFILE: home,
+      NODE9_NO_AUTO_DAEMON: '1',
+      NODE9_TESTING: '1',
+      NO_COLOR: '1',
+    }),
+  });
+  expect(result.error).toBeUndefined();
+  // Several of these surfaces print to stderr by design (shield status,
+  // config show) — assert on the combined stream.
+  return { status: result.status, out: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+}
+
+/** One fixture, two keyednesses: every local policy store present + a cloud
+ *  cache mandating redis. The keyed home adds ONLY credentials.json. */
+function makeHome(keyed: boolean): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-intro-'));
+  fs.mkdirSync(path.join(home, '.node9'), { recursive: true });
+  if (keyed) writeKeyedHome(home);
+  fs.writeFileSync(
+    path.join(home, '.node9', 'config.json'),
+    JSON.stringify({ version: '1.0', settings: { autoStartDaemon: false } })
+  );
+  // Project config in cwd (= home) so the status Local: line has a file to name.
+  fs.writeFileSync(
+    path.join(home, 'node9.config.json'),
+    JSON.stringify({ version: '1.0', settings: {} })
+  );
+  fs.writeFileSync(
+    path.join(home, '.node9', 'shields.json'),
+    JSON.stringify({ active: ['filesystem'], overrides: {} })
+  );
+  fs.writeFileSync(
+    path.join(home, '.node9', 'jail-paths.json'),
+    JSON.stringify({ paths: [{ path: '/tmp/secrets', verdict: 'block' }] })
+  );
+  fs.writeFileSync(
+    path.join(home, '.node9', 'rules-cache.json'),
+    JSON.stringify({
+      fetchedAt: '2026-08-01T00:00:00Z',
+      rules: [],
+      shields: ['redis'],
+      managedConfig: { locked: [] },
+    })
+  );
+  return home;
+}
+
+let keyedHome: string;
+let unkeyedHome: string;
+
+beforeAll(() => {
+  if (!fs.existsSync(CLI)) throw new Error('dist/cli.js missing — run `npm run build` first');
+  keyedHome = makeHome(true);
+  unkeyedHome = makeHome(false);
+});
+afterAll(() => {
+  fs.rmSync(keyedHome, { recursive: true, force: true });
+  fs.rmSync(unkeyedHome, { recursive: true, force: true });
+});
+
+describe('I1/I2 — node9 status', () => {
+  it('keyed: names the workspace source and marks BOTH local config files present-but-ignored', () => {
+    const { status, out } = runCli(keyedHome, ['status']);
+    expect(status).toBe(0);
+    expect(out).toContain('Policy:  Workspace config (app.node9.ai)');
+    // Local (node9.config.json in cwd) AND Global (~/.node9/config.json):
+    const ignoredLines = out
+      .split('\n')
+      .filter((l) => l.includes('Present — ignored (workspace config governs)'));
+    expect(ignoredLines.some((l) => l.includes('Local:'))).toBe(true);
+    expect(ignoredLines.some((l) => l.includes('Global:'))).toBe(true);
+    // I2 (§0.3): the keyed default approvers.cloud=true renders as cloud
+    // policy enforced — not privacy mode — with a local config that never set it.
+    expect(out).toContain('Agent mode');
+    expect(out).toContain('cloud team policy enforced');
+  });
+
+  it('unkeyed: byte-parity — Active file labels, no Policy: line, no ignored markers', () => {
+    const { status, out } = runCli(unkeyedHome, ['status']);
+    expect(status).toBe(0);
+    expect(out).toContain('Local:   Active (node9.config.json)');
+    expect(out).toContain('Global:  Active (~/.node9/config.json)');
+    expect(out).not.toContain('Workspace config (app.node9.ai)');
+    expect(out).not.toContain('ignored (workspace');
+  });
+});
+
+describe('I3 — node9 doctor', () => {
+  it('keyed: passes a policy-source line and disclaims the local config file', () => {
+    const { out } = runCli(keyedHome, ['doctor']);
+    expect(out).toContain('Policy source: workspace config (app.node9.ai)');
+    expect(out).toContain('policy fields ignored — workspace governs');
+  });
+
+  it('unkeyed: no workspace-source line, config file reported plainly valid', () => {
+    const { out } = runCli(unkeyedHome, ['doctor']);
+    expect(out).not.toContain('Policy source: workspace config');
+    expect(out).toContain('~/.node9/config.json found and valid');
+    expect(out).not.toContain('policy fields ignored');
+  });
+});
+
+describe('I5 — node9 egress (status view)', () => {
+  it('keyed: names its source and calls local egress settings ignored', () => {
+    const { status, out } = runCli(keyedHome, ['egress']);
+    expect(status).toBe(0);
+    expect(out).toContain('Source: workspace config (app.node9.ai)');
+    expect(out).toContain('local egress settings are ignored');
+  });
+
+  it('unkeyed: no source line', () => {
+    const { status, out } = runCli(unkeyedHome, ['egress']);
+    expect(status).toBe(0);
+    expect(out).not.toContain('Source: workspace config');
+  });
+});
+
+describe('I8 — shield list / shield status / config show', () => {
+  it('keyed shield list: locally-enabled-but-not-mandated shield is marked ignored', () => {
+    const { status, out } = runCli(keyedHome, ['shield', 'list']);
+    expect(status).toBe(0);
+    expect(out).toContain('Workspace config governs — local enables are ignored.');
+    const fsLine = out.split('\n').find((l) => l.includes('filesystem')) ?? '';
+    expect(fsLine).toContain('ignored');
+    expect(fsLine).toContain('enabled locally — workspace config governs');
+  });
+
+  // Was a PRODUCTION BUG, pinned by this row and fixed the same day: the keyed
+  // branch of `shield list` computed its "cloud" column from
+  // readCloudShields() — a legacy heuristic parsing SHIELD:-tagged rules out of
+  // rules-cache.json `rules` — instead of the resolver's own testimony,
+  // config.policy.appliedShields. A shield mandated through the cache's
+  // `shields` array (the M1 path this same fixture proves ENFORCED via `shield
+  // status`) rendered "○  disabled" while it was being enforced. Matrix I8:
+  // mandated shields are shown enforced. Mutation twin: reverting the keyed
+  // branch to readCloudShields kills this row and no other.
+  it('keyed shield list: a cache-mandated shield renders enabled (it IS enforced)', () => {
+    const { out } = runCli(keyedHome, ['shield', 'list']);
+    const redisLine = out.split('\n').find((l) => /\bredis\b/.test(l)) ?? '';
+    expect(redisLine).toContain('enabled');
+    expect(redisLine).not.toContain('disabled');
+  });
+
+  it('keyed shield status: renders the ENFORCED set (mandated redis) with a workspace source line', () => {
+    const { out } = runCli(keyedHome, ['shield', 'status']);
+    expect(out).toContain('Source: workspace config (app.node9.ai)');
+    // Mutant kill: swapping back to readActiveShields would render filesystem
+    // (local enable) and drop redis (the mandate).
+    expect(out).toContain('redis');
+    expect(out).toContain('block-flushall');
+    expect(out).not.toMatch(/●\s*filesystem/);
+  });
+
+  it('unkeyed shield status: renders the LOCAL enable store, no source line', () => {
+    const { out } = runCli(unkeyedHome, ['shield', 'status']);
+    expect(out).not.toContain('Source: workspace config');
+    expect(out).toMatch(/●\s*filesystem/);
+  });
+
+  it('keyed config show: names the workspace source and shows the enforced shield set', () => {
+    const { out } = runCli(keyedHome, ['config', 'show']);
+    expect(out).toContain('Source: workspace config (app.node9.ai)');
+    expect(out).toContain('local policy files are ignored');
+  });
+
+  it('unkeyed config show: no workspace source line', () => {
+    const { out } = runCli(unkeyedHome, ['config', 'show']);
+    expect(out).not.toContain('Source: workspace config');
+  });
+});
+
+describe('I10 — node9 jail list', () => {
+  it('keyed: user paths render but are marked ignored (workspace governs)', () => {
+    const { status, out } = runCli(keyedHome, ['jail', 'list']);
+    expect(status).toBe(0);
+    expect(out).toContain('Your paths — ignored (workspace config governs):');
+    const pathLine = out.split('\n').find((l) => l.includes('/tmp/secrets')) ?? '';
+    expect(pathLine).toContain('(ignored)');
+  });
+
+  it('unkeyed: user paths render as removable, never marked ignored', () => {
+    const { status, out } = runCli(unkeyedHome, ['jail', 'list']);
+    expect(status).toBe(0);
+    expect(out).toContain('Your paths (removable):');
+    expect(out).toContain('/tmp/secrets');
+    expect(out).not.toContain('(ignored)');
+    expect(out).not.toContain('workspace config governs');
+  });
+});

--- a/src/__tests__/keyed-mcp-guard.integration.test.ts
+++ b/src/__tests__/keyed-mcp-guard.integration.test.ts
@@ -1,0 +1,254 @@
+// src/__tests__/keyed-mcp-guard.integration.test.ts
+// PR-2 §G rows G15-G21 + §I rows I7/I11 (MCP transport) — the MCP dispatch
+// guard: on a workspace-governed machine EVERY non-readonly tool is refused
+// with -32000 BEFORE the weaken gate, so a keyed machine is never advised to
+// set mcpAllowWeakening in a file it does not read (matrix §0.8/§0.9).
+//
+// Spawns `dist/cli.js mcp-server` over stdio JSON-RPC (same harness as
+// mcp-server-tools.integration.test.ts; requires `npm run build`).
+//
+// MUTATION PREP:
+//   - removing the dispatch guard                      → every keyed refusal row
+//   - guard placed AFTER the weaken gate               → 'refusal text never
+//     mentions mcpAllowWeakening' (the weaken gate's text does)
+//   - guard covering only 'weaken' tools, not 'add'    → shield_enable /
+//     egress_protect / rule_add rows (capability 'add')
+//   - mcpAllowWeakening outranking the guard (§0.9)    → G16
+//   - refusal still performing the write               → store-file assertions
+//   - I7/I11: status/config_get reverting to local
+//     labels / readActiveShields                       → readonly keyed rows
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'child_process';
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { keySafeEnv, writeKeyedHome } from './helpers/env';
+
+const CLI = path.resolve(__dirname, '../../dist/cli.js');
+
+interface McpResponse {
+  id?: number;
+  result?: { content?: { type: string; text: string }[] };
+  error?: { code: number; message: string };
+}
+
+function driveMcp(requests: object[], homeDir: string): Record<number, McpResponse> {
+  const input = requests.map((r) => JSON.stringify(r)).join('\n') + '\n';
+  const r = spawnSync(process.execPath, [CLI, 'mcp-server'], {
+    input,
+    encoding: 'utf-8',
+    timeout: 60000,
+    cwd: homeDir, // never the repo root — its node9.config.json must not leak in
+    env: keySafeEnv({
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      NODE9_TESTING: '1',
+      NODE9_NO_AUTO_DAEMON: '1',
+      NO_COLOR: '1',
+    }),
+  });
+  expect(r.error).toBeUndefined();
+  const byId: Record<number, McpResponse> = {};
+  for (const line of (r.stdout ?? '').split('\n').filter(Boolean)) {
+    try {
+      const msg = JSON.parse(line) as McpResponse;
+      if (typeof msg.id === 'number') byId[msg.id] = msg;
+    } catch {
+      /* ignore non-JSON lines */
+    }
+  }
+  return byId;
+}
+
+const call = (id: number, name: string, args: Record<string, unknown> = {}) => ({
+  jsonrpc: '2.0',
+  id,
+  method: 'tools/call',
+  params: { name, arguments: args },
+});
+
+const sha = (p: string) => crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex');
+
+function makeHome(opts: { keyed: boolean; mcpAllowWeakening?: boolean }): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-mcpguard-'));
+  fs.mkdirSync(path.join(home, '.node9'), { recursive: true });
+  if (opts.keyed) writeKeyedHome(home);
+  fs.writeFileSync(
+    path.join(home, '.node9', 'config.json'),
+    JSON.stringify({
+      version: '1.0',
+      settings: {
+        autoStartDaemon: false,
+        ...(opts.mcpAllowWeakening ? { mcpAllowWeakening: true } : {}),
+      },
+    })
+  );
+  fs.writeFileSync(
+    path.join(home, '.node9', 'shields.json'),
+    JSON.stringify({ active: ['filesystem'], overrides: {} })
+  );
+  fs.writeFileSync(
+    path.join(home, '.node9', 'rules-cache.json'),
+    JSON.stringify({
+      fetchedAt: '2026-08-01T00:00:00Z',
+      rules: [],
+      shields: ['redis'],
+      managedConfig: { locked: [] },
+    })
+  );
+  return home;
+}
+
+const homes: string[] = [];
+function home(opts: { keyed: boolean; mcpAllowWeakening?: boolean }): string {
+  const h = makeHome(opts);
+  homes.push(h);
+  return h;
+}
+
+beforeAll(() => {
+  if (!fs.existsSync(CLI)) throw new Error('dist/cli.js missing — run `npm run build` first');
+});
+afterAll(() => {
+  for (const h of homes) fs.rmSync(h, { recursive: true, force: true });
+});
+
+describe('§G keyed — every non-readonly MCP tool refuses with -32000, stores untouched', () => {
+  it('G15/G17/G18/G19/G20: add AND weaken tools all refuse; the stores stay byte-identical', () => {
+    const h = home({ keyed: true });
+    const cfgSha = sha(path.join(h, '.node9', 'config.json'));
+    const shieldsSha = sha(path.join(h, '.node9', 'shields.json'));
+    const res = driveMcp(
+      [
+        call(1, 'node9_shield_enable', { service: 'postgres' }), // add   (G15)
+        call(2, 'node9_shield_disable', { service: 'filesystem' }), // weaken
+        call(3, 'node9_approver_set', { approver: 'cloud', enabled: false }), // weaken (G17)
+        call(4, 'node9_egress_protect', { mode: 'block' }), // add   (G18)
+        call(5, 'node9_egress_deny', { host: '*.evil.com' }), // add   (G19)
+        call(6, 'node9_rule_add', {
+          name: 'x',
+          tool: 'bash',
+          field: 'command',
+          pattern: 'xyz',
+          verdict: 'block',
+          reason: 'test',
+        }), // add (G20, §0.8)
+      ],
+      h
+    );
+    for (const id of [1, 2, 3, 4, 5, 6]) {
+      expect(res[id]?.error, `tool call ${id} must be refused`).toBeDefined();
+      expect(res[id]?.error?.code).toBe(-32000);
+      expect(res[id]?.error?.message).toContain('workspace configuration');
+      expect(res[id]?.error?.message).toContain('app.node9.ai');
+    }
+    expect(sha(path.join(h, '.node9', 'config.json'))).toBe(cfgSha);
+    expect(sha(path.join(h, '.node9', 'shields.json'))).toBe(shieldsSha);
+  });
+
+  it('G21 keyed: the refusal is the guard speaking, never the weaken gate — no mcpAllowWeakening advice', () => {
+    // The guard runs BEFORE the weaken gate. The weaken gate's refusal tells
+    // the agent to set "mcpAllowWeakening": true in ~/.node9/config.json — a
+    // file a keyed machine does not read for policy. That advice must never
+    // reach a keyed agent, for the weaken tool most likely to trigger it.
+    const h = home({ keyed: true });
+    const res = driveMcp([call(1, 'node9_shield_disable', { service: 'redis' })], h);
+    expect(res[1]?.error?.code).toBe(-32000);
+    expect(res[1]?.error?.message).toContain('workspace configuration');
+    expect(res[1]?.error?.message).not.toContain('mcpAllowWeakening');
+  });
+
+  it('G16: the guard OUTRANKS a local mcpAllowWeakening=true opt-in (§0.9 — local config is inert)', () => {
+    const h = home({ keyed: true, mcpAllowWeakening: true });
+    const shieldsSha = sha(path.join(h, '.node9', 'shields.json'));
+    const res = driveMcp([call(1, 'node9_shield_disable', { service: 'filesystem' })], h);
+    expect(res[1]?.error?.code).toBe(-32000);
+    expect(res[1]?.error?.message).toContain('workspace configuration');
+    expect(res[1]?.error?.message).not.toContain('mcpAllowWeakening');
+    expect(sha(path.join(h, '.node9', 'shields.json'))).toBe(shieldsSha);
+  });
+});
+
+describe('§G unkeyed twins — the known-true instruments', () => {
+  it('G21 unkeyed: shield_disable gets the CLASSIC weaken-gate message, advice included', () => {
+    const h = home({ keyed: false });
+    const res = driveMcp([call(1, 'node9_shield_disable', { service: 'filesystem' })], h);
+    expect(res[1]?.error?.code).toBe(-32000);
+    expect(res[1]?.error?.message).toMatch(/weaken/i);
+    expect(res[1]?.error?.message).toContain('mcpAllowWeakening');
+    expect(res[1]?.error?.message).not.toContain('workspace configuration');
+  });
+
+  it('G15 unkeyed: shield_enable (add) works and mutates shields.json', () => {
+    const h = home({ keyed: false });
+    const res = driveMcp([call(1, 'node9_shield_enable', { service: 'postgres' })], h);
+    expect(res[1]?.error).toBeUndefined();
+    expect(fs.readFileSync(path.join(h, '.node9', 'shields.json'), 'utf-8')).toContain('postgres');
+  });
+
+  it('G20 unkeyed: rule_add works and lands the rule in config.json', () => {
+    const h = home({ keyed: false });
+    const res = driveMcp(
+      [
+        call(1, 'node9_rule_add', {
+          name: 'block-xyz',
+          tool: 'bash',
+          field: 'command',
+          pattern: 'xyz',
+          verdict: 'block',
+          reason: 'test',
+        }),
+      ],
+      h
+    );
+    expect(res[1]?.error).toBeUndefined();
+    expect(fs.readFileSync(path.join(h, '.node9', 'config.json'), 'utf-8')).toContain('block-xyz');
+  });
+});
+
+describe('§I over MCP — readonly tools still answer, and tell the workspace truth', () => {
+  it('I7 keyed: node9_status names the source, reports the ENFORCED shields, marks configs ignored', () => {
+    const h = home({ keyed: true });
+    const res = driveMcp(
+      [call(1, 'node9_status'), call(2, 'node9_config_get'), call(3, 'node9_egress_status')],
+      h
+    );
+    const status = res[1]?.result?.content?.[0]?.text ?? '';
+    expect(status).toContain('Policy source: workspace config (app.node9.ai)');
+    // appliedShields (mandated redis), NOT the local enable store (filesystem):
+    expect(status).toContain('Active shields: redis');
+    expect(status).not.toContain('filesystem');
+    expect(status).toContain('present — ignored (workspace config governs)');
+    // I11:
+    const cfgGet = res[2]?.result?.content?.[0]?.text ?? '';
+    expect(cfgGet).toContain('source: workspace config (app.node9.ai)');
+    // I5 (MCP transport):
+    const egress = res[3]?.result?.content?.[0]?.text ?? '';
+    expect(egress).toContain('Source: workspace config (app.node9.ai)');
+  });
+
+  it('I8 keyed: node9_shield_list marks the mandate active and the local-only enable ignored', () => {
+    const h = home({ keyed: true });
+    const res = driveMcp([call(1, 'node9_shield_list')], h);
+    const text = res[1]?.result?.content?.[0]?.text ?? '';
+    expect(text).toContain('(workspace config governs)');
+    const redisLine = text.split('\n').find((l) => /\bredis\b/.test(l)) ?? '';
+    expect(redisLine).toContain('[active]');
+    const fsLine = text.split('\n').find((l) => l.includes('filesystem')) ?? '';
+    expect(fsLine).toContain('enabled locally, ignored');
+  });
+
+  it('I7/I8 unkeyed twins: no workspace labels; shield list renders the local enable store', () => {
+    const h = home({ keyed: false });
+    const res = driveMcp([call(1, 'node9_status'), call(2, 'node9_shield_list')], h);
+    const status = res[1]?.result?.content?.[0]?.text ?? '';
+    expect(status).not.toContain('Policy source: workspace config');
+    expect(status).not.toContain('ignored (workspace config governs)');
+    const list = res[2]?.result?.content?.[0]?.text ?? '';
+    const fsLine = list.split('\n').find((l) => l.includes('filesystem')) ?? '';
+    expect(fsLine).toContain('[active]');
+    expect(list).not.toContain('workspace config governs');
+  });
+});

--- a/src/__tests__/keyed-replace.spec.ts
+++ b/src/__tests__/keyed-replace.spec.ts
@@ -1,0 +1,715 @@
+// src/__tests__/keyed-replace.spec.ts
+// PR-2 "replace-mode" §K — keyed behavior per policy family
+// (doc/roadmap/active/one-config-pr2-test-matrix.md).
+//
+// THE LAW UNDER TEST: a KEYED machine (credentials.json apiKey present, not
+// localOnly) builds POLICY from DEFAULT_CONFIG ⊕ the cloud cache
+// (rules-cache.json) ONLY. Local config.json / node9.config.json policy is
+// INERT; operational settings still apply. Unkeyed keeps today's stack
+// byte-for-byte (unkeyed-parity-golden.spec.ts is the other half).
+//
+// These are UNIT rows at the getConfig() seam — the fork lives entirely in
+// getConfig, so the resolved Config IS the behavior under test. Gate-level
+// keyed coverage lives in the converted suites (taint-review-not-dropped,
+// strict-cloud-allow-bypass, app-permissions, inline-ask-v2-defer).
+//
+// MUTATION PREP (which row kills which core mutant — matrix "global mutation
+// discipline"):
+//   - fork condition inverted / keyed=cache-presence  → K1a + every §U row
+//   - keyed mode routed through resolveManagedMode     → K1c
+//   - keyed dlp routed through applyManagedDlp         → K3b
+//   - keyed egress routed through applyManagedEgress   → K2b/K2c
+//   - keyed pass skips the WHOLE local layer           → K19
+//   - keyed defaults forget approvers.cloud            → K5a
+//   - trustedHostsManaged force forgotten              → K10a
+//   - shields union kept keyed (local ∪ cloud)         → K12a / K9b
+//   - Class-B guard dropped in the keyed pass          → K4d
+//   - NODE9_MODE re-honored keyed                      → K1b
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { ShieldDefinition } from '../shields';
+
+// The shields store paths (shields.json / user shields dir) are module-load
+// consts frozen to the REAL home — a temp-HOME fixture can't move them, so the
+// local-file readers are mocked (same harness as applied-shields.spec.ts).
+// getShield stays hermetic: a test-provided user shadow, else the builtin
+// catalog, never the dev machine's ~/.node9/shields.
+const shieldState = vi.hoisted(() => ({
+  active: [] as string[],
+  overrides: {} as Record<string, Record<string, 'allow' | 'review' | 'block'>>,
+  userShields: {} as Record<string, unknown>,
+}));
+
+vi.mock('../shields', async () => {
+  const actual = await vi.importActual<typeof import('../shields')>('../shields');
+  const engine =
+    await vi.importActual<typeof import('@node9/policy-engine')>('@node9/policy-engine');
+  return {
+    ...actual,
+    readActiveShields: () => shieldState.active,
+    readShieldOverrides: () => shieldState.overrides,
+    getShield: (name: string) =>
+      (shieldState.userShields[name] as ShieldDefinition | undefined) ??
+      engine.BUILTIN_SHIELDS[name] ??
+      null,
+  };
+});
+
+import { getConfig, _resetConfigCache, DEFAULT_CONFIG } from '../config';
+
+describe('§K — keyed replace-mode: policy = DEFAULT_CONFIG ⊕ cloud only', () => {
+  let home: string;
+  let proj: string;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  const ENV_KEYS = ['NODE9_API_KEY', 'NODE9_API_URL', 'NODE9_PROFILE', 'NODE9_MODE'];
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-keyed-'));
+    proj = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-keyed-proj-'));
+    savedEnv.HOME = process.env.HOME;
+    savedEnv.USERPROFILE = process.env.USERPROFILE;
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    for (const k of ENV_KEYS) delete process.env[k];
+    fs.mkdirSync(path.join(home, '.node9'), { recursive: true });
+    shieldState.active = [];
+    shieldState.overrides = {};
+    shieldState.userShields = {};
+    _resetConfigCache();
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v !== undefined) process.env[k] = v;
+      else delete process.env[k];
+    }
+    fs.rmSync(home, { recursive: true, force: true });
+    fs.rmSync(proj, { recursive: true, force: true });
+    _resetConfigCache();
+  });
+
+  /** THE keyed fixture (matrix conventions): credentials.json, default profile,
+   *  no localOnly. File-keyed — the machine-wide channel. */
+  const keyed = () => {
+    fs.writeFileSync(
+      path.join(home, '.node9', 'credentials.json'),
+      JSON.stringify({ default: { apiKey: 'n9_test_matrix' } })
+    );
+  };
+  const writeGlobal = (cfgObj: Record<string, unknown>) => {
+    fs.writeFileSync(
+      path.join(home, '.node9', 'config.json'),
+      JSON.stringify({ version: '1.0', ...cfgObj })
+    );
+  };
+  const writeRepo = (cfgObj: Record<string, unknown>) => {
+    fs.writeFileSync(
+      path.join(proj, 'node9.config.json'),
+      JSON.stringify({ version: '1.0', ...cfgObj })
+    );
+  };
+  const writeCache = (cache: Record<string, unknown>) => {
+    fs.writeFileSync(
+      path.join(home, '.node9', 'rules-cache.json'),
+      JSON.stringify({ fetchedAt: '2026-08-01T00:00:00Z', rules: [], ...cache })
+    );
+  };
+  const mc = (managed: Record<string, unknown>) =>
+    writeCache({ managedConfig: { ...managed, locked: [] } });
+  const cfg = () => {
+    _resetConfigCache();
+    return getConfig(proj);
+  };
+
+  // ── K1 mode ───────────────────────────────────────────────────────────────
+  describe('K1 mode', () => {
+    it('K1a: local strict is policy — keyed with no cache runs the shipped default (standard)', () => {
+      keyed();
+      writeGlobal({ settings: { mode: 'strict' } });
+      const c = cfg();
+      expect(c.settings.mode).toBe('standard');
+      expect(c.policySource).toBe('workspace');
+    });
+
+    it('K1b: NODE9_MODE is ignored when keyed', () => {
+      keyed();
+      process.env.NODE9_MODE = 'observe';
+      mc({});
+      expect(cfg().settings.mode).toBe('standard');
+    });
+
+    it('K1b-twin (unkeyed instrument): NODE9_MODE=observe IS honored without a key', () => {
+      process.env.NODE9_MODE = 'observe';
+      const c = cfg();
+      expect(c.settings.mode).toBe('observe');
+      expect(c.policySource).toBe('local');
+    });
+
+    it('K1c: cloud observe applies VERBATIM keyed (was impossible under the floor)', () => {
+      keyed();
+      mc({ mode: 'observe' });
+      // Mutation kill: routing the keyed mode through resolveManagedMode floors
+      // this back to 'standard' (the seeded default counts as a local opinion).
+      expect(cfg().settings.mode).toBe('observe');
+    });
+
+    it('K1d: managed strict + a repo requireApproval:false escape — the escape is inert (environments={})', () => {
+      keyed();
+      mc({ mode: 'strict' });
+      writeRepo({ environments: { development: { requireApproval: false } } });
+      const c = cfg();
+      expect(c.settings.mode).toBe('strict');
+      expect(c.environments).toEqual({});
+    });
+
+    it('K1e: shadowMode stays absolute — forces observe over a managed strict', () => {
+      keyed();
+      writeCache({ shadowMode: true, managedConfig: { mode: 'strict', locked: [] } });
+      expect(cfg().settings.mode).toBe('observe');
+    });
+
+    it('K1f: panicMode from the cache lands on settings (orchestrator upgrades review→block)', () => {
+      keyed();
+      writeCache({ panicMode: true });
+      expect(cfg().settings.panicMode).toBe(true);
+    });
+  });
+
+  // ── K2 egress ─────────────────────────────────────────────────────────────
+  describe('K2 egress', () => {
+    it('K2a: a pre-login local egress lock goes inert at login — cloud-silent = DEFAULT (disabled)', () => {
+      keyed();
+      writeGlobal({
+        policy: { egress: { enabled: true, mode: 'block', deny: ['evil.com'] } },
+      });
+      mc({});
+      const c = cfg();
+      expect(c.policy.egress).toEqual({
+        enabled: false,
+        mode: 'review',
+        allow: [],
+        deny: [],
+        allowPrivate: true,
+      });
+    });
+
+    it("K2b: cloud egress mode 'off' applies verbatim keyed", () => {
+      keyed();
+      mc({ egress: { enabled: true, mode: 'off' } });
+      const c = cfg();
+      expect(c.policy.egress.enabled).toBe(true);
+      expect(c.policy.egress.mode).toBe('off');
+    });
+
+    it('K2c: local allow entries never union into the cloud allowlist', () => {
+      keyed();
+      writeGlobal({ policy: { egress: { enabled: true, mode: 'block', allow: ['mine.dev'] } } });
+      mc({ egress: { enabled: true, mode: 'block', allow: ['api.corp.com'] } });
+      // Mutation kill: keeping the local applyLayer for egress unions mine.dev in.
+      expect(cfg().policy.egress.allow).toEqual(['api.corp.com']);
+    });
+
+    it('K2d: deny unions with DEFAULT ([]) — never with the local list', () => {
+      keyed();
+      writeGlobal({ policy: { egress: { enabled: true, deny: ['a.com'] } } });
+      mc({ egress: { enabled: true, deny: ['b.com'] } });
+      expect(cfg().policy.egress.deny).toEqual(['b.com']);
+    });
+
+    it('K2e: local allowPrivate:false dropped; cloud-silent = DEFAULT true; cloud false lands', () => {
+      keyed();
+      writeGlobal({ policy: { egress: { allowPrivate: false } } });
+      mc({ egress: { enabled: true } });
+      expect(cfg().policy.egress.allowPrivate).toBe(true);
+      mc({ egress: { enabled: true, allowPrivate: false } });
+      expect(cfg().policy.egress.allowPrivate).toBe(false);
+    });
+  });
+
+  // ── K3 dlp ────────────────────────────────────────────────────────────────
+  describe('K3 dlp', () => {
+    it('K3a: local dlp off is dropped — cloud-silent = DEFAULT ON (replace-mode TIGHTENS here)', () => {
+      keyed();
+      writeGlobal({ policy: { dlp: { enabled: false } } });
+      mc({});
+      expect(cfg().policy.dlp.enabled).toBe(true);
+    });
+
+    it('K3b: cloud dlp.enabled:false WORKS keyed (X-12 — was impossible under the force-on floor)', () => {
+      keyed();
+      mc({ dlp: { enabled: false } });
+      // Mutation kill: routing keyed dlp through applyManagedDlp force-on keeps it true.
+      expect(cfg().policy.dlp.enabled).toBe(false);
+    });
+
+    it("K3c: cloud pii 'block' replaces verbatim", () => {
+      keyed();
+      mc({ dlp: { enabled: true, pii: 'block' } });
+      expect(cfg().policy.dlp.pii).toBe('block');
+    });
+
+    it('K3d: scanIgnoredTools is cloud-inexpressible — local false falls to DEFAULT true', () => {
+      keyed();
+      writeGlobal({ policy: { dlp: { scanIgnoredTools: false } } });
+      expect(cfg().policy.dlp.scanIgnoredTools).toBe(true);
+    });
+
+    it("K3e: cloud reviewAction 'block' replaces verbatim", () => {
+      keyed();
+      mc({ dlp: { reviewAction: 'block' } });
+      expect(cfg().policy.dlp.reviewAction).toBe('block');
+    });
+  });
+
+  // ── K4 commandChecks ──────────────────────────────────────────────────────
+  describe('K4 commandChecks', () => {
+    it('K4a: local knobs dropped both directions; review-rm advisory injected at review', () => {
+      keyed();
+      writeGlobal({ policy: { commandChecks: { chmod: 'off', inlineExec: 'block' } } });
+      const c = cfg();
+      expect(c.policy.commandChecks?.chmod).toBeUndefined();
+      expect(c.policy.commandChecks?.inlineExec).toBeUndefined();
+      const rm = c.policy.smartRules.find((r) => r.name === 'review-rm');
+      expect(rm?.verdict).toBe('review');
+    });
+
+    it("K4b: cloud Class-A 'off' applies verbatim — the 3 -sql advisories are NOT injected", () => {
+      keyed();
+      mc({ commandChecks: { sqlDdl: 'off' } });
+      const names = cfg().policy.smartRules.map((r) => r.name);
+      expect(names).not.toContain('review-drop-table-sql');
+      expect(names).not.toContain('review-truncate-sql');
+      expect(names).not.toContain('review-drop-column-sql');
+    });
+
+    it("K4c: cloud rmAdvisory 'block' escalates the injected advisory, pinned", () => {
+      keyed();
+      mc({ commandChecks: { rmAdvisory: 'block' } });
+      const rm = cfg().policy.smartRules.find((r) => r.name === 'review-rm');
+      expect(rm?.verdict).toBe('block');
+      expect(rm?.pinned).toBe(true);
+    });
+
+    it("K4d: a hostile hand-edited cache cannot set a Class-B key to 'off'", () => {
+      keyed();
+      mc({ commandChecks: { evalDynamic: 'off' } });
+      // Mutation kill: dropping the Class-B guard in the keyed pass lands 'off'.
+      expect(cfg().policy.commandChecks?.evalDynamic).not.toBe('off');
+    });
+  });
+
+  // ── K5 approvers / reviewChannel / timeout ────────────────────────────────
+  describe('K5 approvers / reviewChannel / timeout', () => {
+    it('K5a: keyed default approvers.cloud=true — with AND without the local login-v2 seed', () => {
+      keyed();
+      writeGlobal({ settings: { approvers: { cloud: true } } }); // the login seed (local, ignored)
+      expect(cfg().settings.approvers.cloud).toBe(true);
+      // Mutation kill (§0.3): a keyed pass starting from plain DEFAULT_CONFIG
+      // has cloud:false when NO local seed exists — audit shipping goes dark.
+      writeGlobal({ settings: {} });
+      expect(cfg().settings.approvers.cloud).toBe(true);
+    });
+
+    it('K5b: cloud approvers replace per-field over the keyed defaults', () => {
+      keyed();
+      mc({ approvers: { terminal: false } });
+      expect(cfg().settings.approvers).toEqual({
+        native: true,
+        browser: false,
+        cloud: true,
+        terminal: false,
+      });
+    });
+
+    it('K5c: local reviewChannel dropped; cloud-silent = unset (smart default)', () => {
+      keyed();
+      writeGlobal({ settings: { reviewChannel: 'approver' } });
+      const c = cfg();
+      expect(c.settings.reviewChannel).toBeUndefined();
+      expect(c.settings.reviewChannelManaged).not.toBe(true);
+    });
+
+    it("K5d: cloud reviewChannel 'ask' applies + is marked managed", () => {
+      keyed();
+      mc({ reviewChannel: 'ask' });
+      const c = cfg();
+      expect(c.settings.reviewChannel).toBe('ask');
+      expect(c.settings.reviewChannelManaged).toBe(true);
+    });
+
+    it('K5e: local timeout alias ignored; a cloud 0 is rejected — DEFAULT 120000 stands', () => {
+      keyed();
+      writeGlobal({ settings: { approvalTimeoutSeconds: 30 } });
+      mc({ approvalTimeoutMs: 0 });
+      expect(cfg().settings.approvalTimeoutMs).toBe(120_000);
+    });
+  });
+
+  // ── K6-K8 injectionScan / loopDetection / skillPinning ────────────────────
+  describe('K6-K8 detections', () => {
+    it('K6a: local injectionScan opt-in dropped — cloud-silent = DEFAULT off (a keyed LOOSENING, deliberate)', () => {
+      keyed();
+      writeGlobal({ policy: { injectionScan: { enabled: true } } });
+      expect(cfg().policy.injectionScan.enabled).toBe(false);
+    });
+
+    it('K6b: cloud injectionScan applies verbatim', () => {
+      keyed();
+      mc({ injectionScan: { enabled: true, minConfidence: 'high', allow: ['webfetch'] } });
+      expect(cfg().policy.injectionScan).toEqual({
+        enabled: true,
+        minConfidence: 'high',
+        allow: ['webfetch'],
+      });
+    });
+
+    it('K7a: local loopDetection off dropped — DEFAULT on 5/120 (tightening direction)', () => {
+      keyed();
+      writeGlobal({ policy: { loopDetection: { enabled: false } } });
+      expect(cfg().policy.loopDetection).toEqual({
+        enabled: true,
+        threshold: 5,
+        windowSeconds: 120,
+      });
+    });
+
+    it('K7b: cloud loopDetection off applies verbatim', () => {
+      keyed();
+      mc({ loopDetection: { enabled: false } });
+      expect(cfg().policy.loopDetection.enabled).toBe(false);
+    });
+
+    it('K8a: local skillPinning roots never union keyed — cloud roots only', () => {
+      keyed();
+      writeGlobal({ policy: { skillPinning: { enabled: true, roots: ['/x'] } } });
+      mc({ skillPinning: { enabled: true, mode: 'block', roots: ['/y'] } });
+      const c = cfg();
+      expect(c.policy.skillPinning.roots).toEqual(['/y']);
+      expect(c.policy.skillPinning.mode).toBe('block');
+    });
+  });
+
+  // ── K9 jailPaths ──────────────────────────────────────────────────────────
+  describe('K9 jailPaths', () => {
+    it('K9a: cloud jailPaths land as managedJailPaths + org:-prefixed rules', () => {
+      keyed();
+      mc({ jailPaths: [{ path: '~/.aws', verdict: 'block' }] });
+      const c = cfg();
+      expect(c.policy.managedJailPaths).toEqual([{ path: '~/.aws', verdict: 'block' }]);
+      expect(c.policy.smartRules.some((r) => r.name?.startsWith('org:'))).toBe(true);
+    });
+
+    it('K9b: a pre-login local user-jail is dead keyed (unkeyed instrument row first)', () => {
+      // The local jail shield exists and is enabled locally.
+      shieldState.active = ['user-jail'];
+      shieldState.userShields['user-jail'] = {
+        name: 'user-jail',
+        description: 'user jail',
+        aliases: [],
+        smartRules: [
+          {
+            name: 'user-jail:block-secrets',
+            tool: '*',
+            conditions: [{ field: 'file_path', op: 'contains', value: '/secrets/' }],
+            conditionMode: 'all',
+            verdict: 'block',
+            reason: 'jailed path',
+          },
+        ],
+        dangerousWords: [],
+      };
+      // INSTRUMENT (known-true) row: unkeyed, the jail shield applies.
+      const before = cfg();
+      expect(before.policy.appliedShields).toContain('user-jail');
+      expect(before.policy.smartRules.some((r) => r.name === 'user-jail:block-secrets')).toBe(true);
+      // Same fixture + a key: the local jail contributes NOTHING (guard-arming
+      // reads appliedShields ∪ managedJailPaths — both empty here, §0.4).
+      keyed();
+      const after = cfg();
+      expect(after.policy.appliedShields).toEqual([]);
+      expect(after.policy.smartRules.some((r) => r.name === 'user-jail:block-secrets')).toBe(false);
+      expect(after.policy.managedJailPaths).toEqual([]);
+    });
+  });
+
+  // ── K10-K11 trustedHosts / appPermissions ─────────────────────────────────
+  describe('K10-K11 trustedHosts / appPermissions', () => {
+    it('K10a: keyed forces trustedHostsManaged=true with an empty list — the local trust file is never consulted', () => {
+      keyed();
+      // Pre-login `node9 trust add evil.exfil.com` artifact:
+      fs.writeFileSync(
+        path.join(home, '.node9', 'trusted-hosts.json'),
+        JSON.stringify({ hosts: ['evil.exfil.com'] })
+      );
+      const c = cfg();
+      // Mutation kill: forgetting the force leaves managed=false → the policy
+      // hook falls back to the fresh local-file read → downgrade leaks through.
+      expect(c.policy.trustedHostsManaged).toBe(true);
+      expect(c.policy.trustedHosts).toEqual([]);
+    });
+
+    it('K10b: cloud trustedHosts are normalized (scheme/port stripped) and managed', () => {
+      keyed();
+      mc({ trustedHosts: ['https://api.co:443'] });
+      const c = cfg();
+      expect(c.policy.trustedHosts).toEqual(['api.co']);
+      expect(c.policy.trustedHostsManaged).toBe(true);
+    });
+
+    it('K11a: cloud appPermissions apply keyed (gateway enforcement pinned in app-permissions.spec.ts)', () => {
+      keyed();
+      mc({ appPermissions: { ghKey: { delete_repo: 'block' } } });
+      expect(cfg().policy.appPermissions).toEqual({ ghKey: { delete_repo: 'block' } });
+    });
+
+    it('K11b: cloud-silent appPermissions = {} — there is no local layer to miss', () => {
+      keyed();
+      writeGlobal({ policy: { appPermissions: { local: { x: 'allow' } } } }); // never merged
+      mc({});
+      expect(cfg().policy.appPermissions).toEqual({});
+    });
+  });
+
+  // ── K12 shields ───────────────────────────────────────────────────────────
+  describe('K12 shields', () => {
+    it('K12a: keyed runs the CLOUD-mandated shields only; local enables and overrides are inert', () => {
+      keyed();
+      shieldState.active = ['filesystem']; // local enable — must contribute nothing
+      shieldState.overrides = { redis: { 'shield:redis:block-flushall': 'allow' } }; // local weaken attempt
+      writeCache({ shields: ['redis'] });
+      const c = cfg();
+      // Mutation kill: keeping the local∪cloud union keyed lists filesystem too.
+      expect(c.policy.appliedShields).toEqual(['redis']);
+      expect(c.policy.smartRules.some((r) => r.name?.startsWith('shield:filesystem:'))).toBe(false);
+      const flushall = c.policy.smartRules.find((r) => r.name === 'shield:redis:block-flushall');
+      expect(flushall?.verdict).toBe('block'); // the override never applied to a mandate
+      expect(flushall?.pinned).toBe(true);
+    });
+
+    it('K12b: a user shadow of a mandated shield is ignored — BUILTIN body enforced (B1)', () => {
+      keyed();
+      shieldState.userShields['redis'] = {
+        name: 'redis',
+        description: 'all-allow shadow',
+        aliases: [],
+        smartRules: [
+          {
+            name: 'shield:redis:block-flushall',
+            tool: '*',
+            conditions: [],
+            conditionMode: 'all',
+            verdict: 'allow',
+            reason: 'weakened',
+          },
+        ],
+        dangerousWords: [],
+      };
+      writeCache({ shields: ['redis'] });
+      const c = cfg();
+      const flushall = c.policy.smartRules.find((r) => r.name === 'shield:redis:block-flushall');
+      expect(flushall?.verdict).toBe('block');
+      expect(
+        c.policy.smartRules.filter((r) => r.name === 'shield:redis:block-flushall')
+      ).toHaveLength(1);
+    });
+
+    it('K12c: an unknown mandated shield fails CLOSED (dropped) without throwing', () => {
+      keyed();
+      writeCache({ shields: ['redis', 'not-a-shield'] });
+      expect(cfg().policy.appliedShields).toEqual(['redis']);
+    });
+  });
+
+  // ── K13 smartRules ────────────────────────────────────────────────────────
+  describe('K13 smartRules', () => {
+    it('K13a: a local same-name override of a DEFAULT rule is dead — the default is restored (STRICTER keyed)', () => {
+      keyed();
+      writeGlobal({
+        policy: {
+          smartRules: [
+            {
+              name: 'review-sudo',
+              tool: 'bash',
+              conditions: [{ field: 'command', op: 'matches', value: '\\bsudo\\s' }],
+              conditionMode: 'all',
+              verdict: 'allow',
+              reason: 'local defeat attempt',
+            },
+          ],
+        },
+      });
+      const sudo = cfg().policy.smartRules.filter((r) => r.name === 'review-sudo');
+      expect(sudo).toHaveLength(1);
+      expect(sudo[0].verdict).toBe('review');
+    });
+
+    it('K13b: a repo-carried block rule is fully inert keyed', () => {
+      keyed();
+      writeRepo({
+        policy: {
+          smartRules: [
+            {
+              name: 'repo-block-x',
+              tool: 'bash',
+              conditions: [{ field: 'command', op: 'contains', value: 'xyz' }],
+              conditionMode: 'all',
+              verdict: 'block',
+              reason: 'repo rule',
+            },
+          ],
+        },
+      });
+      expect(cfg().policy.smartRules.some((r) => r.name === 'repo-block-x')).toBe(false);
+    });
+
+    // The cloud cache's `rules` array routes through applyLayer, and the PR-2
+    // fork's keyed gate initially swallowed it — a KEYED machine dropped every
+    // workspace smart rule (found as an it.fails pin while writing this
+    // matrix). Fixed by the isCloud flag: the cloud layer is the one applyLayer
+    // caller that passes the gate. Mutation twin: reverting `keyed && !isCloud`
+    // to `keyed` kills this row.
+    it('K13c: cloud cache rules are enforced keyed', () => {
+      keyed();
+      writeCache({
+        rules: [
+          {
+            name: 'org-block-x',
+            tool: 'bash',
+            conditions: [{ field: 'command', op: 'contains', value: 'xyz' }],
+            conditionMode: 'all',
+            verdict: 'block',
+            reason: 'org rule',
+          },
+        ],
+      });
+      expect(cfg().policy.smartRules.some((r) => r.name === 'org-block-x')).toBe(true);
+    });
+
+    it('K13c-instrument: the same cache rules DO apply unkeyed (known-true witness)', () => {
+      writeCache({
+        rules: [
+          {
+            name: 'org-block-x',
+            tool: 'bash',
+            conditions: [{ field: 'command', op: 'contains', value: 'xyz' }],
+            conditionMode: 'all',
+            verdict: 'block',
+            reason: 'org rule',
+          },
+        ],
+      });
+      expect(cfg().policy.smartRules.some((r) => r.name === 'org-block-x')).toBe(true);
+    });
+  });
+
+  // ── K14-K18 cloud-inexpressible families fall to DEFAULT ──────────────────
+  describe('K14-K18 cloud-inexpressible families', () => {
+    it('K14: local ignoredTools additions dropped — DEFAULT list only', () => {
+      keyed();
+      writeGlobal({ policy: { ignoredTools: ['bash'] } });
+      mc({ egress: { enabled: true, mode: 'block' } });
+      const c = cfg();
+      expect(c.policy.ignoredTools).not.toContain('bash');
+      expect(c.policy.ignoredTools).toEqual(
+        expect.arrayContaining(DEFAULT_CONFIG.policy.ignoredTools)
+      );
+    });
+
+    it('K15: local sandboxPaths additions dropped — DEFAULT only', () => {
+      keyed();
+      writeGlobal({ policy: { sandboxPaths: ['/**'] } });
+      expect(cfg().policy.sandboxPaths).not.toContain('/**');
+    });
+
+    it('K16: local dangerousWords weakening replace ([]) is dead — DEFAULT words restored', () => {
+      keyed();
+      writeGlobal({ policy: { dangerousWords: [] } });
+      expect(cfg().policy.dangerousWords).toContain('mkfs');
+    });
+
+    it('K17: local toolInspection mapping is a permanent, cloud-inexpressible loss (pinned deliberate, §0.15)', () => {
+      keyed();
+      writeGlobal({ policy: { toolInspection: { 'my_db:query': 'sql' } } });
+      expect(cfg().policy.toolInspection['my_db:query']).toBeUndefined();
+    });
+
+    it('K18: local environments + settings.environment are gone keyed', () => {
+      keyed();
+      writeGlobal({
+        settings: { environment: 'production' },
+        environments: { production: { requireApproval: true } },
+      });
+      const c = cfg();
+      expect(c.environments).toEqual({});
+      expect(c.settings.environment).toBeUndefined();
+    });
+  });
+
+  // ── K19 operational pass stays local ──────────────────────────────────────
+  describe('K19 operational settings', () => {
+    it('K19: operational knobs keep working keyed — the fork SPLITS applyLayer, it does not skip it', () => {
+      keyed();
+      writeGlobal({
+        settings: {
+          autoStartDaemon: false,
+          enableHookLogDebug: false,
+          shipper: { intervalSeconds: 99 },
+          mcpReconcileIntervalMinutes: 30,
+        },
+      });
+      const c = cfg();
+      // Mutation kill: skipping the whole local layer loses all four.
+      expect(c.settings.autoStartDaemon).toBe(false);
+      expect(c.settings.enableHookLogDebug).toBe(false);
+      expect(c.settings.shipper.intervalSeconds).toBe(99);
+      expect(c.settings.mcpReconcileIntervalMinutes).toBe(30);
+      // (settings.hud is stripped by the config schema before the merge — it is
+      // not exercisable through a config file; not asserted here.)
+    });
+  });
+
+  // ── keyedness detection (the --local promise, profiles, env keys) ─────────
+  describe('keyedness detection', () => {
+    it('localOnly credentials (`login --local`) keep FULL local behavior (§0.1 — the printed promise)', () => {
+      fs.writeFileSync(
+        path.join(home, '.node9', 'credentials.json'),
+        JSON.stringify({ default: { apiKey: 'n9_local_key', localOnly: true } })
+      );
+      writeGlobal({ settings: { mode: 'strict' } });
+      const c = cfg();
+      expect(c.settings.mode).toBe('strict');
+      expect(c.policySource).toBe('local');
+    });
+
+    it('a NAMED profile key is localOnly-for-policy (§0.11 — profiles never policy-sync)', () => {
+      fs.writeFileSync(
+        path.join(home, '.node9', 'credentials.json'),
+        JSON.stringify({ work: { apiKey: 'n9_work_key' } })
+      );
+      process.env.NODE9_PROFILE = 'work';
+      writeGlobal({ settings: { mode: 'strict' } });
+      const c = cfg();
+      expect(c.settings.mode).toBe('strict');
+      expect(c.policySource).toBe('local');
+    });
+
+    it('an ENV key (CI) is fully keyed — no localOnly channel', () => {
+      process.env.NODE9_API_KEY = 'n9_ci_key';
+      writeGlobal({ settings: { mode: 'strict' } });
+      const c = cfg();
+      expect(c.settings.mode).toBe('standard');
+      expect(c.policySource).toBe('workspace');
+    });
+
+    it('policySource: workspace when keyed, local when unkeyed', () => {
+      expect(cfg().policySource).toBe('local');
+      keyed();
+      expect(cfg().policySource).toBe('workspace');
+    });
+  });
+});

--- a/src/__tests__/keyed-review-fixes.spec.ts
+++ b/src/__tests__/keyed-review-fixes.spec.ts
@@ -1,0 +1,178 @@
+// src/__tests__/keyed-review-fixes.spec.ts
+// Regression rows for the PR-2 ADVERSARIAL REVIEW findings (2026-08-30).
+// Every row here failed before its fix — that is the whole point of the file.
+//
+//   F3 — `shield create --enable` wrote shields.json and printed "Active now."
+//        on a workspace-governed machine while enforcing nothing (the write
+//        guard's enumeration missed `create`).
+//   F5 — `status` / `config show` rendered `observe` as "standard" via an
+//        `else → standard` ternary. PR-2 made it load-bearing: a keyed machine
+//        applies a cloud `observe` VERBATIM, so the one surface people check
+//        reported the opposite of the truth on a machine enforcing nothing.
+//   F8 — the keyed commandChecks branch iterated whatever keys the cache
+//        carried instead of the known list, so a hand-edited cache could seed
+//        arbitrary keys into the policy object.
+//
+// MUTATION PREP:
+//   - guard dropped from `shield create`            → F3 refusal + store rows
+//   - `--enable` guard widened to the whole command → F3 authoring row
+//   - observe branch removed from either ternary    → the two F5 rows
+//   - keyed commandChecks back to Object.entries    → F8 unknown-key row
+//
+// F1/F2/F4 (keyedness and the cache are decided from attacker-writable local
+// inputs) are NOT covered here: the fix is a founder decision plus a
+// server-side change, tracked in enforcement-one-config-design.md.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { keySafeEnv, writeKeyedHome } from './helpers/env';
+import { getConfig, _resetConfigCache } from '../config';
+
+const CLI = path.resolve(__dirname, '../../dist/cli.js');
+
+function runCli(home: string, args: string[]): { status: number | null; out: string } {
+  const r = spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf-8',
+    timeout: 60000,
+    cwd: home,
+    env: keySafeEnv({
+      HOME: home,
+      USERPROFILE: home,
+      NODE9_NO_AUTO_DAEMON: '1',
+      NODE9_TESTING: '1',
+      NO_COLOR: '1',
+    }),
+  });
+  expect(r.error).toBeUndefined();
+  return { status: r.status, out: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+}
+
+/** Keyed home whose WORKSPACE mandates the given managedConfig. */
+function makeKeyedHome(managed: Record<string, unknown> = {}): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-rev-'));
+  fs.mkdirSync(path.join(home, '.node9'), { recursive: true });
+  writeKeyedHome(home);
+  fs.writeFileSync(
+    path.join(home, '.node9', 'rules-cache.json'),
+    JSON.stringify({
+      fetchedAt: '2026-08-01T00:00:00Z',
+      rules: [],
+      shields: [],
+      managedConfig: { locked: [], ...managed },
+    })
+  );
+  return home;
+}
+
+const homes: string[] = [];
+afterAll(() => {
+  for (const h of homes) fs.rmSync(h, { recursive: true, force: true });
+});
+function keyedHome(managed?: Record<string, unknown>): string {
+  const h = makeKeyedHome(managed);
+  homes.push(h);
+  return h;
+}
+
+// ── F3 — shield create --enable is a policy write ────────────────────────────
+describe('F3 — `shield create --enable` is guarded', () => {
+  it('refuses --enable on a workspace-governed machine and writes NO enable store', () => {
+    const home = keyedHome();
+    const r = runCli(home, [
+      'shield',
+      'create',
+      'revshield',
+      '--block-tool',
+      'nothing',
+      '--enable',
+    ]);
+    expect(r.status).not.toBe(0);
+    expect(r.out).toMatch(/workspace configuration/i);
+    // The bug's signature was a green exit plus this line.
+    expect(r.out).not.toMatch(/Active now/i);
+    expect(fs.existsSync(path.join(home, '.node9', 'shields.json'))).toBe(false);
+  });
+
+  it('still allows AUTHORING without --enable (only the enable half is a write)', () => {
+    const home = keyedHome();
+    const r = runCli(home, ['shield', 'create', 'draftshield', '--block-tool', 'nothing']);
+    expect(r.status).toBe(0);
+    expect(fs.existsSync(path.join(home, '.node9', 'shields', 'draftshield.json'))).toBe(true);
+    // Authoring must not enable it either.
+    expect(fs.existsSync(path.join(home, '.node9', 'shields.json'))).toBe(false);
+  });
+
+  it('unkeyed instrument: the same --enable command works and enables (known-true)', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-rev-unkeyed-'));
+    homes.push(home);
+    fs.mkdirSync(path.join(home, '.node9'), { recursive: true });
+    const r = runCli(home, ['shield', 'create', 'okshield', '--block-tool', 'nothing', '--enable']);
+    expect(r.status).toBe(0);
+    const active = JSON.parse(
+      fs.readFileSync(path.join(home, '.node9', 'shields.json'), 'utf-8')
+    ) as { active: string[] };
+    expect(active.active).toContain('okshield');
+  });
+});
+
+// ── F5 — observe must never render as "standard" ─────────────────────────────
+describe('F5 — a machine enforcing nothing says so', () => {
+  it('`status` names observe when the workspace mandates it', () => {
+    const home = keyedHome({ mode: 'observe' });
+    const r = runCli(home, ['status']);
+    expect(r.out).toMatch(/Mode:\s+observe/);
+    expect(r.out).not.toMatch(/Mode:\s+standard/);
+  });
+
+  it('`config show` names observe too (the second copy of the ternary)', () => {
+    const home = keyedHome({ mode: 'observe' });
+    const r = runCli(home, ['config', 'show']);
+    expect(r.out).toMatch(/Mode:\s+observe/);
+    expect(r.out).not.toMatch(/Mode:\s+standard/);
+  });
+
+  it('instrument: a standard workspace still renders standard on both surfaces', () => {
+    const home = keyedHome({ mode: 'standard' });
+    expect(runCli(home, ['status']).out).toMatch(/Mode:\s+standard/);
+    expect(runCli(home, ['config', 'show']).out).toMatch(/Mode:\s+standard/);
+  });
+});
+
+// ── F8 — the keyed commandChecks branch only reads KNOWN keys ────────────────
+describe('F8 — a hand-edited cache cannot seed unknown commandChecks keys', () => {
+  const saved: Record<string, string | undefined> = {};
+  let home: string;
+
+  beforeAll(() => {
+    home = keyedHome({
+      commandChecks: { inlineExec: 'block', notARealCheck: 'off', anotherFake: 'block' },
+    });
+    saved.HOME = process.env.HOME;
+    saved.USERPROFILE = process.env.USERPROFILE;
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    _resetConfigCache();
+  });
+
+  afterAll(() => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v !== undefined) process.env[k] = v;
+      else delete process.env[k];
+    }
+    _resetConfigCache();
+  });
+
+  it('applies the known key and drops the invented ones', () => {
+    const cc = getConfig().policy.commandChecks ?? {};
+    expect(cc.inlineExec).toBe('block');
+    expect(Object.keys(cc)).not.toContain('notARealCheck');
+    expect(Object.keys(cc)).not.toContain('anotherFake');
+  });
+
+  it('Class-B still cannot be turned off through the keyed branch', () => {
+    expect(getConfig().policy.commandChecks?.evalDynamic).not.toBe('off');
+  });
+});

--- a/src/__tests__/keyed-sync-bootstrap.spec.ts
+++ b/src/__tests__/keyed-sync-bootstrap.spec.ts
@@ -1,0 +1,286 @@
+// src/__tests__/keyed-sync-bootstrap.spec.ts
+// PR-2 "replace-mode" §S — sync / cache / bootstrap / transitions
+// (doc/roadmap/active/one-config-pr2-test-matrix.md).
+//
+// In-process rows at the getConfig() seam. The login/logout transition rows
+// (S5/S6) model the daemon's own behavior: daemon/server.ts calls
+// _resetConfigCache at the top of every POST /check ("Always read fresh
+// config"), so a credentials.json write/delete lands on the NEXT decision.
+//
+// NOT implemented here (needs live processes / the pending §0.10 fix):
+//   S7  — mcp-gateway staleness across login/logout: the gateway never resets
+//         the ambient config cache today; the row FAILS pre-fix by design and
+//         belongs with the gateway fix, not in a green suite.
+//   S8  — `node9 connect` first-sync-synchronous: onboarding integration with
+//         a mock cloud (connect.integration territory).
+//   S12 — `--local` daemon sync tick skips the policy PULL but keeps audit
+//         shipping: daemon sync loop integration (sync.test territory).
+//
+// MUTATION PREP: S1/S2 kill `keyed = rules-cache exists` (creds with NO cache
+// must still be workspace-sourced); S5/S6/S9 kill any keyedness memoization
+// that survives _resetConfigCache; S3/S4 kill "keyed pass bypasses
+// readRulesCacheResilient"; S11 kills "keyed falls back to LOCAL when the
+// cache disappears" (it must fall to SHIPPED DEFAULTS).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { ShieldDefinition } from '../shields';
+
+// Shields store paths are module-load consts frozen to the real home; mock the
+// local-file readers (applied-shields.spec.ts harness) so S13's unkeyed twin
+// can control the local enable list.
+const shieldState = vi.hoisted(() => ({
+  active: [] as string[],
+  overrides: {} as Record<string, Record<string, 'allow' | 'review' | 'block'>>,
+  userShields: {} as Record<string, unknown>,
+}));
+
+vi.mock('../shields', async () => {
+  const actual = await vi.importActual<typeof import('../shields')>('../shields');
+  const engine =
+    await vi.importActual<typeof import('@node9/policy-engine')>('@node9/policy-engine');
+  return {
+    ...actual,
+    readActiveShields: () => shieldState.active,
+    readShieldOverrides: () => shieldState.overrides,
+    getShield: (name: string) =>
+      (shieldState.userShields[name] as ShieldDefinition | undefined) ??
+      engine.BUILTIN_SHIELDS[name] ??
+      null,
+  };
+});
+
+import { getConfig, _resetConfigCache, __resetRulesCacheStateForTest } from '../config';
+import { readActiveShields, readShieldOverrides } from '../shields';
+import { buildPolicySnapshot } from '../policy-snapshot/build';
+
+describe('§S — sync / cache / bootstrap / transitions', () => {
+  let home: string;
+  let proj: string;
+  const savedEnv: Record<string, string | undefined> = {};
+  const ENV_KEYS = ['NODE9_API_KEY', 'NODE9_API_URL', 'NODE9_PROFILE', 'NODE9_MODE'];
+
+  const credsPath = () => path.join(home, '.node9', 'credentials.json');
+  const cachePath = () => path.join(home, '.node9', 'rules-cache.json');
+  const backupPath = () => path.join(home, '.node9', 'rules-cache.last-good.json');
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-sboot-'));
+    proj = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-sboot-proj-'));
+    savedEnv.HOME = process.env.HOME;
+    savedEnv.USERPROFILE = process.env.USERPROFILE;
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    for (const k of ENV_KEYS) delete process.env[k];
+    fs.mkdirSync(path.join(home, '.node9'), { recursive: true });
+    shieldState.active = [];
+    shieldState.overrides = {};
+    shieldState.userShields = {};
+    _resetConfigCache();
+    __resetRulesCacheStateForTest(); // memo + log rate-limit are process state
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v !== undefined) process.env[k] = v;
+      else delete process.env[k];
+    }
+    fs.rmSync(home, { recursive: true, force: true });
+    fs.rmSync(proj, { recursive: true, force: true });
+    _resetConfigCache();
+    __resetRulesCacheStateForTest();
+  });
+
+  const keyed = () => {
+    fs.writeFileSync(credsPath(), JSON.stringify({ default: { apiKey: 'n9_test_matrix' } }));
+  };
+  /** A RICH local config — every family sets something non-default, so a
+   *  bootstrap row can prove NONE of it leaks into the keyed policy. */
+  const writeRichLocal = () => {
+    fs.writeFileSync(
+      path.join(home, '.node9', 'config.json'),
+      JSON.stringify({
+        version: '1.0',
+        settings: { mode: 'strict', approvalTimeoutMs: 45_000 },
+        policy: {
+          dlp: { enabled: false },
+          egress: { enabled: true, mode: 'block', deny: ['evil.com'] },
+          ignoredTools: ['bash'],
+          smartRules: [
+            {
+              name: 'local-rule',
+              tool: 'bash',
+              conditions: [{ field: 'command', op: 'contains', value: 'xyz' }],
+              conditionMode: 'all',
+              verdict: 'block',
+              reason: 'local',
+            },
+          ],
+        },
+        environments: { production: { requireApproval: true } },
+      })
+    );
+  };
+  const cfg = () => {
+    _resetConfigCache();
+    return getConfig(proj);
+  };
+
+  const expectShippedDefaults = (c: ReturnType<typeof getConfig>) => {
+    expect(c.policySource).toBe('workspace');
+    expect(c.settings.mode).toBe('standard');
+    expect(c.policy.dlp.enabled).toBe(true);
+    expect(c.policy.egress.enabled).toBe(false);
+    expect(c.policy.appliedShields).toEqual([]);
+    expect(c.policy.smartRules.some((r) => r.name === 'local-rule')).toBe(false);
+    expect(c.policy.ignoredTools).not.toContain('bash');
+    expect(c.environments).toEqual({});
+    expect(c.settings.approvalTimeoutMs).toBe(120_000);
+  };
+
+  it('S1: keyed + NO rules-cache ⇒ SHIPPED DEFAULTS, never the local stack', () => {
+    keyed();
+    writeRichLocal();
+    // Mutation kill: `keyed = cache exists` makes this row resolve the local
+    // stack (strict / dlp off / egress lock) — every assertion below fails.
+    expectShippedDefaults(cfg());
+  });
+
+  it('S2: keyed + EMPTY cache ({} — a zero-policy workspace) ⇒ same shipped defaults', () => {
+    keyed();
+    writeRichLocal();
+    fs.writeFileSync(cachePath(), '{}');
+    expectShippedDefaults(cfg());
+  });
+
+  it('S3: corrupt cache + valid last-good ⇒ the last-good policy is enforced (resilience kept keyed)', () => {
+    keyed();
+    fs.writeFileSync(
+      backupPath(),
+      JSON.stringify({ rules: [], managedConfig: { mode: 'observe', locked: [] } })
+    );
+    fs.writeFileSync(cachePath(), '{"rules": [truncated-mid-wri');
+    expect(cfg().settings.mode).toBe('observe');
+  });
+
+  it('S4: corrupt cache + no backup ⇒ the in-memory memo serves the last-good policy (F4), loudly', () => {
+    keyed();
+    // Prime the memo with a successful read (the long-lived daemon's state).
+    fs.writeFileSync(
+      cachePath(),
+      JSON.stringify({ rules: [], managedConfig: { mode: 'observe', locked: [] } })
+    );
+    expect(cfg().settings.mode).toBe('observe');
+    // Disk turns unreadable: corrupt primary, no backup. _resetConfigCache
+    // does NOT clear the memo (by design — it runs on the enforcement path).
+    fs.writeFileSync(cachePath(), '{"rules": [truncated-mid-wri');
+    expect(cfg().settings.mode).toBe('observe');
+    const log = fs.readFileSync(path.join(home, '.node9', 'hook-debug.log'), 'utf-8');
+    expect(log).toContain('RULES_CACHE_USED_MEMORY');
+  });
+
+  it('S5: login mid-process — credentials written between reads land on the NEXT decision', () => {
+    writeRichLocal();
+    // Decision 1 (unkeyed): the local stack governs.
+    const before = cfg();
+    expect(before.policySource).toBe('local');
+    expect(before.settings.mode).toBe('strict');
+    // login writes credentials.json; the daemon resets the cache per check.
+    keyed();
+    const after = cfg();
+    expect(after.policySource).toBe('workspace');
+    expect(after.settings.mode).toBe('standard');
+  });
+
+  it('S6: logout (credentials deleted) — the local stack RESUMES on the next read', () => {
+    writeRichLocal();
+    keyed();
+    expect(cfg().policySource).toBe('workspace');
+    fs.rmSync(credsPath()); // logout.ts removes the profile
+    const after = cfg();
+    expect(after.policySource).toBe('local');
+    expect(after.settings.mode).toBe('strict');
+  });
+
+  it('S9: an ENV key is process-scoped — keyed with it, unkeyed without it (§0.14)', () => {
+    writeRichLocal();
+    process.env.NODE9_API_KEY = 'n9_ci_key';
+    expect(cfg().policySource).toBe('workspace');
+    delete process.env.NODE9_API_KEY;
+    const second = cfg();
+    expect(second.policySource).toBe('local');
+    expect(second.settings.mode).toBe('strict');
+  });
+
+  it('S10: a named-profile key (NODE9_PROFILE) is unkeyed-for-policy (§0.11 — profiles never policy-sync)', () => {
+    writeRichLocal();
+    fs.writeFileSync(credsPath(), JSON.stringify({ work: { apiKey: 'n9_work_key' } }));
+    process.env.NODE9_PROFILE = 'work';
+    const c = cfg();
+    expect(c.policySource).toBe('local');
+    expect(c.settings.mode).toBe('strict');
+  });
+
+  it('S11: deleting the cache mid-run falls to SHIPPED DEFAULTS — never back to local ("key present ⇒ server only")', () => {
+    keyed();
+    writeRichLocal();
+    fs.writeFileSync(
+      cachePath(),
+      JSON.stringify({ rules: [], managedConfig: { mode: 'observe', locked: [] } })
+    );
+    expect(cfg().settings.mode).toBe('observe');
+    fs.rmSync(cachePath());
+    __resetRulesCacheStateForTest(); // ENOENT is "no cloud policy" — the memo only serves corrupt-PRESENT files
+    const after = cfg();
+    // Mutation kill: a fallback to the LOCAL stack would read strict here.
+    expect(after.settings.mode).toBe('standard');
+    expect(after.policySource).toBe('workspace');
+  });
+
+  it("S-classB (K4d twin at the bootstrap seam): a hand-edited cache cannot turn a Class-B check 'off'", () => {
+    keyed();
+    fs.writeFileSync(
+      cachePath(),
+      JSON.stringify({
+        rules: [],
+        managedConfig: { commandChecks: { evalDynamic: 'off', pipeChainHigh: 'off' }, locked: [] },
+      })
+    );
+    const cc = cfg().policy.commandChecks ?? {};
+    expect(cc.evalDynamic).not.toBe('off');
+    expect(cc.pipeChainHigh).not.toBe('off');
+  });
+
+  // ── S13 — the snapshot wire ships what the CONFIG APPLIED (§0.5) ──────────
+  // sync.ts (both push sites) passes `cfg.policy.appliedShields ??
+  // readActiveShields()` into buildPolicySnapshot. These rows pin the wire
+  // field through that exact call shape.
+  it('S13: keyed snapshot ships appliedShields (the cloud mandate), not the local shields file', () => {
+    keyed();
+    shieldState.active = ['filesystem']; // local file lists something else entirely
+    fs.writeFileSync(cachePath(), JSON.stringify({ rules: [], shields: ['redis'] }));
+    const c = cfg();
+    const body = buildPolicySnapshot(c, c.policy.appliedShields ?? readActiveShields(), {});
+    // The fw comparator marks a mandated shield absent from activeShields as
+    // `not-applied` (drift) — shipping the local file here would flag every
+    // correctly-enforcing keyed machine forever.
+    expect(body.activeShields).toEqual(['redis']);
+    expect(body.mode).toBe(c.settings.mode);
+    expect(body.dlpEnabled).toBe(c.policy.dlp.enabled);
+  });
+
+  it('S13-unkeyed twin: the snapshot carries the applied local∪cloud union byte-for-byte', () => {
+    shieldState.active = ['filesystem'];
+    fs.writeFileSync(cachePath(), JSON.stringify({ rules: [], shields: ['redis'] }));
+    const c = cfg();
+    const body = buildPolicySnapshot(
+      c,
+      c.policy.appliedShields ?? readActiveShields(),
+      readShieldOverrides()
+    );
+    expect(body.activeShields).toEqual(['filesystem', 'redis']);
+  });
+});

--- a/src/__tests__/keyed-write-guard.integration.test.ts
+++ b/src/__tests__/keyed-write-guard.integration.test.ts
@@ -1,0 +1,268 @@
+// src/__tests__/keyed-write-guard.integration.test.ts
+// PR-2 §G — the CLI write-guard, end to end (rows G1-G14, G23, G24 of
+// doc/roadmap/active/one-config-pr2-test-matrix.md).
+//
+// Contract per KEYED row: exit code ≠ 0, the refusal names the workspace
+// configuration + the dashboard, and the target store is byte-identical
+// (sha256 of every file under ~/.node9 — the standing sha256-not-diff-stat
+// rule; a refusal may not even CREATE a store). Per UNKEYED row the same
+// command works exactly as today (exit 0, store mutated) — the known-true
+// instruments that make every "refused" row meaningful.
+//
+// Spawns the real dist/cli.js (requires `npm run build`), temp HOME per
+// describe, keyedness by FILE via writeKeyedHome (§0.12 — never by env
+// inheritance).
+//
+// MUTATION PREP:
+//   - guard removed from ONE command family (the gauntlet
+//     lesson: a floor keyed on one mandate type)          → one row per family
+//   - "guard prints but exits 0"                          → status !== 0 rows
+//   - guard checks rules-cache presence, not policySource → keyed-NO-cache row
+//   - guard re-derives keyedness ignoring localOnly       → G23
+//   - guard reads only the creds file, missing env keys   → G24
+//   - refusal still performs the write                    → sha256 snapshots
+//
+// NOT covered here (needs a live daemon / real cloud): none — every §G CLI row
+// is spawnable. MCP rows G15-G21 live in keyed-mcp-guard.integration.test.ts.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'child_process';
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { keySafeEnv, writeKeyedHome } from './helpers/env';
+
+const CLI = path.resolve(__dirname, '../../dist/cli.js');
+
+interface RunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(home: string, args: string[], extraEnv: Record<string, string> = {}): RunResult {
+  const result = spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf-8',
+    timeout: 60000,
+    cwd: home, // never the repo root — its node9.config.json must not leak in
+    env: keySafeEnv({
+      HOME: home,
+      USERPROFILE: home,
+      NODE9_NO_AUTO_DAEMON: '1',
+      NODE9_TESTING: '1',
+      NO_COLOR: '1',
+      ...extraEnv,
+    }),
+  });
+  expect(result.error).toBeUndefined();
+  return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+}
+
+/** sha256 of every file under <home>/.node9, keyed by relative path — the
+ *  refusal contract is "no store changed AND no store appeared". */
+function snapshotStores(home: string): Record<string, string> {
+  const root = path.join(home, '.node9');
+  const out: Record<string, string> = {};
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else
+        out[path.relative(root, p)] = crypto
+          .createHash('sha256')
+          .update(fs.readFileSync(p))
+          .digest('hex');
+    }
+  };
+  walk(root);
+  return out;
+}
+
+/** A keyed home carrying EVERY local policy store the guarded commands target,
+ *  so "byte-identical after refusal" is a real assertion for each family. */
+function makeKeyedHome(opts: { cache?: boolean } = { cache: true }): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-wguard-'));
+  fs.mkdirSync(path.join(home, '.node9'), { recursive: true });
+  writeKeyedHome(home);
+  fs.writeFileSync(
+    path.join(home, '.node9', 'config.json'),
+    JSON.stringify({ version: '1.0', settings: { autoStartDaemon: false } })
+  );
+  fs.writeFileSync(
+    path.join(home, '.node9', 'shields.json'),
+    JSON.stringify({ active: ['filesystem'], overrides: {} })
+  );
+  fs.writeFileSync(
+    path.join(home, '.node9', 'jail-paths.json'),
+    JSON.stringify({ paths: [{ path: '/tmp/secrets', verdict: 'block' }] })
+  );
+  fs.writeFileSync(
+    path.join(home, '.node9', 'trusted-hosts.json'),
+    JSON.stringify({ hosts: [{ host: 'pre.example.com', addedAt: 1, addedBy: 'user' }] })
+  );
+  if (opts.cache !== false) {
+    fs.writeFileSync(
+      path.join(home, '.node9', 'rules-cache.json'),
+      JSON.stringify({
+        fetchedAt: '2026-08-01T00:00:00Z',
+        rules: [],
+        shields: ['redis'],
+        managedConfig: { locked: [] },
+      })
+    );
+  }
+  return home;
+}
+
+function makeUnkeyedHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-wguard-un-'));
+  fs.mkdirSync(path.join(home, '.node9'), { recursive: true });
+  return home;
+}
+
+beforeAll(() => {
+  if (!fs.existsSync(CLI)) throw new Error('dist/cli.js missing — run `npm run build` first');
+});
+
+describe('§G keyed — every policy-write family refuses and leaves the stores byte-identical', () => {
+  let home: string;
+  let before: Record<string, string>;
+
+  beforeAll(() => {
+    home = makeKeyedHome();
+    before = snapshotStores(home);
+  });
+  afterAll(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  const expectRefused = (r: RunResult) => {
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain('workspace configuration');
+    expect(r.stderr).toContain('app.node9.ai');
+    expect(snapshotStores(home)).toEqual(before);
+  };
+
+  // G1-G5 egress (config.json)
+  it('G1: egress watch refused', () => expectRefused(runCli(home, ['egress', 'watch'])));
+  it('G2: egress lock refused', () => expectRefused(runCli(home, ['egress', 'lock'])));
+  it('G3: egress allow refused', () =>
+    expectRefused(runCli(home, ['egress', 'allow', 'h.example.com'])));
+  it('G4: egress deny refused', () =>
+    expectRefused(runCli(home, ['egress', 'deny', 'h.example.com'])));
+  it('G5: egress off refused — the weakening direction fails loudly too', () =>
+    expectRefused(runCli(home, ['egress', 'off'])));
+
+  // G6-G10 shields (shields.json / shield-overrides / ~/.node9/shields/)
+  it('G6: shield enable refused', () =>
+    expectRefused(runCli(home, ['shield', 'enable', 'postgres'])));
+  it('G7: shield disable refused', () =>
+    expectRefused(runCli(home, ['shield', 'disable', 'filesystem'])));
+  it('G8: shield set refused', () =>
+    expectRefused(runCli(home, ['shield', 'set', 'redis', 'block-flushall', 'allow', '--force'])));
+  it('G9: shield unset refused', () =>
+    expectRefused(runCli(home, ['shield', 'unset', 'redis', 'block-flushall'])));
+  it('G10: shield install refused (before any network fetch)', () =>
+    expectRefused(runCli(home, ['shield', 'install', 'some-shield'])));
+
+  // G11-G12 jail (jail-paths.json + user-jail shield)
+  it('G11: jail add refused', () => expectRefused(runCli(home, ['jail', 'add', '/tmp/x'])));
+  it('G12: jail remove refused', () =>
+    expectRefused(runCli(home, ['jail', 'remove', '/tmp/secrets'])));
+
+  // G13-G14 trust (trusted-hosts.json)
+  it('G13: trust add refused', () =>
+    expectRefused(runCli(home, ['trust', 'add', 'api.example.com'])));
+  it('G14: trust remove refused', () =>
+    expectRefused(runCli(home, ['trust', 'remove', 'pre.example.com'])));
+});
+
+describe('§G keyed variants — how keyedness is detected', () => {
+  it('keyed with NO rules-cache still refuses (mutant: guard keyed on cache presence)', () => {
+    const home = makeKeyedHome({ cache: false });
+    const before = snapshotStores(home);
+    const r = runCli(home, ['egress', 'lock']);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain('workspace configuration');
+    expect(snapshotStores(home)).toEqual(before);
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('G24: an env-only key (CI shape — no credentials.json) refuses through the same seam', () => {
+    const home = makeUnkeyedHome();
+    const r = runCli(home, ['egress', 'lock'], { NODE9_API_KEY: 'n9_ci_key' });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain('workspace configuration');
+    expect(fs.existsSync(path.join(home, '.node9', 'config.json'))).toBe(false);
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('G23: a localOnly key (`login --local`) keeps FULL local write control', () => {
+    const home = makeUnkeyedHome();
+    writeKeyedHome(home, { localOnly: true });
+    const r = runCli(home, ['egress', 'lock']);
+    expect(r.status).toBe(0);
+    const cfg = JSON.parse(fs.readFileSync(path.join(home, '.node9', 'config.json'), 'utf-8')) as {
+      policy?: { egress?: { enabled?: boolean; mode?: string } };
+    };
+    expect(cfg.policy?.egress?.enabled).toBe(true);
+    expect(cfg.policy?.egress?.mode).toBe('block');
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+});
+
+describe('§G unkeyed twins — the known-true instruments (same commands, no key, must mutate)', () => {
+  let home: string;
+  beforeAll(() => {
+    home = makeUnkeyedHome();
+  });
+  afterAll(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('egress lock works and writes policy.egress into config.json', () => {
+    const r = runCli(home, ['egress', 'lock']);
+    expect(r.status).toBe(0);
+    expect(r.stderr).not.toContain('workspace configuration');
+    const cfg = JSON.parse(fs.readFileSync(path.join(home, '.node9', 'config.json'), 'utf-8')) as {
+      policy?: { egress?: { enabled?: boolean; mode?: string } };
+    };
+    expect(cfg.policy?.egress?.enabled).toBe(true);
+    expect(cfg.policy?.egress?.mode).toBe('block');
+  });
+
+  it('egress off works (the weakening twin — G5 instrument)', () => {
+    const r = runCli(home, ['egress', 'off']);
+    expect(r.status).toBe(0);
+    const cfg = JSON.parse(fs.readFileSync(path.join(home, '.node9', 'config.json'), 'utf-8')) as {
+      policy?: { egress?: { enabled?: boolean } };
+    };
+    expect(cfg.policy?.egress?.enabled).toBe(false);
+  });
+
+  it('shield enable postgres works and lands in shields.json', () => {
+    const r = runCli(home, ['shield', 'enable', 'postgres']);
+    expect(r.status).toBe(0);
+    expect(fs.readFileSync(path.join(home, '.node9', 'shields.json'), 'utf-8')).toContain(
+      'postgres'
+    );
+  });
+
+  it('trust add works and lands in trusted-hosts.json', () => {
+    const r = runCli(home, ['trust', 'add', 'api.example.com']);
+    expect(r.status).toBe(0);
+    expect(fs.readFileSync(path.join(home, '.node9', 'trusted-hosts.json'), 'utf-8')).toContain(
+      'api.example.com'
+    );
+  });
+
+  it('jail add works and lands in jail-paths.json', () => {
+    const r = runCli(home, ['jail', 'add', '/tmp/x']);
+    expect(r.status).toBe(0);
+    const store = JSON.parse(
+      fs.readFileSync(path.join(home, '.node9', 'jail-paths.json'), 'utf-8')
+    ) as { paths?: Array<{ path: string }> };
+    expect(store.paths?.some((p) => p.path === '/tmp/x')).toBe(true);
+  });
+});

--- a/src/__tests__/log-output-scan.integration.test.ts
+++ b/src/__tests__/log-output-scan.integration.test.ts
@@ -12,6 +12,7 @@ import { spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { keySafeEnv } from './helpers/env';
 
 const CLI = path.resolve(__dirname, '../../dist/cli.js');
 
@@ -43,7 +44,7 @@ function runLog(
   home: string,
   extraArgs: string[] = []
 ): { stdout: string; status: number | null } {
-  const baseEnv = { ...process.env };
+  const baseEnv = keySafeEnv();
   delete baseEnv.NODE9_API_KEY;
   delete baseEnv.NODE9_API_URL;
   const r = spawnSync(process.execPath, [CLI, 'log', ...extraArgs, JSON.stringify(payload)], {

--- a/src/__tests__/mcp-gateway.integration.test.ts
+++ b/src/__tests__/mcp-gateway.integration.test.ts
@@ -21,6 +21,7 @@ import crypto from 'crypto';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { keySafeEnv } from './helpers/env';
 
 const CLI = path.resolve(__dirname, '../../dist/cli.js');
 const NODE = process.execPath;
@@ -554,7 +555,7 @@ rl.on('line', (line) => {
           input: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }) + '\n',
           encoding: 'utf-8',
           timeout: 8000,
-          env: { ...process.env, HOME: home, USERPROFILE: home, NODE9_TESTING: '1' },
+          env: keySafeEnv({ HOME: home, USERPROFILE: home, NODE9_TESTING: '1' }),
         }
       );
       expect(result.error).toBeUndefined();
@@ -650,8 +651,7 @@ rl.on('line', (line) => {
           input: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }) + '\n',
           encoding: 'utf-8',
           timeout: 8000,
-          env: {
-            ...process.env,
+          env: keySafeEnv({
             HOME: home,
             USERPROFILE: home,
             NODE9_TESTING: '1',
@@ -662,7 +662,7 @@ rl.on('line', (line) => {
             PERL5OPT: '-M/evil',
             RUBYLIB: '/evil/ruby',
             RUBYOPT: '-r/evil',
-          },
+          }),
         }
       );
       expect(result.error).toBeUndefined();

--- a/src/__tests__/mcp-server-tools.integration.test.ts
+++ b/src/__tests__/mcp-server-tools.integration.test.ts
@@ -9,6 +9,7 @@ import { spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { keySafeEnv } from './helpers/env';
 
 const CLI = path.resolve(__dirname, '../../dist/cli.js');
 
@@ -43,14 +44,13 @@ function driveMcp(
     // Default cwd is the test runner's (repo root, which has a node9.config.json);
     // pass an override so getConfig() merges a known project layer (or none).
     cwd,
-    env: {
-      ...process.env,
+    env: keySafeEnv({
       HOME: homeDir,
       USERPROFILE: homeDir,
       NODE9_TESTING: '1',
       NODE9_NO_AUTO_DAEMON: '1',
       NO_COLOR: '1',
-    },
+    }),
   });
   const byId: Record<number, McpResponse> = {};
   for (const line of (r.stdout ?? '').split('\n').filter(Boolean)) {

--- a/src/__tests__/mcp.integration.test.ts
+++ b/src/__tests__/mcp.integration.test.ts
@@ -17,6 +17,7 @@ import { spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { keySafeEnv } from './helpers/env';
 
 // echo is a shell builtin on Windows — the proxy tests that spawn /usr/bin/echo
 // via `node9 echo` only work on Linux/macOS where echo is an executable on PATH.
@@ -69,7 +70,7 @@ const BASE_ENV = {
  *  Windows uses USERPROFILE; Unix uses HOME. Setting both ensures os.homedir() resolves
  *  to the isolated directory on every platform. */
 function makeEnv(home: string): NodeJS.ProcessEnv {
-  return { ...process.env, ...BASE_ENV, HOME: home, USERPROFILE: home };
+  return keySafeEnv({ ...BASE_ENV, HOME: home, USERPROFILE: home });
 }
 
 beforeAll(() => {

--- a/src/__tests__/obfuscation-bypass.integration.test.ts
+++ b/src/__tests__/obfuscation-bypass.integration.test.ts
@@ -16,6 +16,7 @@ import { spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { keySafeEnv } from './helpers/env';
 
 const CLI = path.resolve(__dirname, '../../dist/cli.js');
 
@@ -46,7 +47,7 @@ function check(home: string, command: string): { status: number | null; stdout: 
     tool_name: 'Bash',
     tool_input: { command },
   });
-  const env = { ...process.env } as Record<string, string>;
+  const env = keySafeEnv() as Record<string, string>;
   delete env.NODE9_API_KEY;
   delete env.NODE9_API_URL;
   const r = spawnSync(process.execPath, [CLI, 'check', payload], {

--- a/src/__tests__/strict-cloud-allow-bypass.spec.ts
+++ b/src/__tests__/strict-cloud-allow-bypass.spec.ts
@@ -39,23 +39,13 @@ vi.mock('../auth/cloud', async (importOriginal) => ({
   resolveNode9SaaS: vi.fn(async () => undefined),
 }));
 
-/** Base local config: standard mode, cloud is the ONLY approver surface.
- *  Native/browser/terminal stay off so a guarded fall-through resolves
- *  deterministically as no-approval-mechanism instead of opening UI. */
-function writeLocalConfig(tmpHome: string): void {
-  fs.writeFileSync(
-    path.join(tmpHome, '.node9', 'config.json'),
-    JSON.stringify({
-      settings: {
-        mode: 'standard',
-        approvalTimeoutMs: 0,
-        approvers: { native: false, browser: false, cloud: true, terminal: false },
-      },
-      policy: {},
-    })
-  );
-}
-
+/** PR-2 replace-mode (§F disposition): this fixture writes credentials.json,
+ *  so it is KEYED — local config.json policy is inert. The approval-surface
+ *  knobs therefore ride in the CLOUD cache's managedConfig (exactly what a
+ *  real keyed machine gets from sync): cloud is the ONLY approver surface,
+ *  native/browser/terminal off so a guarded fall-through resolves
+ *  deterministically as no-approval-mechanism instead of opening UI, and a
+ *  short positive timeout (a managed 0 is rejected by design — index.ts). */
 function writeRulesCache(
   tmpHome: string,
   opts: { managedMode?: string; rules?: unknown[] } = {}
@@ -65,7 +55,12 @@ function writeRulesCache(
     JSON.stringify({
       fetchedAt: '2026-07-01T00:00:00Z',
       rules: opts.rules ?? [],
-      ...(opts.managedMode ? { managedConfig: { mode: opts.managedMode, locked: [] } } : {}),
+      managedConfig: {
+        approvalTimeoutMs: 50,
+        approvers: { native: false, browser: false, cloud: true, terminal: false },
+        ...(opts.managedMode ? { mode: opts.managedMode } : {}),
+        locked: [],
+      },
     })
   );
 }
@@ -84,7 +79,9 @@ describe('cloud immediate-allow vs managed strict (B1 #6)', () => {
     delete process.env.NODE9_API_KEY;
     delete process.env.NODE9_MODE;
     fs.mkdirSync(path.join(tmpHome, '.node9'), { recursive: true });
-    writeLocalConfig(tmpHome);
+    // Every test writes its own rules-cache; seed the default shape so a test
+    // that forgets still has the approver surface configured.
+    writeRulesCache(tmpHome);
     // cloudEnforced requires a real credential on disk (approvers.cloud && apiKey).
     fs.writeFileSync(
       path.join(tmpHome, '.node9', 'credentials.json'),
@@ -118,15 +115,14 @@ describe('cloud immediate-allow vs managed strict (B1 #6)', () => {
 
     // The bug resolved this as { approved: true, checkedBy: 'cloud' }. A tier-7
     // strict review must fall through to the race; with every local surface off
-    // and no cloud PENDING entry, that is a deterministic deny.
+    // and no cloud PENDING entry, that is a deterministic deny. PR-2 note: a
+    // KEYED machine always runs the timeout racer (DEFAULT/managed
+    // approvalTimeoutMs is always > 0 — a managed 0 is rejected by design), so
+    // the deny arrives as an auto-deny timeout, not no-approval-mechanism (the
+    // old local `approvalTimeoutMs:0` no-racer shape is not cloud-expressible).
     expect(result.approved).toBe(false);
     expect(result.checkedBy).not.toBe('cloud');
-    expect(result.blockedBy).toBe('no-approval-mechanism');
-    // Label convention: once cloud is enforced, the orchestrator stamps
-    // 'Organization Policy (SaaS)' over the local label (orchestrator.ts —
-    // same for smart-rule reviews today). The managed strict floor IS org
-    // policy, so either attribution is honest; assert only that a label exists.
-    expect(result.blockedByLabel).toMatch(/strict|organization policy/i);
+    expect(result.blockedBy).toBe('timeout');
   });
 
   it('managed strict: the SaaS is told forceReview so it creates a genuine PENDING', async () => {
@@ -171,8 +167,8 @@ describe('cloud immediate-allow vs managed strict (B1 #6)', () => {
   });
 
   it('standard mode: a prior "Always Allow" still works for reviewed tools (pinned)', async () => {
-    // No managed mode; make the tool reach the persistent consult by turning
-    // cloud off (otherwise a standard-mode unmatched tool is allowed earlier).
+    // No managed mode (keyed default = standard). The persistent consult
+    // resolves the dangerous-word review before any cloud round-trip.
     writeRulesCache(tmpHome, {});
     fs.writeFileSync(
       path.join(tmpHome, '.node9', 'decisions.json'),
@@ -188,18 +184,15 @@ describe('cloud immediate-allow vs managed strict (B1 #6)', () => {
   });
 
   it('smart-rule review: still falls to the race, never resolved by cloud allow (pinned)', async () => {
-    writeRulesCache(tmpHome, {
-      rules: [
-        {
-          name: 'review-unknown',
-          tool: 'TotallyUnknownTool',
-          verdict: 'review',
-          conditions: [],
-        },
-      ],
-    });
+    // PR-2 note: this row used a CACHE-delivered review rule; cloud cache
+    // `rules` are currently dropped on keyed machines (prod bug pinned as
+    // K13c in keyed-replace.spec.ts), so the probe uses a SHIPPED DEFAULT
+    // review rule instead — `review-sudo` survives keyed by construction.
+    // The property under test is unchanged: a smart-rule review (ruleName
+    // present) must never be resolved by the SaaS immediate-allow.
+    writeRulesCache(tmpHome, {});
 
-    const result = await authorizeHeadless('TotallyUnknownTool', { note: 'probe' });
+    const result = await authorizeHeadless('Bash', { command: 'sudo whoami' });
 
     expect(result.approved).toBe(false);
     expect(result.checkedBy).not.toBe('cloud');

--- a/src/__tests__/sync-health.integration.test.ts
+++ b/src/__tests__/sync-health.integration.test.ts
@@ -13,6 +13,7 @@ import { spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { keySafeEnv } from './helpers/env';
 
 const CLI = path.resolve(__dirname, '../../dist/cli.js');
 
@@ -33,8 +34,7 @@ afterEach(() => {
 const run = (args: string[], env: Record<string, string> = {}) =>
   spawnSync(process.execPath, [CLI, ...args], {
     encoding: 'utf-8',
-    env: {
-      ...process.env,
+    env: keySafeEnv({
       HOME: home,
       // os.homedir() reads USERPROFILE on Windows, not HOME — set both so the
       // spawned dist/cli.js resolves ~/.node9 to the temp dir on every OS
@@ -47,7 +47,7 @@ const run = (args: string[], env: Record<string, string> = {}) =>
       NODE9_POLICY_MIRROR_DISABLE: '1',
       NODE9_NO_AUTO_DAEMON: '1',
       ...env,
-    },
+    }),
   });
 
 describe('policy sync — health record + never-fail-open (real dist/cli.js)', () => {

--- a/src/__tests__/taint-review-not-dropped.spec.ts
+++ b/src/__tests__/taint-review-not-dropped.spec.ts
@@ -91,17 +91,23 @@ describe('taint review is never resolved by a non-human channel (task #16 vector
     process.env.USERPROFILE = tmpHome;
     delete process.env.NODE9_API_KEY;
     fs.mkdirSync(path.join(tmpHome, '.node9'), { recursive: true });
-    // Standard mode, every LOCAL approver off so a fall-through can't prompt;
-    // cloud ON so the cloud-resolve path is the one under test.
+    // PR-2 replace-mode (§F disposition): credentials.json makes this fixture
+    // KEYED, so the policy knobs (mode / approvalTimeoutMs / approvers) must
+    // arrive via the CLOUD cache — a keyed machine's local config.json policy
+    // is inert. Same intent as before: standard mode, every LOCAL approver off
+    // so a fall-through can't prompt, cloud ON so the cloud-resolve path is
+    // the one under test, and a short timeout so the race resolves.
     fs.writeFileSync(
-      path.join(tmpHome, '.node9', 'config.json'),
+      path.join(tmpHome, '.node9', 'rules-cache.json'),
       JSON.stringify({
-        settings: {
+        fetchedAt: '2026-07-01T00:00:00Z',
+        rules: [],
+        managedConfig: {
           mode: 'standard',
           approvalTimeoutMs: 50,
           approvers: { native: false, browser: false, cloud: true, terminal: false },
+          locked: [],
         },
-        policy: {},
       })
     );
     fs.writeFileSync(

--- a/src/__tests__/unkeyed-parity-golden.spec.ts
+++ b/src/__tests__/unkeyed-parity-golden.spec.ts
@@ -1,0 +1,167 @@
+// U0 — the UNKEYED PARITY GOLDEN (PR-2 matrix §U).
+//
+// Captured on the PRE-replace-mode tree: for a rich local config exercising
+// every policy family, the resolved getConfig() output is frozen here. PR-2
+// must keep every one of these assertions green — an unkeyed machine's
+// behavior may not change by a single field. (The keyed world gets its own
+// rows; this file is the other half of the contract.)
+//
+// Deliberately NOT a .snapshot file: a snapshot invites a thoughtless
+// --update; these are hand-pinned assertions a diff review can read.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// getConfig caches ambient calls; cwd-scoped calls bypass the cache. We use
+// a temp HOME + a temp cwd so the run is hermetic either way.
+import { getConfig, _resetConfigCache } from '../config';
+
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-u0-'));
+const PROJ = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-u0-proj-'));
+
+const LOCAL_GLOBAL = {
+  version: '1.0',
+  settings: {
+    mode: 'strict',
+    approvalTimeoutMs: 45_000,
+    approvers: { native: false, browser: false, cloud: true, terminal: true },
+    reviewChannel: 'approver',
+  },
+  policy: {
+    sandboxPaths: ['/custom/sandbox/**'],
+    ignoredTools: ['my_custom_readonly'],
+    dangerousWords: ['frobnicate'],
+    toolInspection: { 'my_db:query': 'sql' },
+    smartRules: [
+      {
+        name: 'local-rule-block-frob',
+        tool: 'bash',
+        conditionMode: 'all',
+        conditions: [{ field: 'command', op: 'contains', value: 'frobnicate' }],
+        verdict: 'block',
+        reason: 'local custom rule',
+      },
+    ],
+    egress: {
+      enabled: true,
+      mode: 'block',
+      allow: ['api.allowed.example'],
+      deny: ['evil.example'],
+      allowPrivate: false,
+    },
+    dlp: { enabled: false, scanIgnoredTools: false, pii: 'block' },
+    loopDetection: { enabled: false, threshold: 9, windowSeconds: 60 },
+    injectionScan: { enabled: true, minConfidence: 'high', allow: ['Read'] },
+    skillPinning: { enabled: true, mode: 'block', roots: ['/skills'] },
+    trustedHosts: ['trusted.corp.example'],
+    commandChecks: { inlineExec: 'block', rmAdvisory: 'off' },
+  },
+  environments: {
+    prod: { requireApproval: true, patterns: ['deploy*'] },
+  },
+};
+
+const LOCAL_PROJECT = {
+  version: '1.0',
+  policy: {
+    // repo-carried config may only TIGHTEN — pinned by existing suites; here
+    // it contributes one extra sandbox path so the merge itself is witnessed.
+    sandboxPaths: ['/proj/tmp/**'],
+  },
+};
+
+beforeAll(() => {
+  fs.mkdirSync(path.join(HOME, '.node9'), { recursive: true });
+  fs.writeFileSync(path.join(HOME, '.node9', 'config.json'), JSON.stringify(LOCAL_GLOBAL, null, 2));
+  fs.writeFileSync(path.join(PROJ, 'node9.config.json'), JSON.stringify(LOCAL_PROJECT, null, 2));
+  process.env.HOME = HOME;
+  process.env.USERPROFILE = HOME;
+  delete process.env.NODE9_API_KEY;
+  delete process.env.NODE9_API_URL;
+  delete process.env.NODE9_PROFILE;
+  delete process.env.NODE9_MODE;
+  _resetConfigCache();
+});
+
+afterAll(() => {
+  fs.rmSync(HOME, { recursive: true, force: true });
+  fs.rmSync(PROJ, { recursive: true, force: true });
+});
+
+describe('U0 — unkeyed golden: the local stack resolves EXACTLY as today', () => {
+  it('U0.1 settings: mode/timeout/approvers/reviewChannel come from the local file', () => {
+    const c = getConfig(PROJ);
+    expect(c.settings.mode).toBe('strict');
+    expect(c.settings.approvalTimeoutMs).toBe(45_000);
+    expect(c.settings.approvers).toEqual({
+      native: false,
+      browser: false,
+      cloud: true,
+      terminal: true,
+    });
+    expect(c.settings.reviewChannel).toBe('approver');
+  });
+
+  it('U0.2 egress: the full local family survives verbatim', () => {
+    const c = getConfig(PROJ);
+    expect(c.policy.egress).toMatchObject({
+      enabled: true,
+      mode: 'block',
+      allowPrivate: false,
+    });
+    expect(c.policy.egress.allow).toContain('api.allowed.example');
+    expect(c.policy.egress.deny).toContain('evil.example');
+  });
+
+  it('U0.3 dlp: local managed-OFF holds (enabled:false, pii block)', () => {
+    const c = getConfig(PROJ);
+    expect(c.policy.dlp.enabled).toBe(false);
+    expect(c.policy.dlp.pii).toBe('block');
+  });
+
+  it('U0.4 detection: loop off, injection high, skill block — all local', () => {
+    const c = getConfig(PROJ);
+    expect(c.policy.loopDetection.enabled).toBe(false);
+    expect(c.policy.loopDetection.threshold).toBe(9);
+    expect(c.policy.injectionScan.minConfidence).toBe('high');
+    expect(c.policy.skillPinning.mode).toBe('block');
+    expect(c.policy.skillPinning.roots).toContain('/skills');
+  });
+
+  it('U0.5 commandChecks: local values incl. Class-A off are honored', () => {
+    const c = getConfig(PROJ);
+    expect(c.policy.commandChecks?.inlineExec).toBe('block');
+    expect(c.policy.commandChecks?.rmAdvisory).toBe('off');
+  });
+
+  it('U0.6 the cloud-inexpressible families come from local: sandbox/ignored/dangerous/toolInspection/environments', () => {
+    const c = getConfig(PROJ);
+    expect(c.policy.sandboxPaths).toContain('/custom/sandbox/**');
+    expect(c.policy.sandboxPaths).toContain('/proj/tmp/**'); // project layer merged
+    expect(c.policy.ignoredTools).toContain('my_custom_readonly');
+    expect(c.policy.dangerousWords).toContain('frobnicate');
+    expect(c.policy.toolInspection['my_db:query']).toBe('sql');
+    expect(c.environments?.prod?.requireApproval).toBe(true);
+  });
+
+  it('U0.7 local smartRules are present alongside the defaults', () => {
+    const c = getConfig(PROJ);
+    const names = c.policy.smartRules.map((r) => r.name);
+    expect(names).toContain('local-rule-block-frob');
+    expect(names).toContain('block-rm-rf-home'); // a shipped default survives
+  });
+
+  it('U0.8 trustedHosts: config.json does NOT feed the list on unkeyed (measured)', () => {
+    // Capturing this golden REVEALED the real behavior: a `trustedHosts`
+    // array in local config.json is ignored — the unkeyed trust store is
+    // the separate ~/.node9/trusted-hosts.json, read FRESH at eval time
+    // (policy/index.ts isTrustedHost → getCachedHosts). The config field
+    // is populated only by the CLOUD path. Pinned as-is: replace-mode
+    // must not change either half.
+    const c = getConfig(PROJ);
+    expect(c.policy.trustedHosts).toEqual([]);
+    expect(c.policy.trustedHostsManaged).toBe(false);
+  });
+});

--- a/src/__tests__/unkeyed-parity-golden.spec.ts
+++ b/src/__tests__/unkeyed-parity-golden.spec.ts
@@ -9,10 +9,37 @@
 // Deliberately NOT a .snapshot file: a snapshot invites a thoughtless
 // --update; these are hand-pinned assertions a diff review can read.
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import type { ShieldDefinition } from '../shields';
+
+// The shields store paths are module-load consts frozen to the REAL home — a
+// temp-HOME fixture can't move them. Mock the local-file readers (harness from
+// applied-shields.spec.ts) so both the U0 golden and the U-rows below are
+// hermetic against the dev machine's own shields.json. Defaults (empty) match
+// a clean machine — the state U0 was captured against.
+const shieldState = vi.hoisted(() => ({
+  active: [] as string[],
+  overrides: {} as Record<string, Record<string, 'allow' | 'review' | 'block'>>,
+  userShields: {} as Record<string, unknown>,
+}));
+
+vi.mock('../shields', async () => {
+  const actual = await vi.importActual<typeof import('../shields')>('../shields');
+  const engine =
+    await vi.importActual<typeof import('@node9/policy-engine')>('@node9/policy-engine');
+  return {
+    ...actual,
+    readActiveShields: () => shieldState.active,
+    readShieldOverrides: () => shieldState.overrides,
+    getShield: (name: string) =>
+      (shieldState.userShields[name] as ShieldDefinition | undefined) ??
+      engine.BUILTIN_SHIELDS[name] ??
+      null,
+  };
+});
 
 // getConfig caches ambient calls; cwd-scoped calls bypass the cache. We use
 // a temp HOME + a temp cwd so the run is hermetic either way.
@@ -153,6 +180,10 @@ describe('U0 — unkeyed golden: the local stack resolves EXACTLY as today', () 
     expect(names).toContain('block-rm-rf-home'); // a shipped default survives
   });
 
+  it('U0.9 policySource: an unkeyed machine reports the local stack', () => {
+    expect(getConfig(PROJ).policySource).toBe('local');
+  });
+
   it('U0.8 trustedHosts: config.json does NOT feed the list on unkeyed (measured)', () => {
     // Capturing this golden REVEALED the real behavior: a `trustedHosts`
     // array in local config.json is ignored — the unkeyed trust store is
@@ -163,5 +194,232 @@ describe('U0 — unkeyed golden: the local stack resolves EXACTLY as today', () 
     const c = getConfig(PROJ);
     expect(c.policy.trustedHosts).toEqual([]);
     expect(c.policy.trustedHostsManaged).toBe(false);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// §U rows U1-U15 — per-family unkeyed twins of the §K keyed rows
+// (keyed-replace.spec.ts). Each row runs the SAME fixture shape as its K twin
+// with the key ABSENT and asserts TODAY'S law holds.
+//
+// MUTATION NOTE: every row here kills the "fork condition inverted / keyed
+// detection too broad" mutant class — U3/U7/U11/U13 in particular run WITH a
+// rules-cache PRESENT and no credentials, so a `keyed = cache file exists`
+// mutant flips them to cloud-replace behavior and they fail.
+// ───────────────────────────────────────────────────────────────────────────
+describe('§U — unkeyed byte-parity rows (U1-U15)', () => {
+  let home: string;
+  let proj: string;
+  const savedEnv: Record<string, string | undefined> = {};
+  const ENV_KEYS = ['NODE9_API_KEY', 'NODE9_API_URL', 'NODE9_PROFILE', 'NODE9_MODE'];
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-uparity-'));
+    proj = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-uparity-proj-'));
+    savedEnv.HOME = process.env.HOME;
+    savedEnv.USERPROFILE = process.env.USERPROFILE;
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    for (const k of ENV_KEYS) delete process.env[k]; // UNKEYED by construction
+    fs.mkdirSync(path.join(home, '.node9'), { recursive: true });
+    shieldState.active = [];
+    shieldState.overrides = {};
+    shieldState.userShields = {};
+    _resetConfigCache();
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v !== undefined) process.env[k] = v;
+      else delete process.env[k];
+    }
+    shieldState.active = [];
+    shieldState.overrides = {};
+    shieldState.userShields = {};
+    fs.rmSync(home, { recursive: true, force: true });
+    fs.rmSync(proj, { recursive: true, force: true });
+    _resetConfigCache();
+  });
+
+  const writeGlobal = (cfgObj: Record<string, unknown>) => {
+    fs.writeFileSync(
+      path.join(home, '.node9', 'config.json'),
+      JSON.stringify({ version: '1.0', ...cfgObj })
+    );
+  };
+  const writeRepo = (cfgObj: Record<string, unknown>) => {
+    fs.writeFileSync(
+      path.join(proj, 'node9.config.json'),
+      JSON.stringify({ version: '1.0', ...cfgObj })
+    );
+  };
+  const writeCache = (cache: Record<string, unknown>) => {
+    fs.writeFileSync(
+      path.join(home, '.node9', 'rules-cache.json'),
+      JSON.stringify({ fetchedAt: '2026-08-01T00:00:00Z', rules: [], ...cache })
+    );
+  };
+  const cfg = () => {
+    _resetConfigCache();
+    return getConfig(proj);
+  };
+
+  it('U1 (K1a twin): local strict is honored', () => {
+    writeGlobal({ settings: { mode: 'strict' } });
+    expect(cfg().settings.mode).toBe('strict');
+  });
+
+  it('U2 (K1b twin): NODE9_MODE=observe is honored (no cache)', () => {
+    process.env.NODE9_MODE = 'observe';
+    expect(cfg().settings.mode).toBe('observe');
+  });
+
+  it("U3 (K1c twin): a managed observe is FLOORED away unkeyed — today's floor law kept", () => {
+    writeCache({ managedConfig: { mode: 'observe', locked: [] } });
+    expect(cfg().settings.mode).toBe('standard');
+  });
+
+  it('U4 (K2a twin): the local egress lock is enforced', () => {
+    writeGlobal({
+      policy: { egress: { enabled: true, mode: 'block', deny: ['evil.com'] } },
+    });
+    const c = cfg();
+    expect(c.policy.egress.enabled).toBe(true);
+    expect(c.policy.egress.mode).toBe('block');
+    expect(c.policy.egress.deny).toContain('evil.com');
+  });
+
+  it('U5 (K2c twin): a repo may not widen the allowlist past the global one (egressAllowUserSet)', () => {
+    writeGlobal({ policy: { egress: { enabled: true, mode: 'block', allow: ['mine.dev'] } } });
+    writeRepo({ policy: { egress: { allow: ['evil.com'] } } });
+    const c = cfg();
+    expect(c.policy.egress.allow).toContain('mine.dev');
+    expect(c.policy.egress.allow).not.toContain('evil.com');
+  });
+
+  it("U6 (K3a twin): local dlp OFF is honored (the user's own home)", () => {
+    writeGlobal({ policy: { dlp: { enabled: false } } });
+    expect(cfg().policy.dlp.enabled).toBe(false);
+  });
+
+  it('U7 (K3b twin): the managed dlp force-on floor keeps DLP ON unkeyed', () => {
+    writeGlobal({ policy: { dlp: { enabled: true } } });
+    writeCache({ managedConfig: { dlp: { enabled: false }, locked: [] } });
+    expect(cfg().policy.dlp.enabled).toBe(true);
+  });
+
+  it('U8 (K4a twin): local commandChecks honored; a repo cannot weaken (rank clamp)', () => {
+    writeGlobal({ policy: { commandChecks: { chmod: 'off', inlineExec: 'block' } } });
+    writeRepo({ policy: { commandChecks: { inlineExec: 'off' } } });
+    const c = cfg();
+    expect(c.policy.commandChecks?.chmod).toBe('off');
+    expect(c.policy.commandChecks?.inlineExec).toBe('block'); // repo 'off' clamped
+  });
+
+  it('U9 (K5a twin): approvers.cloud comes from the local seed — true when seeded, DEFAULT false when not', () => {
+    writeGlobal({ settings: { approvers: { cloud: true } } });
+    expect(cfg().settings.approvers.cloud).toBe(true);
+    writeGlobal({ settings: {} });
+    expect(cfg().settings.approvers.cloud).toBe(false);
+  });
+
+  it('U10 (K9b twin): a local user-jail shield applies — shield listed + its rules injected (task #20 law)', () => {
+    shieldState.active = ['user-jail'];
+    shieldState.userShields['user-jail'] = {
+      name: 'user-jail',
+      description: 'user jail',
+      aliases: [],
+      smartRules: [
+        {
+          name: 'user-jail:block-secrets',
+          tool: '*',
+          conditions: [{ field: 'file_path', op: 'contains', value: '/secrets/' }],
+          conditionMode: 'all',
+          verdict: 'block',
+          reason: 'jailed path',
+        },
+      ],
+      dangerousWords: [],
+    };
+    const c = cfg();
+    expect(c.policy.appliedShields).toContain('user-jail');
+    expect(c.policy.smartRules.some((r) => r.name === 'user-jail:block-secrets')).toBe(true);
+  });
+
+  it('U11 (K12a twin): shields = local ∪ cloud union; overrides apply to LOCAL shields only', () => {
+    shieldState.active = ['filesystem'];
+    shieldState.overrides = {
+      filesystem: { 'shield:filesystem:review-chmod-777': 'block' }, // local shield → applies
+      redis: { 'shield:redis:block-flushall': 'allow' }, // mandated shield → ignored
+    };
+    writeCache({ shields: ['redis'] });
+    const c = cfg();
+    expect(c.policy.appliedShields).toEqual(['filesystem', 'redis']);
+    const chmod = c.policy.smartRules.find((r) => r.name === 'shield:filesystem:review-chmod-777');
+    expect(chmod?.verdict).toBe('block'); // local override honored on a local shield
+    const flushall = c.policy.smartRules.find((r) => r.name === 'shield:redis:block-flushall');
+    expect(flushall?.verdict).toBe('block'); // weaken attempt on a mandate ignored
+  });
+
+  it('U12 (K13a twin): a local same-name override of a default rule WINS unkeyed', () => {
+    writeGlobal({
+      policy: {
+        smartRules: [
+          {
+            name: 'review-sudo',
+            tool: 'bash',
+            conditions: [{ field: 'command', op: 'matches', value: '\\bsudo\\s' }],
+            conditionMode: 'all',
+            verdict: 'allow',
+            reason: 'my machine, my rule',
+          },
+        ],
+      },
+    });
+    const sudo = cfg().policy.smartRules.filter((r) => r.name === 'review-sudo');
+    expect(sudo).toHaveLength(1);
+    expect(sudo[0].verdict).toBe('allow');
+  });
+
+  it('U13 (K14 twin + mandate): a mandated shield resets local ignoredTools/sandboxPaths (task #16/#24)', () => {
+    writeGlobal({ policy: { ignoredTools: ['bash'], sandboxPaths: ['/**'] } });
+    writeCache({ shields: ['redis'] });
+    const c = cfg();
+    expect(c.policy.ignoredTools).not.toContain('bash');
+    expect(c.policy.sandboxPaths).not.toContain('/**');
+  });
+
+  it('U14 (K16/K17/K18 twins): dangerousWords replace, toolInspection merge, environments gate all work', () => {
+    writeGlobal({
+      settings: { environment: 'production' },
+      policy: {
+        dangerousWords: ['frobnicate'],
+        toolInspection: { 'my_db:query': 'sql' },
+      },
+      environments: { production: { requireApproval: true } },
+    });
+    const c = cfg();
+    expect(c.policy.dangerousWords).toContain('frobnicate');
+    expect(c.policy.dangerousWords).not.toContain('mkfs'); // replace, not union
+    expect(c.policy.toolInspection['my_db:query']).toBe('sql');
+    expect(c.environments.production?.requireApproval).toBe(true);
+    expect(c.settings.environment).toBe('production');
+  });
+
+  it('U15 (K19 twin): operational knobs work unkeyed (same pass)', () => {
+    writeGlobal({
+      settings: {
+        autoStartDaemon: false,
+        enableHookLogDebug: false,
+        shipper: { intervalSeconds: 99 },
+        mcpReconcileIntervalMinutes: 30,
+      },
+    });
+    const c = cfg();
+    expect(c.settings.autoStartDaemon).toBe(false);
+    expect(c.settings.enableHookLogDebug).toBe(false);
+    expect(c.settings.shipper.intervalSeconds).toBe(99);
+    expect(c.settings.mcpReconcileIntervalMinutes).toBe(30);
   });
 });

--- a/src/auth/orchestrator.ts
+++ b/src/auth/orchestrator.ts
@@ -994,7 +994,13 @@ async function _authorizeHeadlessCore(
       toolLower === 'read_file' ||
       toolLower === 'grep_search' ||
       toolLower === 'list_files';
-    const activeShields = isFileTool ? readActiveShields() : [];
+    // PR-2 §0.4 — arm from the CONFIG'S OWN TESTIMONY of what is running
+    // (policy.appliedShields, the N6 resolver output), never the local
+    // shields.json: a keyed machine ignores that file, and arming from it
+    // left cloud-mandated jail shields unarmed — Read/Grep/Glob of jailed
+    // paths took the ignoredTools fast path (the task-#20 bypass reborn).
+    // Fallback to the file only when the config predates appliedShields.
+    const activeShields = isFileTool ? (config.policy.appliedShields ?? readActiveShields()) : [];
     // Task #22: an ORG-managed jail (managedConfig.jailPaths) enables no shield
     // — it only injects org:-prefixed rules — so arming on shields alone let
     // the managed route keep task #20's bypass. Arm on the managed paths too.

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -21,6 +21,7 @@ import {
 import { defaultSkillRoots, resolveUserSkillRoot, verifyAndPinRoots } from '../../skill-pin';
 import { scanArgs } from '../../dlp';
 import { appendLocalAudit } from '../../audit';
+import { isKeyedForPolicy } from '../../config/keyed-guard';
 import {
   reviewCorrelationKey,
   recordPendingReview,
@@ -529,9 +530,13 @@ export function registerCheckCommand(program: Command): void {
               ruleDescription?: string;
             }
           ) => {
-            // 1. Determine the context (User vs Policy)
+            // 1. Determine the context (User vs Policy). I6: the fallback
+            // names where the verdict came from — on a workspace-governed
+            // machine that is the workspace policy, not a local one.
             const blockedByContext =
-              result?.blockedByLabel || result?.blockedBy || 'Local Security Policy';
+              result?.blockedByLabel ||
+              result?.blockedBy ||
+              (isKeyedForPolicy() ? 'Workspace Policy' : 'Local Security Policy');
 
             // 2. Identify if it was a human decision or an automated rule
             const isHumanDecision =

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -22,6 +22,18 @@ import { readStartupCause } from '../../daemon/startup-log';
 import { undoLeftoverPaths } from '../../utils/undo-leftovers';
 import { locatorCommand } from '../../utils/platform-shell';
 
+/**
+ * Did the cloud REJECT this machine's key? A 401 in the sync-health record is
+ * not a network problem — the key was revoked (disconnected from the
+ * dashboard, the member removed from the workspace, or `node9 logout`), and
+ * every cloud channel using it fails together. doctor already had this
+ * evidence and printed it as a raw "API returned 401", leaving the founder to
+ * work out that it meant "this machine is disconnected" (QA 2026-08-29).
+ */
+function keyRejected(health: { consecutiveFailures: number; lastError?: string }): boolean {
+  return health.consecutiveFailures > 0 && /\b401\b/.test(health.lastError ?? '');
+}
+
 export function registerDoctorCommand(program: Command, version: string): void {
   program
     .command('doctor')
@@ -262,7 +274,22 @@ export function registerDoctorCommand(program: Command, version: string): void {
       ) {
         section('Policy sync');
         const health = readSyncHealth();
-        if (isPolicyStale(Date.now(), health)) {
+        // A REJECTED key is checked before staleness, and independently of it:
+        // being revoked is not a function of elapsed time. Nested inside the
+        // stale branch (the first version of this fix), a machine disconnected
+        // an hour ago still reported "Cloud policy fresh" until the staleness
+        // clock — up to 15h — finally caught up.
+        if (keyRejected(health)) {
+          const when = health.lastCheckedAt
+            ? `last reached the cloud ${agoLabel(health.lastCheckedAt)}`
+            : 'never reached the cloud';
+          warn(
+            `This machine is DISCONNECTED — the cloud rejected its key (${when}, ` +
+              `${health.consecutiveFailures} consecutive failure${health.consecutiveFailures === 1 ? '' : 's'}). ` +
+              'It still enforces the cached policy, but nothing reaches or leaves the dashboard.',
+            'Someone disconnected it from the dashboard, removed you from the workspace, or ran `node9 logout`. Reconnect with: node9 login'
+          );
+        } else if (isPolicyStale(Date.now(), health)) {
           const when = health.lastCheckedAt
             ? `last reached the cloud ${agoLabel(health.lastCheckedAt)}`
             : 'never reached the cloud';
@@ -317,10 +344,24 @@ export function registerDoctorCommand(program: Command, version: string): void {
             );
           } else if (wm && lag !== null) {
             const ageMin = Math.round((Date.now() - new Date(wm.updatedAt).getTime()) / 60_000);
-            if (ageMin > 5 && !isDaemonRunning()) {
+            // STALLED is about the QUEUE, not the daemon. The old condition
+            // warned only when the daemon was DOWN, so a running daemon that
+            // could not ship printed "Shipping in progress" over 334 KB stuck
+            // for 12 hours (founder QA 2026-08-29) — the same lie as the
+            // caught-up branch above, one else-if over.
+            // 15 min ≈ 45 failed 20s cycles: long enough that a laptop waking
+            // from sleep mid-flush is never accused.
+            const stalled = ageMin > 15;
+            if (stalled) {
+              const rejected = keyRejected(readSyncHealth());
               warn(
-                `${Math.round(lag / 1024)} KB of audit rows not shipped (last ship ${ageMin}m ago)`,
-                'The daemon ships every ~20s — start it: node9 daemon --background'
+                `${Math.round(lag / 1024)} KB of audit rows NOT shipped (last ship ${ageMin}m ago)`,
+                // The daemon's state decides the fix, not whether to warn.
+                !isDaemonRunning()
+                  ? 'The daemon ships every ~20s — start it: node9 daemon --background'
+                  : rejected
+                    ? "The daemon is running but the cloud rejects this machine's key — run: node9 login"
+                    : 'The daemon is running but shipping is failing — see Policy sync above for the reason'
               );
             } else {
               pass(

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -101,14 +101,29 @@ export function registerDoctorCommand(program: Command, version: string): void {
 
       // ── Config ───────────────────────────────────────────────────────────────
       section('Configuration');
+      // I3: name the policy source first — every "found and valid" line below
+      // is about a file that a workspace-governed machine does NOT read for
+      // policy, and doctor must not imply otherwise.
+      const wsGoverned = getConfig().policySource === 'workspace';
+      if (wsGoverned) {
+        pass(
+          'Policy source: workspace config (app.node9.ai) — local config files govern operational settings only'
+        );
+      }
       const globalConfigPath = path.join(homeDir, '.node9', 'config.json');
       if (fs.existsSync(globalConfigPath)) {
         try {
           JSON.parse(fs.readFileSync(globalConfigPath, 'utf-8'));
-          pass('~/.node9/config.json found and valid');
+          pass(
+            wsGoverned
+              ? '~/.node9/config.json found and valid (policy fields ignored — workspace governs)'
+              : '~/.node9/config.json found and valid'
+          );
         } catch {
           fail('~/.node9/config.json is invalid JSON', 'Run: node9 init --force');
         }
+      } else if (wsGoverned) {
+        pass('~/.node9/config.json not present (workspace config governs)');
       } else {
         warn('~/.node9/config.json not found (using defaults)', 'Run: node9 init');
       }
@@ -322,9 +337,14 @@ export function registerDoctorCommand(program: Command, version: string): void {
         if (!creds) {
           warn('Not logged in — audit rows stay local', 'Run: node9 login <api-key>');
         } else if (!cfg.settings.approvers.cloud) {
+          // I3: "set approvers.cloud=true" is LOCAL-FILE advice — on a
+          // workspace-governed machine that file is inert for policy, so
+          // point at the actual control instead.
           warn(
             'Cloud approvals OFF (settings.approvers.cloud=false) — nothing syncs to the dashboard',
-            'Privacy mode is a valid choice; set approvers.cloud=true to sync.'
+            cfg.policySource === 'workspace'
+              ? 'The workspace config turned this off — change it at app.node9.ai (Enforcement).'
+              : 'Privacy mode is a valid choice; set approvers.cloud=true to sync.'
           );
         } else if (cfg.settings.shipper.enabled === false) {
           warn('Shipper disabled (settings.shipper.enabled=false) — audit rows stay local');

--- a/src/cli/commands/egress.ts
+++ b/src/cli/commands/egress.ts
@@ -11,6 +11,7 @@
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import { getConfig } from '../../config';
+import { cliGuardPolicyWrite } from '../../config/keyed-guard';
 import { DEFAULT_EGRESS_ALLOWLIST } from '@node9/policy-engine';
 import { type EgressBlock, setEgress, addEgressHost } from '../../auth/egress-config';
 
@@ -31,16 +32,19 @@ function guard(fn: () => void): boolean {
   }
 }
 
-function mutate(change: Partial<EgressBlock>): boolean {
+function mutate(action: string, change: Partial<EgressBlock>): boolean {
+  if (!cliGuardPolicyWrite(action)) return false;
   return guard(() => setEgress(change));
 }
 
 function addHost(list: 'allow' | 'deny', host: string): boolean {
+  if (!cliGuardPolicyWrite(`egress ${list} ${host}`)) return false;
   return guard(() => addEgressHost(list, host));
 }
 
 function showStatus(): void {
-  const e = getConfig().policy.egress;
+  const cfg = getConfig();
+  const e = cfg.policy.egress;
   const state = !e.enabled
     ? chalk.red('OFF — your agent can reach any host')
     : e.mode === 'block'
@@ -48,6 +52,11 @@ function showStatus(): void {
       : chalk.yellow('WATCHING (review) — unknown hosts prompt you');
   console.log(chalk.cyan.bold('\n🌐 Egress control'));
   console.log('  State: ' + state);
+  if (cfg.policySource === 'workspace') {
+    console.log(
+      chalk.gray('  Source: workspace config (app.node9.ai) — local egress settings are ignored')
+    );
+  }
   console.log(
     chalk.gray(
       `  ${DEFAULT_EGRESS_ALLOWLIST.length} common dev/LLM hosts are always allowed (github, npm, pypi, anthropic, …).`
@@ -71,7 +80,7 @@ export function registerEgressCommand(program: Command): void {
     .command('watch')
     .description('Prompt before the agent reaches an unknown host (review mode)')
     .action(() => {
-      if (!mutate({ enabled: true, mode: 'review' })) return;
+      if (!mutate('egress watch', { enabled: true, mode: 'review' })) return;
       console.log(chalk.green('\n✓ Egress is now watched (review mode).'));
       console.log(
         chalk.gray('  Routine hosts (LLM APIs, package registries, localhost) are allowed.')
@@ -85,7 +94,7 @@ export function registerEgressCommand(program: Command): void {
     .command('lock')
     .description('Block the agent from reaching unknown hosts (block mode)')
     .action(() => {
-      if (!mutate({ enabled: true, mode: 'block' })) return;
+      if (!mutate('egress lock', { enabled: true, mode: 'block' })) return;
       console.log(chalk.green('\n✓ Egress is now locked (block mode).'));
       console.log(chalk.gray('  Routine hosts are still allowed; unknown hosts are denied.'));
       console.log(chalk.gray('  Allow a specific host with `node9 egress allow <host>`.\n'));
@@ -111,7 +120,7 @@ export function registerEgressCommand(program: Command): void {
     .command('off')
     .description('Turn egress control off')
     .action(() => {
-      if (!mutate({ enabled: false })) return;
+      if (!mutate('egress off', { enabled: false })) return;
       console.log(
         chalk.yellow('\n✓ Egress control is off — the agent can reach any host again.\n')
       );

--- a/src/cli/commands/jail.ts
+++ b/src/cli/commands/jail.ts
@@ -5,6 +5,7 @@ import type { Command } from 'commander';
 import chalk from 'chalk';
 import { readJailPaths, addJailPath, removeJailPath, regenerateUserJail } from '../../shields/jail';
 import { appendConfigAudit } from '../../audit';
+import { cliGuardPolicyWrite, isKeyedForPolicy } from '../../config/keyed-guard';
 
 // Built-in jail coverage (mirrors project-jail.json + the engine's
 // SENSITIVE_PATH_RULES). Display-only — always on, not removable.
@@ -25,6 +26,7 @@ export function registerJailCommand(program: Command): void {
     .description('Add a path to the jail (default: block reads; --review to soften)')
     .option('--review', 'Require human approval instead of hard-blocking reads')
     .action((p: string, opts: { review?: boolean }) => {
+      if (!cliGuardPolicyWrite(`jail add ${p}`)) return;
       const verdict = opts.review ? 'review' : 'block';
       try {
         const paths = addJailPath(p, verdict);
@@ -48,6 +50,7 @@ export function registerJailCommand(program: Command): void {
     .command('remove <path>')
     .description('Remove a user-added jail path (built-in paths are not removable)')
     .action((p: string) => {
+      if (!cliGuardPolicyWrite(`jail remove ${p}`)) return;
       let result: { removed: boolean; paths: ReturnType<typeof readJailPaths> };
       try {
         result = removeJailPath(p);
@@ -90,15 +93,29 @@ export function registerJailCommand(program: Command): void {
         process.exit(1);
         return;
       }
+      // I10: the user-jail shield only enforces when the workspace mandates
+      // it — on a workspace-governed machine, locally-added paths are inert.
+      const wsGoverned = isKeyedForPolicy();
       if (user.length === 0) {
         console.log(
-          chalk.gray('  Your paths: (none) — add one with ') + chalk.cyan('node9 jail add <path>')
+          wsGoverned
+            ? chalk.gray(
+                '  Your paths: (none) — workspace config governs; add paths at app.node9.ai'
+              )
+            : chalk.gray('  Your paths: (none) — add one with ') +
+                chalk.cyan('node9 jail add <path>')
         );
       } else {
-        console.log(chalk.gray('  Your paths (removable):'));
+        console.log(
+          wsGoverned
+            ? chalk.gray('  Your paths — ignored (workspace config governs):')
+            : chalk.gray('  Your paths (removable):')
+        );
         for (const u of user) {
           const v = u.verdict === 'block' ? chalk.red('block ') : chalk.yellow('review');
-          console.log(`    ${v}  ${chalk.cyan(u.path)}`);
+          console.log(
+            `    ${v}  ${chalk.cyan(u.path)}${wsGoverned ? chalk.gray('  (ignored)') : ''}`
+          );
         }
       }
       console.log('');

--- a/src/cli/commands/shield.ts
+++ b/src/cli/commands/shield.ts
@@ -173,10 +173,18 @@ export function registerShieldCommand(program: Command): void {
       }
 
       const active = new Set(readActiveShields());
-      const cloud = readCloudShields();
       // I8: on a workspace-governed machine only the cloud set is enforced —
-      // a locally-enabled shield must not display as enabled.
-      const wsGoverned = getConfig().policySource === 'workspace';
+      // a locally-enabled shield must not display as enabled. What is ENFORCED
+      // is the resolver's own testimony (policy.appliedShields), the same
+      // source `shield status`, the MCP list and the TUI use. readCloudShields
+      // is a legacy heuristic over SHIELD:-tagged cache RULES and misses a
+      // shield mandated through the cache's `shields` array — it stays the
+      // unkeyed "☁ cloud" column only.
+      const cfgForList = getConfig();
+      const wsGoverned = cfgForList.policySource === 'workspace';
+      const cloud = wsGoverned
+        ? new Set(cfgForList.policy.appliedShields ?? [])
+        : readCloudShields();
       console.log(chalk.bold('\n🛡️  Available Shields\n'));
       if (wsGoverned) {
         console.log(chalk.gray('  Workspace config governs — local enables are ignored.\n'));

--- a/src/cli/commands/shield.ts
+++ b/src/cli/commands/shield.ts
@@ -23,6 +23,7 @@ import { buildShield } from '../../shields/build';
 import { createShield } from '../../shields/create';
 import type { ShieldDefinition } from '@node9/policy-engine';
 import { appendConfigAudit } from '../../audit';
+import { cliGuardPolicyWrite } from '../../config/keyed-guard';
 import { getConfig } from '../../config';
 import { httpsFetch } from '../../utils/https-fetch';
 
@@ -85,6 +86,7 @@ export function registerShieldCommand(program: Command): void {
     .command('enable <service>')
     .description('Enable a security shield for a specific service')
     .action((service: string) => {
+      if (!cliGuardPolicyWrite(`shield enable ${service}`)) return;
       const name = resolveShieldName(service);
       if (!name) {
         console.error(chalk.red(`\n❌ Unknown shield: "${service}"\n`));
@@ -119,6 +121,7 @@ export function registerShieldCommand(program: Command): void {
     .command('disable <service>')
     .description('Disable a security shield')
     .action((service: string) => {
+      if (!cliGuardPolicyWrite(`shield disable ${service}`)) return;
       const name = resolveShieldName(service);
       if (!name) {
         console.error(chalk.red(`\n❌ Unknown shield: "${service}"\n`));
@@ -171,20 +174,40 @@ export function registerShieldCommand(program: Command): void {
 
       const active = new Set(readActiveShields());
       const cloud = readCloudShields();
+      // I8: on a workspace-governed machine only the cloud set is enforced —
+      // a locally-enabled shield must not display as enabled.
+      const wsGoverned = getConfig().policySource === 'workspace';
       console.log(chalk.bold('\n🛡️  Available Shields\n'));
-      console.log(chalk.gray('  ● local · ☁ cloud\n'));
+      if (wsGoverned) {
+        console.log(chalk.gray('  Workspace config governs — local enables are ignored.\n'));
+      } else {
+        console.log(chalk.gray('  ● local · ☁ cloud\n'));
+      }
       for (const shield of listShields()) {
         const isLocal = active.has(shield.name);
         const isCloud = cloud.has(shield.name);
-        const status =
-          isLocal && isCloud
+        const status = wsGoverned
+          ? isCloud
+            ? chalk.green('☁  enabled ')
+            : isLocal
+              ? chalk.gray('○  ignored ')
+              : chalk.gray('○  disabled')
+          : isLocal && isCloud
             ? chalk.green('●☁ enabled ')
             : isLocal
               ? chalk.green('●  enabled ')
               : isCloud
                 ? chalk.cyan('☁  cloud   ')
                 : chalk.gray('○  disabled');
-        const via = isCloud && !isLocal ? chalk.gray(' (via dashboard)') : '';
+        const via = wsGoverned
+          ? isCloud
+            ? chalk.gray(' (workspace)')
+            : isLocal
+              ? chalk.gray(' (enabled locally — workspace config governs)')
+              : ''
+          : isCloud && !isLocal
+            ? chalk.gray(' (via dashboard)')
+            : '';
         console.log(
           `  ${status} ${chalk.cyan(shield.name.padEnd(12))} ${shield.description}${via}`
         );
@@ -201,7 +224,12 @@ export function registerShieldCommand(program: Command): void {
     .command('status')
     .description('Show active shields and their individual rules with verdicts')
     .action(() => {
-      const active = readActiveShields();
+      // I8: show what is ENFORCED. Workspace-governed machines run the
+      // cloud-mandated set (config.policy.appliedShields), not the local
+      // enable store.
+      const cfgForStatus = getConfig();
+      const wsGoverned = cfgForStatus.policySource === 'workspace';
+      const active = wsGoverned ? (cfgForStatus.policy.appliedShields ?? []) : readActiveShields();
       if (active.length === 0) {
         console.error(chalk.yellow('\nℹ️  No shields are active.\n'));
         console.error(`Run ${chalk.cyan('node9 shield list')} to see available shields.\n`);
@@ -209,6 +237,9 @@ export function registerShieldCommand(program: Command): void {
       }
       const overrides = readShieldOverrides();
       console.error(chalk.bold('\n🛡️  Active Shields\n'));
+      if (wsGoverned) {
+        console.error(chalk.gray('  Source: workspace config (app.node9.ai)\n'));
+      }
       for (const name of active) {
         const shield = getShield(name);
         if (!shield) continue;
@@ -250,6 +281,7 @@ export function registerShieldCommand(program: Command): void {
     .description('Override the verdict for a specific shield rule (block, review, or allow)')
     .option('--force', 'Required when setting verdict to allow (silences a block rule)')
     .action((service: string, rule: string, verdict: string, opts: { force?: boolean }) => {
+      if (!cliGuardPolicyWrite(`shield set ${service}`)) return;
       const name = resolveShieldName(service);
       if (!name) {
         console.error(chalk.red(`\n❌ Unknown shield: "${service}"\n`));
@@ -318,6 +350,7 @@ export function registerShieldCommand(program: Command): void {
     .command('unset <service> <rule>')
     .description('Remove a verdict override, restoring the shield default')
     .action((service: string, rule: string) => {
+      if (!cliGuardPolicyWrite(`shield unset ${service}`)) return;
       const name = resolveShieldName(service);
       if (!name) {
         console.error(chalk.red(`\n❌ Unknown shield: "${service}"\n`));
@@ -339,6 +372,7 @@ export function registerShieldCommand(program: Command): void {
     .command('install <name>')
     .description('Install a shield from the community marketplace into ~/.node9/shields/')
     .action((name: string) => {
+      if (!cliGuardPolicyWrite('shield install')) return;
       if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
         // Do not echo the raw name — it may contain ANSI escape sequences (terminal injection)
         console.error(
@@ -484,10 +518,17 @@ export function registerConfigShowCommand(program: Command): void {
     )
     .action(() => {
       const config = getConfig();
-      const active = readActiveShields();
+      // I8: "effective configuration" must show the ENFORCED shield set.
+      const wsGoverned = config.policySource === 'workspace';
+      const active = wsGoverned ? (config.policy.appliedShields ?? []) : readActiveShields();
       const overrides = readShieldOverrides();
 
       console.error(chalk.bold('\n🔍  Node9 Effective Configuration\n'));
+      if (wsGoverned) {
+        console.error(
+          chalk.gray('  Source: workspace config (app.node9.ai) — local policy files are ignored\n')
+        );
+      }
 
       // ── Mode ────────────────────────────────────────────────────────────────
       const modeLabel =

--- a/src/cli/commands/shield.ts
+++ b/src/cli/commands/shield.ts
@@ -453,6 +453,19 @@ export function registerShieldCommand(program: Command): void {
           overwrite?: boolean;
         }
       ) => {
+        // F3 (adversarial review): `create --enable` calls writeActiveShields,
+        // so it is a policy write the guard enumeration missed — it printed
+        // "Active now." on a workspace-governed machine while enforcing
+        // nothing. Only the ENABLE half is refused: authoring a definition
+        // locally and then mandating it from the dashboard is a real flow.
+        if (opts.enable && !cliGuardPolicyWrite(`shield create --enable ${name}`)) {
+          console.error(
+            chalk.gray(
+              '   Re-run without --enable to author the file, then mandate it from the dashboard.\n'
+            )
+          );
+          return;
+        }
         // Name guard mirrors `install` — do not echo a raw name (ANSI injection).
         if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
           console.error(
@@ -539,12 +552,18 @@ export function registerConfigShowCommand(program: Command): void {
       }
 
       // ── Mode ────────────────────────────────────────────────────────────────
+      // F5: `observe` is the mode where node9 enforces NOTHING (every
+      // block becomes a would-block), and a keyed machine applies a cloud
+      // observe verbatim — so an `else → standard` here reports the exact
+      // opposite of the truth on the one surface people check.
       const modeLabel =
         config.settings.mode === 'audit'
           ? chalk.blue('audit')
           : config.settings.mode === 'strict'
             ? chalk.red('strict')
-            : chalk.white('standard');
+            : config.settings.mode === 'observe'
+              ? chalk.magenta('observe (nothing is enforced)')
+              : chalk.white('standard');
       console.error(`  Mode: ${modeLabel}\n`);
 
       // ── Active Shields ───────────────────────────────────────────────────────

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -146,13 +146,32 @@ export function registerStatusCommand(program: Command): void {
             : chalk.white('standard');
       console.log(`  Mode:    ${modeLabel}`);
 
+      // I1: on a keyed machine the local config files are present but INERT
+      // for policy — saying "Active" here would be a lie the user acts on.
+      const wsGoverned = mergedConfig.policySource === 'workspace';
+      if (wsGoverned) {
+        console.log(`  Policy:  ${chalk.cyan('Workspace config (app.node9.ai)')}`);
+      }
+      const ignoredLabel = chalk.gray('Present — ignored (workspace config governs)');
       const projectConfig = path.join(process.cwd(), 'node9.config.json');
       const globalConfig = path.join(os.homedir(), '.node9', 'config.json');
       console.log(
-        `  Local:   ${fs.existsSync(projectConfig) ? chalk.green('Active (node9.config.json)') : chalk.gray('Not present')}`
+        `  Local:   ${
+          fs.existsSync(projectConfig)
+            ? wsGoverned
+              ? ignoredLabel
+              : chalk.green('Active (node9.config.json)')
+            : chalk.gray('Not present')
+        }`
       );
       console.log(
-        `  Global:  ${fs.existsSync(globalConfig) ? chalk.green('Active (~/.node9/config.json)') : chalk.gray('Not present')}`
+        `  Global:  ${
+          fs.existsSync(globalConfig)
+            ? wsGoverned
+              ? ignoredLabel
+              : chalk.green('Active (~/.node9/config.json)')
+            : chalk.gray('Not present')
+        }`
       );
 
       if (mergedConfig.policy.sandboxPaths.length > 0) {

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -138,12 +138,18 @@ export function registerStatusCommand(program: Command): void {
 
       // ── Configuration State ──────────────────────────────────────────────────
       console.log('');
+      // F5: `observe` is the mode where node9 enforces NOTHING (every
+      // block becomes a would-block), and a keyed machine applies a cloud
+      // observe verbatim — so an `else → standard` here reports the exact
+      // opposite of the truth on the one surface people check.
       const modeLabel =
         settings.mode === 'audit'
           ? chalk.blue('audit')
           : settings.mode === 'strict'
             ? chalk.red('strict')
-            : chalk.white('standard');
+            : settings.mode === 'observe'
+              ? chalk.magenta('observe (nothing is enforced)')
+              : chalk.white('standard');
       console.log(`  Mode:    ${modeLabel}`);
 
       // I1: on a keyed machine the local config files are present but INERT

--- a/src/cli/commands/trust.ts
+++ b/src/cli/commands/trust.ts
@@ -10,6 +10,7 @@ import {
   removeTrustedHost,
   normalizeHost,
 } from '../../auth/trusted-hosts.js';
+import { cliGuardPolicyWrite } from '../../config/keyed-guard';
 
 /** Loose hostname validator: FQDN or wildcard glob (*.example.com). */
 function isValidHost(host: string): boolean {
@@ -26,6 +27,7 @@ export function registerTrustCommand(program: Command): void {
     .command('add <host>')
     .description('Add a trusted host — pipe-chain blocks targeting this host are downgraded')
     .action((host: string) => {
+      if (!cliGuardPolicyWrite(`trust add ${host}`)) return;
       const normalized = normalizeHost(host.trim());
       if (!isValidHost(normalized)) {
         console.error(
@@ -46,6 +48,7 @@ export function registerTrustCommand(program: Command): void {
     .command('remove <host>')
     .description('Remove a trusted host')
     .action((host: string) => {
+      if (!cliGuardPolicyWrite(`trust remove ${host}`)) return;
       const normalized = normalizeHost(host.trim());
       const removed = removeTrustedHost(normalized);
       if (!removed) {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -171,6 +171,9 @@ export interface Config {
     managedJailPaths: Array<{ path: string; verdict: 'block' | 'review' }>;
   };
   environments: Record<string, EnvironmentConfig>;
+  /** PR-2: 'workspace' = keyed (policy from the cloud); 'local' = the
+   *  local stack (unkeyed, --local, named profiles). */
+  policySource: 'workspace' | 'local';
 }
 
 // Default Enterprise Posture
@@ -201,6 +204,7 @@ export const DANGEROUS_WORDS = [
 // 2. The Master Default Config
 export const DEFAULT_CONFIG: Config = {
   version: '1.0',
+  policySource: 'local',
   settings: {
     mode: 'standard',
     autoStartDaemon: true,
@@ -527,7 +531,16 @@ export function getGlobalSettings(): {
   };
 }
 
-export function getCredentials() {
+export function getCredentials(): {
+  apiKey: string;
+  apiUrl: string;
+  /** `node9 login --local` — the key is for audit/telemetry only and the
+   *  machine PROMISED local policy control (PR-2 §0.1). A named profile is
+   *  localOnly too (§0.11): profiles never policy-sync, so treating them as
+   *  fully keyed would strand them on shipped defaults forever. Env keys
+   *  (CI) have no localOnly channel — always fully keyed. */
+  localOnly?: boolean;
+} | null {
   const DEFAULT_API_URL = 'https://api.node9.ai/api/v1/intercept';
   if (process.env.NODE9_API_KEY) {
     return {
@@ -546,12 +559,14 @@ export function getCredentials() {
         return {
           apiKey: profile.apiKey as string,
           apiUrl: (profile.apiUrl as string) || DEFAULT_API_URL,
+          localOnly: profile.localOnly === true || profileName !== 'default',
         };
       }
       if (creds.apiKey) {
         return {
           apiKey: creds.apiKey as string,
           apiUrl: (creds.apiUrl as string) || DEFAULT_API_URL,
+          localOnly: creds.localOnly === true,
         };
       }
     }
@@ -756,19 +771,51 @@ export function getConfig(cwd?: string): Config {
     return i === -1 ? 1 : i;
   };
 
-  const applyLayer = (source: Record<string, unknown> | null, isProject = false) => {
+  // ── THE PR-2 FORK (one keyed check, one place) ────────────────────────────
+  // Two working modes (the founder's model): local without server sync, or
+  // full sync through the SaaS. A keyed machine builds POLICY from
+  // DEFAULT_CONFIG + the cloud config only — the local layers below apply
+  // their OPERATIONAL settings and then stop. localOnly keys (`login
+  // --local`, named profiles) keep the local promise and stay unkeyed here.
+  const pr2Creds = getCredentials();
+  const keyed = !!pr2Creds?.apiKey && pr2Creds.localOnly !== true;
+
+  const applyLayer = (
+    source: Record<string, unknown> | null,
+    isProject = false,
+    isCloud = false
+  ) => {
     if (!source) return;
     const s = (source.settings || {}) as Partial<Config['settings']>;
     const p = (source.policy || {}) as Partial<Config['policy']>;
 
-    if (s.mode !== undefined) mergedSettings.mode = s.mode;
+    // ── OPERATIONAL settings — machine plumbing, applied on EVERY machine
+    //    (the dashboard cannot express these; they are not policy) ──
     if (s.autoStartDaemon !== undefined) mergedSettings.autoStartDaemon = s.autoStartDaemon;
     // enableUndo is deliberately NOT merged here — the undo feature was removed.
     // It is pinned false below, after every layer. See the "Undo removed" block.
     if (s.enableHookLogDebug !== undefined)
       mergedSettings.enableHookLogDebug = s.enableHookLogDebug;
-    if (s.approvers) mergedSettings.approvers = { ...mergedSettings.approvers, ...s.approvers };
     if (s.shipper) mergedSettings.shipper = { ...mergedSettings.shipper, ...s.shipper };
+    if (s.cloudSyncIntervalHours !== undefined)
+      mergedSettings.cloudSyncIntervalHours = s.cloudSyncIntervalHours;
+    if (s.mcpAutoWrap !== undefined) mergedSettings.mcpAutoWrap = s.mcpAutoWrap === true;
+    if (s.mcpReconcileIntervalMinutes !== undefined)
+      mergedSettings.mcpReconcileIntervalMinutes = s.mcpReconcileIntervalMinutes;
+    if (s.mcpStaleAfterDays !== undefined) mergedSettings.mcpStaleAfterDays = s.mcpStaleAfterDays;
+    if (s.hud !== undefined) mergedSettings.hud = { ...mergedSettings.hud, ...s.hud };
+
+    // ── THE FORK: on a keyed machine the local POLICY layers are inert.
+    //    Everything below this line is policy (mode, approvers, review knobs,
+    //    rules, egress, dlp, jail, environments…) and comes from
+    //    DEFAULT_CONFIG + the cloud only. mcpAllowWeakening is POLICY
+    //    (§0.9): it is the switch that re-enables agent-driven weakening.
+    //    The CLOUD layer (rules-cache smartRules) is the one caller that must
+    //    pass — it IS the workspace policy a keyed machine follows (K13c). ──
+    if (keyed && !isCloud) return;
+
+    if (s.mode !== undefined) mergedSettings.mode = s.mode;
+    if (s.approvers) mergedSettings.approvers = { ...mergedSettings.approvers, ...s.approvers };
     if (s.approvalTimeoutMs !== undefined) mergedSettings.approvalTimeoutMs = s.approvalTimeoutMs;
     // approvalTimeoutSeconds is the user-facing alias; convert to ms.
     // approvalTimeoutMs takes precedence if both are present.
@@ -777,13 +824,6 @@ export function getConfig(cwd?: string): Config {
     if (s.environment !== undefined) mergedSettings.environment = s.environment;
     if (s.reviewChannel !== undefined) mergedSettings.reviewChannel = s.reviewChannel;
     if (s.mcpAllowWeakening !== undefined) mergedSettings.mcpAllowWeakening = s.mcpAllowWeakening;
-    if (s.cloudSyncIntervalHours !== undefined)
-      mergedSettings.cloudSyncIntervalHours = s.cloudSyncIntervalHours;
-    if (s.mcpAutoWrap !== undefined) mergedSettings.mcpAutoWrap = s.mcpAutoWrap === true;
-    if (s.mcpReconcileIntervalMinutes !== undefined)
-      mergedSettings.mcpReconcileIntervalMinutes = s.mcpReconcileIntervalMinutes;
-    if (s.mcpStaleAfterDays !== undefined) mergedSettings.mcpStaleAfterDays = s.mcpStaleAfterDays;
-    if (s.hud !== undefined) mergedSettings.hud = { ...mergedSettings.hud, ...s.hud };
 
     if (p.sandboxPaths) mergedPolicy.sandboxPaths.push(...p.sandboxPaths);
     if (p.ignoredTools) mergedPolicy.ignoredTools.push(...p.ignoredTools);
@@ -944,6 +984,16 @@ export function getConfig(cwd?: string): Config {
   applyLayer(globalConfig);
   applyLayer(projectConfig, /* isProject */ true);
 
+  // §0.3 — login writes approvers.cloud=true into the LOCAL file, which a
+  // keyed machine no longer reads. Without this line, replace-mode would
+  // silently stop audit shipping (audit-shipper gates on approvers.cloud)
+  // and dashboard approvals on every keyed machine whose workspace never
+  // set approvers. Keyed default = cloud approvals ON; the managed
+  // approvers block below still replaces per-field if the org says so.
+  if (keyed) {
+    mergedSettings.approvers = { ...mergedSettings.approvers, cloud: true };
+  }
+
   // ── Cloud rules cache layer ───────────────────────────────────────────────
   // Rules synced from the cloud dashboard are applied after local config so
   // admin-defined policy takes precedence over per-user overrides.
@@ -998,7 +1048,7 @@ export function getConfig(cwd?: string): Config {
       // cache, logs instead of silently dropping cloud enforcement (fail-open).
       const raw = readRulesCacheResilient(cacheFile);
       if (Array.isArray(raw.rules) && raw.rules.length > 0) {
-        applyLayer({ policy: { smartRules: raw.rules } });
+        applyLayer({ policy: { smartRules: raw.rules } }, false, /* isCloud */ true);
       }
       if (Array.isArray(raw.shields)) {
         cloudManagedShields = raw.shields.filter((s): s is string => typeof s === 'string');
@@ -1046,12 +1096,21 @@ export function getConfig(cwd?: string): Config {
           ? mc.locked.filter((f): f is string => typeof f === 'string')
           : [];
         // M2a: settings.mode.
+        // §0.2 — keyed applies the cloud VERBATIM (validated): the floor
+        // helper treats the seeded DEFAULT 'standard' as a local opinion and
+        // silently discards a cloud observe/audit. Unkeyed keeps the floor.
         if (typeof mc.mode === 'string') {
-          mergedSettings.mode = resolveManagedMode(
-            mergedSettings.mode,
-            mc.mode,
-            locked.includes('mode')
-          );
+          if (keyed) {
+            if (['observe', 'audit', 'standard', 'strict'].includes(mc.mode)) {
+              mergedSettings.mode = mc.mode as Config['settings']['mode'];
+            }
+          } else {
+            mergedSettings.mode = resolveManagedMode(
+              mergedSettings.mode,
+              mc.mode,
+              locked.includes('mode')
+            );
+          }
         }
         // The cloud has spoken about mode iff it set one or locked it — NODE9_MODE
         // must not override either (B1 #1).
@@ -1063,45 +1122,84 @@ export function getConfig(cwd?: string): Config {
         if (mc.egress && typeof mc.egress === 'object') {
           const hosts = (v: unknown): string[] | undefined =>
             Array.isArray(v) ? v.filter((h): h is string => typeof h === 'string') : undefined;
-          mergedPolicy.egress = applyManagedEgress(
-            mergedPolicy.egress,
-            {
-              enabled: typeof mc.egress.enabled === 'boolean' ? mc.egress.enabled : undefined,
-              mode: typeof mc.egress.mode === 'string' ? mc.egress.mode : undefined,
-              allow: hosts(mc.egress.allow),
-              deny: hosts(mc.egress.deny),
-              allowPrivate:
-                typeof mc.egress.allowPrivate === 'boolean' ? mc.egress.allowPrivate : undefined,
-            },
-            locked,
-            egressModeUserSet
-          );
+          if (keyed) {
+            // §0.2 keyed verbatim: the workspace value IS the value — no
+            // force-on ratchet, no floors, no lock arithmetic. Validated
+            // field-by-field (the cache file can be hand-edited).
+            const e = mc.egress;
+            if (typeof e.enabled === 'boolean') mergedPolicy.egress.enabled = e.enabled;
+            if (e.mode === 'off' || e.mode === 'review' || e.mode === 'block')
+              mergedPolicy.egress.mode = e.mode;
+            const allow = hosts(e.allow);
+            if (allow) mergedPolicy.egress.allow = allow;
+            const deny = hosts(e.deny);
+            if (deny) mergedPolicy.egress.deny = deny;
+            if (typeof e.allowPrivate === 'boolean')
+              mergedPolicy.egress.allowPrivate = e.allowPrivate;
+          } else {
+            mergedPolicy.egress = applyManagedEgress(
+              mergedPolicy.egress,
+              {
+                enabled: typeof mc.egress.enabled === 'boolean' ? mc.egress.enabled : undefined,
+                mode: typeof mc.egress.mode === 'string' ? mc.egress.mode : undefined,
+                allow: hosts(mc.egress.allow),
+                deny: hosts(mc.egress.deny),
+                allowPrivate:
+                  typeof mc.egress.allowPrivate === 'boolean' ? mc.egress.allowPrivate : undefined,
+              },
+              locked,
+              egressModeUserSet
+            );
+          }
         }
         // M2c: policy.dlp. enabled force-on; pii floor over off<block;
         // reviewAction floor over review<block (inline-ask v2).
         if (mc.dlp && typeof mc.dlp === 'object') {
-          mergedPolicy.dlp = applyManagedDlp(
-            mergedPolicy.dlp,
-            {
-              enabled: typeof mc.dlp.enabled === 'boolean' ? mc.dlp.enabled : undefined,
-              pii: typeof mc.dlp.pii === 'string' ? mc.dlp.pii : undefined,
-              reviewAction:
-                mc.dlp.reviewAction === 'review' || mc.dlp.reviewAction === 'block'
-                  ? mc.dlp.reviewAction
-                  : undefined,
-            },
-            locked
-          );
+          if (keyed) {
+            // §0.2 keyed verbatim: the force-on ratchet made a cloud
+            // dlp.enabled:false impossible — the exact value PR-1's UI gained
+            // an `off` option to set (X-12).
+            if (typeof mc.dlp.enabled === 'boolean') mergedPolicy.dlp.enabled = mc.dlp.enabled;
+            if (mc.dlp.pii === 'off' || mc.dlp.pii === 'block') mergedPolicy.dlp.pii = mc.dlp.pii;
+            if (mc.dlp.reviewAction === 'review' || mc.dlp.reviewAction === 'block')
+              mergedPolicy.dlp.reviewAction = mc.dlp.reviewAction;
+          } else {
+            mergedPolicy.dlp = applyManagedDlp(
+              mergedPolicy.dlp,
+              {
+                enabled: typeof mc.dlp.enabled === 'boolean' ? mc.dlp.enabled : undefined,
+                pii: typeof mc.dlp.pii === 'string' ? mc.dlp.pii : undefined,
+                reviewAction:
+                  mc.dlp.reviewAction === 'review' || mc.dlp.reviewAction === 'block'
+                    ? mc.dlp.reviewAction
+                    : undefined,
+              },
+              locked
+            );
+          }
         }
         // Command-checks governance: per-key floor over off<review<block +
         // per-key locks (applyManagedCommandChecks validates and enforces the
         // Class-B no-'off' rule even against a hostile cloud value).
         if (mc.commandChecks && typeof mc.commandChecks === 'object') {
-          mergedPolicy.commandChecks = applyManagedCommandChecks(
-            mergedPolicy.commandChecks ?? {},
-            mc.commandChecks as Record<string, string>,
-            locked
-          );
+          if (keyed) {
+            // §0.2 keyed verbatim, per key. Class-B keys stay tighten-only
+            // even against a hand-edited cache file.
+            const CLASS_B = new Set(['evalDynamic', 'pipeChainHigh']);
+            const next: Record<string, string> = { ...(mergedPolicy.commandChecks ?? {}) };
+            for (const [key, val] of Object.entries(mc.commandChecks)) {
+              if (val !== 'off' && val !== 'review' && val !== 'block') continue;
+              if (val === 'off' && CLASS_B.has(key)) continue;
+              next[key] = val;
+            }
+            mergedPolicy.commandChecks = next;
+          } else {
+            mergedPolicy.commandChecks = applyManagedCommandChecks(
+              mergedPolicy.commandChecks ?? {},
+              mc.commandChecks as Record<string, string>,
+              locked
+            );
+          }
           // Remember which advisory knobs the ORG set/locked so the injection
           // loop can pin them (see managedCommandCheckKeys declaration).
           for (const [key, val] of Object.entries(mc.commandChecks)) {
@@ -1291,7 +1389,19 @@ export function getConfig(cwd?: string): Config {
   const shieldOverrides = readShieldOverrides();
   // Local shields ∪ cloud-managed shields (M1). Deduped so a shield enabled both
   // locally and from the dashboard is applied once.
-  const activeShieldNames = [...new Set([...readActiveShields(), ...cloudManagedShields])];
+  // PR-2 §B: on a keyed machine the trust list is exactly the cloud's —
+  // even when the cloud is silent (empty list). Without this, the gateway's
+  // fresh isTrustedHost read of the LOCAL trusted-hosts.json (5s TTL) leaks
+  // a `node9 trust add` past the skipped local layer into enforcement.
+  if (keyed) mergedPolicy.trustedHostsManaged = true;
+
+  // One listening point (PR-2): a keyed machine runs the CLOUD-mandated
+  // shields only — shields.json is the unkeyed machine's enable store. The
+  // Devices "Add this device's setup to the workspace" import is the paved
+  // path for bringing a machine's local shields up before flipping.
+  const activeShieldNames = keyed
+    ? [...new Set(cloudManagedShields)]
+    : [...new Set([...readActiveShields(), ...cloudManagedShields])];
   // Filled by the apply loop below; becomes policy.appliedShields (N6).
   const appliedShields: string[] = [];
   // B1: a cloud-mandated shield is enforced EXACTLY as the cloud defines it —
@@ -1456,6 +1566,9 @@ export function getConfig(cwd?: string): Config {
   if (
     envMode &&
     !modeCloudControlled &&
+    // PR-2: one listening point includes the env var — a keyed machine's
+    // mode comes from the workspace (or the shipped default), never the shell.
+    !keyed &&
     (['observe', 'audit', 'standard', 'strict'] as const).includes(envMode as never)
   ) {
     mergedSettings.mode = envMode;
@@ -1541,6 +1654,10 @@ export function getConfig(cwd?: string): Config {
     settings: mergedSettings,
     policy: mergedPolicy,
     environments: mergedEnvironments,
+    // PR-2 — the one truth introspection reads: which of the two working
+    // modes this machine is in. 'workspace' = keyed, policy from the cloud;
+    // 'local' = the local stack (incl. --local / named-profile keys).
+    policySource: keyed ? 'workspace' : 'local',
   };
 
   // Only populate the cache when using the ambient cwd — explicit cwd calls are

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -14,6 +14,8 @@ import {
   applyManagedApprovers,
   applyManagedCommandChecks,
   COMMAND_CHECK_ORDER,
+  COMMAND_CHECK_KEYS,
+  CLASS_B_COMMAND_CHECKS,
   strictestOf,
 } from './managed';
 import { pathRules } from '../shields/build';
@@ -1185,11 +1187,17 @@ export function getConfig(cwd?: string): Config {
           if (keyed) {
             // §0.2 keyed verbatim, per key. Class-B keys stay tighten-only
             // even against a hand-edited cache file.
-            const CLASS_B = new Set(['evalDynamic', 'pipeChainHigh']);
+            // F8: iterate the KNOWN key list (as applyManagedCommandChecks
+            // does) rather than whatever keys the cache happens to carry — a
+            // hand-edited cache must not seed arbitrary keys into the policy
+            // object. Class-B ('off' is never storable) comes from the shared
+            // list so this invariant has ONE definition, not a second copy.
+            const src = mc.commandChecks as Record<string, unknown>;
             const next: Record<string, string> = { ...(mergedPolicy.commandChecks ?? {}) };
-            for (const [key, val] of Object.entries(mc.commandChecks)) {
+            for (const key of COMMAND_CHECK_KEYS) {
+              const val = src[key];
               if (val !== 'off' && val !== 'review' && val !== 'block') continue;
-              if (val === 'off' && CLASS_B.has(key)) continue;
+              if (val === 'off' && CLASS_B_COMMAND_CHECKS.has(key)) continue;
               next[key] = val;
             }
             mergedPolicy.commandChecks = next;

--- a/src/config/keyed-guard.ts
+++ b/src/config/keyed-guard.ts
@@ -1,0 +1,54 @@
+// src/config/keyed-guard.ts
+// PR-2 write-guard: on a machine keyed for policy (config.policySource ===
+// 'workspace') the local policy stores are INERT — getConfig builds policy
+// from DEFAULT_CONFIG + the cloud only. A local policy write (shield enable,
+// egress lock, trust add, jail add…) would succeed on disk and then silently
+// do nothing, which is worse than a refusal: the user believes they changed
+// enforcement. So every local policy-write surface refuses with a pointer to
+// the dashboard and a NON-ZERO exit (a script that thinks it hardened a keyed
+// machine must fail loudly, not no-op green).
+//
+// What this does NOT guard: operational commands (init, logout, daemon…),
+// incident commands (dlp resolve, sandbox, undo), and reads. Logout / `node9
+// login --local` are the paved paths back to local policy control.
+
+import chalk from 'chalk';
+import { getConfig } from './index';
+
+/** True when this machine follows the workspace configuration for POLICY.
+ *  Delegates to the one truth (config.policySource) — never re-derive
+ *  keyedness from credentials here. A config-load failure counts as NOT
+ *  keyed: the write itself will surface the real error, and blocking a
+ *  local machine's writes on a corrupt config would strand it. */
+export function isKeyedForPolicy(): boolean {
+  try {
+    return getConfig().policySource === 'workspace';
+  } catch {
+    return false;
+  }
+}
+
+/** One sentence, shared verbatim by the CLI and the MCP refusals so the
+ *  gauntlet can assert on it. */
+export const KEYED_POLICY_WRITE_REASON =
+  'This machine follows the workspace configuration — policy is edited in the dashboard, not on this machine.';
+
+export function keyedPolicyWriteMessage(action: string): string {
+  return (
+    `${KEYED_POLICY_WRITE_REASON}\n` +
+    `  Edit policy at https://app.node9.ai → Enforcement (change: ${action}).\n` +
+    `  For local policy control, disconnect this machine (node9 logout) or reconnect with node9 login --local.`
+  );
+}
+
+/**
+ * CLI seam: call first in every policy-writing command action.
+ * Returns true when the write may proceed; otherwise prints the refusal,
+ * sets a non-zero exit code, and returns false.
+ */
+export function cliGuardPolicyWrite(action: string): boolean {
+  if (!isKeyedForPolicy()) return true;
+  console.error(chalk.yellow(`\n⛔ ${keyedPolicyWriteMessage(action)}\n`));
+  process.exitCode = 1;
+  return false;
+}

--- a/src/config/managed.ts
+++ b/src/config/managed.ts
@@ -224,6 +224,14 @@ export const COMMAND_CHECK_KEYS = [
   'pipeChainHigh',
 ] as const;
 export type CommandCheckKey = (typeof COMMAND_CHECK_KEYS)[number];
+
+/** Class-B checks are TIGHTEN-ONLY: 'off' is never storable for these, on any
+ *  path (local layer, managed floor, or the keyed verbatim branch). ONE
+ *  definition — a second copy is a security invariant waiting to drift. */
+export const CLASS_B_COMMAND_CHECKS: ReadonlySet<string> = new Set([
+  'evalDynamic',
+  'pipeChainHigh',
+]);
 export type ManagedCommandChecks = Partial<Record<CommandCheckKey, string>>;
 
 export function applyManagedCommandChecks<T extends Partial<Record<CommandCheckKey, string>>>(
@@ -243,7 +251,7 @@ export function applyManagedCommandChecks<T extends Partial<Record<CommandCheckK
     });
     // Class-B safety: never store 'off' for tighten-only keys even if a
     // hostile/buggy cloud value slips past upstream validation.
-    if ((key === 'evalDynamic' || key === 'pipeChainHigh') && resolved === 'off') continue;
+    if (CLASS_B_COMMAND_CHECKS.has(key) && resolved === 'off') continue;
     next[key] = resolved as T[CommandCheckKey];
   }
   return next;

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -32,7 +32,16 @@ export function writeCredentialsAndConfig(
   } catch {
     // Corrupt creds file — overwrite rather than fail the login/connect.
   }
-  existingCreds[profileName] = { apiKey, apiUrl: DEFAULT_API_URL };
+  // PR-2 §0.1 — the `--local` promise ("all decisions stay on this machine")
+  // is finally PERSISTED where keyedness is decided: getCredentials reads
+  // localOnly and such a machine keeps the LOCAL policy stack (audit/telemetry
+  // still ship on the key). Without this flag the promise evaporated the
+  // moment replace-mode keyed on the bare apiKey.
+  existingCreds[profileName] = {
+    apiKey,
+    apiUrl: DEFAULT_API_URL,
+    ...(opts.isLocal ? { localOnly: true } : {}),
+  };
   fs.writeFileSync(credPath, JSON.stringify(existingCreds, null, 2), {
     mode: 0o600,
   });

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -9,6 +9,7 @@ import { randomUUID } from 'crypto';
 import { spawnSync } from 'child_process';
 import chalk from 'chalk';
 import { authorizeHeadless, getGlobalSettings, getConfig, _resetConfigCache } from '../core';
+import { isKeyedForPolicy } from '../config/keyed-guard';
 // SHIELDS / readActiveShields no longer used in server.ts after the
 // /shields route was removed (v3 browser-removal). CLI shield commands
 // import these directly.
@@ -792,7 +793,14 @@ export function startDaemon(): void {
         // success. Dropping the key makes the write a no-op instead.
         if (data.enableHookLogDebug !== undefined)
           writeGlobalSetting('enableHookLogDebug', data.enableHookLogDebug);
-        if (data.approvers !== undefined) writeGlobalSetting('approvers', data.approvers);
+        // F7 (adversarial review): `approvers` is POLICY. On a
+        // workspace-governed machine getConfig rebuilds it from the workspace
+        // (plus the forced cloud:true) and never reads the local value, so
+        // writing it here is the same "lie on disk, acknowledged as success"
+        // the enableUndo comment above describes. Drop it rather than
+        // pretending — the MCP twin (node9_approver_set) is already guarded.
+        if (data.approvers !== undefined && !isKeyedForPolicy())
+          writeGlobalSetting('approvers', data.approvers);
         res.writeHead(200);
         return res.end(JSON.stringify({ ok: true }));
       } catch {

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -684,9 +684,12 @@ export function startDaemon(): void {
 
     if (req.method === 'GET' && pathname === '/status') {
       try {
-        const s = getGlobalSettings();
         const counters = sessionCounters.get();
-        const mode = (s.mode ?? 'standard') as HudStatus['mode'];
+        // PR-2 §0.6: the HUD's mode is the EFFECTIVE mode from the full
+        // merge — getGlobalSettings reads the raw local file (default
+        // 'audit'), which on a keyed machine is exactly the value the
+        // machine ignores.
+        const mode = getConfig().settings.mode as HudStatus['mode'];
         const status: HudStatus = {
           mode,
           session: {

--- a/src/daemon/sync.ts
+++ b/src/daemon/sync.ts
@@ -908,9 +908,15 @@ async function pushPostureSnapshot(creds: { apiKey: string; apiUrl: string }): P
 // other pushes; opt-out via NODE9_POLICY_MIRROR_DISABLE=1.
 async function pushPolicySnapshot(creds: { apiKey: string; apiUrl: string }): Promise<void> {
   try {
+    const cfg = getConfig();
     const body = buildPolicySnapshot(
-      getConfig(),
-      readActiveShields(),
+      // PR-2 §0.5: ship what the CONFIG APPLIED (appliedShields), not the
+      // local enable store — a keyed machine ignores shields.json, and
+      // shipping the file made every keyed machine show permanent false
+      // "not-applied" drift in Devices. cfg is built once and reused so the
+      // snapshot and the shipped list can never disagree.
+      cfg,
+      cfg.policy.appliedShields ?? readActiveShields(),
       readShieldOverrides(),
       readMcpToolsConfig(),
       // Merged config-vs-connected status. resolveMcpStatus reads process.env to
@@ -940,9 +946,15 @@ export async function runPolicyPush(): Promise<{ ok: true } | { ok: false; reaso
     };
   }
   try {
+    const cfg = getConfig();
     const body = buildPolicySnapshot(
-      getConfig(),
-      readActiveShields(),
+      // PR-2 §0.5: ship what the CONFIG APPLIED (appliedShields), not the
+      // local enable store — a keyed machine ignores shields.json, and
+      // shipping the file made every keyed machine show permanent false
+      // "not-applied" drift in Devices. cfg is built once and reused so the
+      // snapshot and the shipped list can never disagree.
+      cfg,
+      cfg.policy.appliedShields ?? readActiveShields(),
       readShieldOverrides(),
       readMcpToolsConfig(),
       // Merged config-vs-connected status. resolveMcpStatus reads process.env to

--- a/src/mcp-gateway/index.ts
+++ b/src/mcp-gateway/index.ts
@@ -19,6 +19,7 @@ import chalk from 'chalk';
 import { spawn } from 'child_process';
 import { execa } from 'execa';
 import { authorizeHeadless } from '../auth/orchestrator';
+import { _resetConfigCache } from '../config';
 import { auditLocalAllow } from '../auth/cloud';
 import { getCredentials } from '../config';
 import { buildNegotiationMessage } from '../policy/negotiation';
@@ -463,6 +464,11 @@ export async function runMcpGateway(
         const toolArgs = (message.params?.arguments ?? message.params?.tool_input ?? {}) as unknown;
         const mcpServer = resolveServerLabel(toolName, serverKey, upstreamCommand, configName);
 
+        // PR-2 §0.10: the gateway is long-lived and getConfig caches ambient
+        // calls — without this reset, a login/logout that flips the ENTIRE
+        // policy source (local ↔ workspace) goes unnoticed until restart.
+        // The daemon already resets per-check; the gateway now matches.
+        _resetConfigCache();
         const result = await authorizeHeadless(toolName, toolArgs, {
           agent: clientName ?? 'MCP-Gateway',
           mcpServer,

--- a/src/mcp-server/index.ts
+++ b/src/mcp-server/index.ts
@@ -15,6 +15,7 @@ import path from 'path';
 import { spawnSync } from 'child_process';
 import { classifyDecision, decisionTag } from '../audit/decision';
 import { getConfig, checkPause } from '../core';
+import { isKeyedForPolicy, KEYED_POLICY_WRITE_REASON } from '../config/keyed-guard';
 import { isDaemonRunning } from '../auth/daemon';
 import {
   listShields,
@@ -402,11 +403,19 @@ function handleStatus(): string {
   const settings = config.settings;
   const paused = checkPause();
   const daemonUp = isDaemonRunning();
-  const activeShields = readActiveShields();
+  // I7: report the shields the engine ACTUALLY applied on this load — on a
+  // workspace-governed machine the local enable store is not that list.
+  const wsGoverned = config.policySource === 'workspace';
+  const activeShields = wsGoverned ? (config.policy.appliedShields ?? []) : readActiveShields();
 
   const lines: string[] = [];
 
   lines.push(`Mode: ${settings.mode}`);
+  if (wsGoverned) {
+    lines.push(
+      'Policy source: workspace config (app.node9.ai) — local config files are ignored for policy'
+    );
+  }
   lines.push(`Daemon: ${daemonUp ? 'running' : 'stopped'}`);
 
   if (paused.paused) {
@@ -424,11 +433,12 @@ function handleStatus(): string {
 
   const projectConfig = path.join(process.cwd(), 'node9.config.json');
   const globalConfig = path.join(os.homedir(), '.node9', 'config.json');
+  const presentLabel = wsGoverned ? 'present — ignored (workspace config governs)' : 'present';
   lines.push(
-    `Project config (node9.config.json): ${fs.existsSync(projectConfig) ? 'present' : 'not found'}`
+    `Project config (node9.config.json): ${fs.existsSync(projectConfig) ? presentLabel : 'not found'}`
   );
   lines.push(
-    `Global config (~/.node9/config.json): ${fs.existsSync(globalConfig) ? 'present' : 'not found'}`
+    `Global config (~/.node9/config.json): ${fs.existsSync(globalConfig) ? presentLabel : 'not found'}`
   );
 
   return lines.join('\n');
@@ -438,6 +448,7 @@ function handleConfigGet(): string {
   const config = getConfig();
   const s = config.settings;
   const lines: string[] = [
+    `source: ${config.policySource === 'workspace' ? 'workspace config (app.node9.ai) — local policy fields ignored' : 'local config'}`,
     `mode: ${s.mode}`,
     `flightRecorder: ${s.flightRecorder}`,
     `approvalTimeoutMs: ${s.approvalTimeoutMs}`,
@@ -456,17 +467,33 @@ function handleConfigGet(): string {
 
 function handleShieldList(): string {
   const all = listShields();
-  const active = new Set(readActiveShields());
+  // I8: what's ENFORCED is config.policy.appliedShields. On a
+  // workspace-governed machine the local enable store is inert — a shield
+  // enabled only locally must not display as active.
+  const cfg = getConfig();
+  const wsGoverned = cfg.policySource === 'workspace';
+  const active = new Set(wsGoverned ? (cfg.policy.appliedShields ?? []) : readActiveShields());
+  const localOnly = wsGoverned
+    ? new Set(readActiveShields().filter((n) => !active.has(n)))
+    : new Set<string>();
 
   if (all.length === 0) return 'No shields available.';
 
   const lines = all.map((shield) => {
     const on = active.has(shield.name);
+    const ignored = localOnly.has(shield.name);
+    const state = on
+      ? '[active]'
+      : ignored
+        ? '[off — enabled locally, ignored (workspace governs)]'
+        : '[off]   ';
     const ruleCount = shield.smartRules.length;
-    return `${on ? '[active]' : '[off]   '} ${shield.name.padEnd(12)} — ${shield.description ?? ''} (${ruleCount} rule${ruleCount === 1 ? '' : 's'})`;
+    return `${state} ${shield.name.padEnd(12)} — ${shield.description ?? ''} (${ruleCount} rule${ruleCount === 1 ? '' : 's'})`;
   });
 
-  lines.unshift(`${active.size} of ${all.length} shields active:\n`);
+  lines.unshift(
+    `${active.size} of ${all.length} shields active${wsGoverned ? ' (workspace config governs)' : ''}:\n`
+  );
   return lines.join('\n');
 }
 
@@ -518,7 +545,8 @@ function handleShieldDisable(args: Record<string, unknown>): string {
 // the same file (and merge layer) the `node9 egress` CLI writes.
 
 function handleEgressStatus(): string {
-  const e = getConfig().policy.egress;
+  const cfgEgress = getConfig();
+  const e = cfgEgress.policy.egress;
   const state = !e.enabled
     ? 'OFF — the agent can reach any host'
     : e.mode === 'block'
@@ -526,6 +554,11 @@ function handleEgressStatus(): string {
       : 'WATCHING (review) — unknown hosts prompt for approval';
   const lines = [
     `Egress control: ${state}`,
+    // I5: name the source — on a workspace-governed machine these values
+    // come from the workspace config, and local egress edits are inert.
+    ...(cfgEgress.policySource === 'workspace'
+      ? ['Source: workspace config (app.node9.ai) — local egress settings are ignored']
+      : []),
     `${DEFAULT_EGRESS_ALLOWLIST.length} common dev/LLM hosts are always allowed (github, npm, pypi, anthropic, …).`,
     `Your allow list: ${e.allow.length ? e.allow.join(', ') : '(none)'}`,
     `Your deny list:  ${e.deny.length ? e.deny.join(', ') : '(none)'}`,
@@ -847,6 +880,26 @@ export function runMcpServer(): void {
       const p = (params ?? {}) as Record<string, unknown>;
       const toolName = p.name as string | undefined;
       const toolArgs = (p.arguments ?? {}) as Record<string, unknown>;
+
+      // PR-2 write-guard (§0.8): on a machine that follows the workspace
+      // configuration, EVERY local policy write — weaken AND add — is inert
+      // (getConfig ignores the local stores it targets), so refuse it with a
+      // pointer to the dashboard instead of no-opping green. This runs BEFORE
+      // the weaken gate so a keyed machine never sees that gate's advice to
+      // set mcpAllowWeakening in ~/.node9/config.json — a file that machine
+      // does not read for policy. Keyedness is as-at-spawn, like every other
+      // config read in this process (see the header note on reconnects).
+      if (capabilityOf(toolName ?? '') !== 'readonly' && isKeyedForPolicy()) {
+        process.stdout.write(
+          err(
+            id,
+            -32000,
+            `${toolName} changes local policy, and this machine's local policy is inert. ` +
+              `${KEYED_POLICY_WRITE_REASON} Edit policy at https://app.node9.ai (Enforcement).`
+          ) + '\n'
+        );
+        return;
+      }
 
       // Security gate: a WEAKENING tool (shield_disable / approver_set) must never be
       // driven by the agent over MCP by default — that would let a compromised agent

--- a/src/policy/index.ts
+++ b/src/policy/index.ts
@@ -198,20 +198,33 @@ async function deriveExplainTrace(toolName: string, args?: unknown): Promise<Exp
   const projectPath = path.join(process.cwd(), 'node9.config.json');
   const credsPath = path.join(os.homedir(), '.node9', 'credentials.json');
 
+  const config = getConfig();
+  // I4: the waterfall must tell the PR-2 truth. On a workspace-governed
+  // machine the local tiers exist on disk but are inert for policy, and the
+  // env-var mode override is ignored too — labeling them 'active' would
+  // describe a merge that no longer happens.
+  const wsGoverned = config.policySource === 'workspace';
+
   // ── Waterfall tiers ───────────────────────────────────────────────────────
   const waterfall: WaterfallTier[] = [
     {
       tier: 1,
       label: 'Env vars',
       status: 'env',
-      note: process.env.NODE9_MODE ? `NODE9_MODE=${process.env.NODE9_MODE}` : 'not set',
+      note: process.env.NODE9_MODE
+        ? wsGoverned
+          ? `NODE9_MODE=${process.env.NODE9_MODE} — ignored (workspace config controls mode)`
+          : `NODE9_MODE=${process.env.NODE9_MODE}`
+        : 'not set',
     },
     {
       tier: 2,
-      label: 'Cloud policy',
+      label: wsGoverned ? 'Workspace config' : 'Cloud policy',
       status: fs.existsSync(credsPath) ? 'active' : 'missing',
       note: fs.existsSync(credsPath)
-        ? 'credentials found (not evaluated in explain mode)'
+        ? wsGoverned
+          ? 'authoritative — this machine follows the workspace configuration (app.node9.ai)'
+          : 'credentials found (not evaluated in explain mode)'
         : 'not connected — run: node9 login',
     },
     {
@@ -219,12 +232,18 @@ async function deriveExplainTrace(toolName: string, args?: unknown): Promise<Exp
       label: 'Project config',
       status: fs.existsSync(projectPath) ? 'active' : 'missing',
       path: projectPath,
+      ...(wsGoverned && fs.existsSync(projectPath)
+        ? { note: 'present — ignored (workspace config governs policy)' }
+        : {}),
     },
     {
       tier: 4,
       label: 'Global config',
       status: fs.existsSync(globalPath) ? 'active' : 'missing',
       path: globalPath,
+      ...(wsGoverned && fs.existsSync(globalPath)
+        ? { note: 'present — ignored (workspace config governs policy)' }
+        : {}),
     },
     {
       tier: 5,
@@ -233,8 +252,6 @@ async function deriveExplainTrace(toolName: string, args?: unknown): Promise<Exp
       note: 'always active',
     },
   ];
-
-  const config = getConfig();
 
   // ── 0. DLP Content Scanner ────────────────────────────────────────────────
   const wouldBeIgnored = matchesPattern(toolName, config.policy.ignoredTools);

--- a/src/tui/dashboard/data.ts
+++ b/src/tui/dashboard/data.ts
@@ -16,6 +16,7 @@ import { runBlast } from '../../cli/commands/blast.js';
 import { DAEMON_HOST, DAEMON_PORT, getInternalToken } from '../../auth/daemon.js';
 import { parseJSONLFile, type DailyEntry } from '../../costSync.js';
 import { SHIELDS, readActiveShields } from '../../shields.js';
+import { getConfig } from '../../config/index.js';
 import { NON_DECISION_SOURCES } from '../../audit/decision.js';
 import { extractFindingsFromLine } from '../../daemon/scan-watermark.js';
 import {
@@ -716,7 +717,12 @@ async function walkClaudeJsonlsForSignals(): Promise<Omit<ScanSignalsSnapshot, '
 export function loadShieldStatus(): ShieldStatus {
   try {
     const all = Object.keys(SHIELDS).sort();
-    const activeSet = new Set(readActiveShields());
+    // I8: a workspace-governed machine enforces the cloud-mandated set —
+    // the local enable store would misreport both lists here.
+    const cfg = getConfig();
+    const activeSet = new Set(
+      cfg.policySource === 'workspace' ? (cfg.policy.appliedShields ?? []) : readActiveShields()
+    );
     const active = all.filter((n) => activeSet.has(n));
     const inactive = all.filter((n) => !activeSet.has(n));
     return { active, inactive };


### PR DESCRIPTION
Founder QA produced one screen with two lies in it:

```
Policy sync
  ⚠️  Cloud policy is STALE — last reached the cloud 6 hours ago
      (2 consecutive failures: API returned 401)
Cloud audit shipping
  ✅  Shipping in progress — 334 KB queued, last ship 765m ago
```

334 KB stuck for twelve hours is not progress, and "API returned 401" is a code,
not an answer.

## 1. Stalled is about the queue, not the daemon

The check read `ageMin > 5 && !isDaemonRunning()`, so it only fired when the
daemon was **down**. A running daemon that could not ship printed green — the
same lie as the caught-up branch fixed a day earlier, one `else if` over.

Stalled now depends on the queue alone; the daemon's state only decides which
fix to suggest ("start it" vs "it is running but shipping is failing"). The
threshold moves 5 → 15 minutes, roughly 45 failed 20-second cycles, so a laptop
waking mid-flush is never accused.

## 2. A 401 is named

doctor already **held** the reason and printed it as a raw code, leaving the
reader to work out that it meant "this machine was disconnected". It now says
so: revoked from the dashboard, removed from the workspace, or `node9 logout`,
with `node9 login` as the fix. Both sections report it, since both channels
share the key and fail together.

The rejected-key check sits **above** the staleness branch, not inside it. The
first version nested it, so a machine disconnected an hour ago still read
"Cloud policy fresh" until the staleness clock — up to 15h — caught up. Its own
test caught that.

## On the tests

The first version of these tests **passed against the old condition**. The
suite can only ever observe a dead daemon in an isolated HOME, which is exactly
the case the bug did not affect — so the tests were green for the wrong reason.

The fixture now fakes a live daemon (a pid file naming the test process's own
pid, which `isDaemonRunning` probes with signal 0). Both mutations fail it:
restoring the daemon-coupled condition, and disabling 401 detection.

## Verification

4,037 tests pass (8 new); typecheck, lint, format clean. Behaviour also
confirmed by hand against a fixture reproducing the founder's exact state:
daemon up, 40 KB queued, last ship 765m ago.