### PR TITLE
Close the release gap: e2e runs before the merge, and the README says how to connect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,43 @@ jobs:
           NODE9_TESTING: '1'
         run: npm test
 
+  e2e:
+    # The release used to be the FIRST place `test:e2e` ever ran: CI checked
+    # format/lint/typecheck/build/test, and `npm run validate` (the
+    # prepublishOnly gate) was alone in running the e2e suite. So a broken
+    # e2e could not surface until semantic-release was already mid-publish —
+    # which is exactly how v2.6.0 got a commit and a tag on main while npm
+    # stayed on 2.5.0. This job moves that gate in front of the merge.
+    #
+    # ubuntu + Node 22 deliberately mirrors the Release runner: the point is
+    # to reproduce what `validate` sees, and scripts/e2e.sh is bash-only.
+    name: e2e
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build workspace engine
+        run: npm --workspace @node9/policy-engine run build
+
+      # No explicit build step: `pretest:e2e` builds, so the suite can never
+      # run against a stale dist no matter who invokes it (the failure mode
+      # that faked two green gates in c38d9d9).
+      - name: E2E
+        env:
+          # Prevents native popup dialogs and daemon auto-start in spawned child processes.
+          NODE9_TESTING: '1'
+        run: npm run test:e2e
+
   coverage:
     # Dedicated job so branch protection can require it by name without fragile matrix selectors.
     # Enforces the thresholds defined in vitest.config.mts. Must be listed in branch protection

--- a/README.md
+++ b/README.md
@@ -151,10 +151,23 @@ npm install -g node9-ai
 
 ```bash
 node9 init       # auto-wires all detected agents + MCP servers
-node9 doctor     # verify everything is wired correctly
+node9 login      # connect this machine to your workspace (approve it in the browser)
+node9 doctor     # verify everything is wired and reporting
 ```
 
 Requires Node.js 18+.
+
+`init` on its own gives you full local enforcement: rules, shields, DLP and
+approvals all work offline, on this machine.
+
+`login` is what puts the machine on your dashboard. It prints a code, opens
+the browser, and you approve the machine there; if you don't have an account
+yet, signing up mid-flow returns you to the same approval with the code
+intact. Until you run it, everything is enforced locally but nothing reaches
+Mission Control, so the dashboard stays empty.
+
+`node9 logout` disconnects a machine again. It revokes that machine's key;
+local enforcement keeps running.
 
 ## Shields — curated rule packs
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "bump-extractor-version": "node scripts/check-extractor-version.mjs --bump",
     "fix": "npm run format && npm run lint:fix",
     "validate": "npm run format && npm run lint && npm run typecheck && npm run test && npm run test:e2e && npm run build",
+    "pretest:e2e": "npm run build",
     "test:e2e": "cross-env NODE9_TESTING=1 bash scripts/e2e.sh",
     "pretest": "npm run build",
     "test": "cross-env NODE9_TESTING=1 vitest --run",

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -74,6 +74,23 @@ export HOME="$TEST_HOME"
 # config source depending on whose machine runs this script.
 unset NODE9_API_KEY NODE9_API_URL NODE9_PROFILE
 
+# Client-identity hygiene — the same class of leak as the key above, and the
+# reason v2.6.0 got a tag on main while npm stayed at 2.5.0.
+#
+# A review verdict only surfaces as an inline ask when the CLIENT can render
+# one; node9 detects Claude Code from CLAUDECODE / CLAUDE_CODE_SESSION_ID
+# (src/cli/commands/check.ts). Without it a review fails CLOSED to a block,
+# which is correct.
+#
+# This suite's Part 1 heading claims it simulates a Claude Code hook, but it
+# never set the variable that makes it one: it inherited it from the shell.
+# That made it pass on any developer box (always inside a Claude Code
+# session) and fail on every CI runner. Pin the identity so the suite tests
+# what it says it tests, and drop the second signal so exactly one thing
+# drives the branch.
+export CLAUDECODE=1
+unset CLAUDE_CODE_SESSION_ID
+
 # =============================================================================
 # PART 1 — node9 check  (simulates Claude Code's PreToolUse hook)
 # Claude Code pipes JSON to stdin: { tool_name, tool_input }
@@ -150,6 +167,19 @@ check_review "Bash: purge /opt/data"   '{"tool_name":"Bash","tool_input":{"comma
 
 # 6. Test 'find -delete' (the parser finds the "delete" token which is often a rule action)
 check_review "Bash: find . -delete"    '{"tool_name":"Bash","tool_input":{"command":"find . -name tmp -delete"}}'
+
+# The inverse of every assertion above, and the behaviour that made this suite
+# environment-dependent in the first place: with NO inline-ask-capable client,
+# a review verdict must fail CLOSED to a block rather than sail through. Real
+# security behaviour that nothing verified until v2.6.0 failed to publish.
+echo -e "\n  ${YELLOW}No inline-ask-capable client — review must fail closed:${RESET}"
+out=$(env -u CLAUDECODE -u CLAUDE_CODE_SESSION_ID sh -c \
+  'echo '"'"'{"tool_name":"delete_user","tool_input":{"id":1}}'"'"' | '"$NODE9"' check' 2>/dev/null) || true
+if echo "$out" | grep -q '"decision":"block"'; then
+  pass "FAIL-CLOSED → review becomes a block with no client to ask"
+else
+  fail "Review did not fail closed without a client  (got: '$out')"
+fi
 
 
 echo -e "\n  ${YELLOW}Claude Code Bash tool — safe commands (must NOT be blocked):${RESET}"


### PR DESCRIPTION
Three commits that unblock the publish v2.6.0 never completed.

### `ci:` the e2e suite runs before the merge, not during the publish
`npm run validate` (prepublishOnly) was the only caller of `test:e2e`, so the release was the first place the suite ever ran. That is how v2.6.0 got a commit and a tag on main while npm stayed on 2.5.0: the gate fired after the point of no return.

The new job mirrors the Release runner deliberately (ubuntu, Node 22). `pretest:e2e` binds the build to the suite rather than to the caller, so no invocation can grade a stale dist.

### `fix(test):` the e2e suite pins its client identity instead of inheriting it
Part 1 claims to simulate a Claude Code PreToolUse hook but never set `CLAUDECODE`. It inherited it from whoever ran it, and every developer box runs from inside a Claude Code session, so it was green locally and red on every runner.

Same leak class as the `unset NODE9_API_KEY` hygiene block four lines above it, so the fix lives there.

**The product was never wrong.** A review with no client to ask must fail closed to a block, which nothing verified because every assertion ran with a client present. That inverse is now a test of its own.

Proven both directions: 50/50 with the vars present and stripped; removing the export alone brings the 15 failures straight back.

### `docs(readme):` the install steps never mentioned connecting the machine
The quickstart was `init` then `doctor`. `node9 login` appeared nowhere in 339 lines, and neither did `logout`. A reader got full local enforcement and an empty dashboard with nothing explaining why. Every claim added was verified against the code, not assumed.

### Release
`fix:` cuts a patch, so this publishes **2.6.1**. No tag surgery: the code on main already carries everything 2.6.0 would have shipped, so 2.6.0 is simply skipped on npm.

CI green on all six jobs including the new e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)