### PR TITLE
fix: restore canonical Apache 2.0 license text, auth race, hook-debug default

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -32,33 +33,36 @@
       not limited to compiled object code, generated documentation,
       and conversions to other media types.
 
-      "Work" shall mean the work of authorship made available under
-      the License, as indicated by a copyright notice that is included in
-      or attached to the work (an example is provided in the Appendix below).
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
       "Derivative Works" shall mean any work, whether in Source or Object
       form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other transformations
+      editorial revisions, annotations, elaborations, or other modifications
       represent, as a whole, an original work of authorship. For the purposes
       of this License, Derivative Works shall not include works that remain
       separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and the Derivative Works thereof.
+      the Work and Derivative Works thereof.
 
-      "Contribution" shall mean, as submitted to the Licensor for inclusion
-      in the Work by the copyright owner or by an individual or Legal Entity
-      authorized to submit on behalf of the copyright owner. For the purposes
-      of this definition, "submitted" means any form of electronic, verbal,
-      or written communication sent to the Licensor or its representations,
-      including but not limited to communication on electronic mailing lists,
-      source code control systems, and issue tracking systems that are managed
-      by, or on behalf of, the Licensor for the purpose of discussing and
-      improving the Work, but excluding communication that is conspicuously
-      marked or designated in writing by the copyright owner as "Not a
-      Contribution."
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-      "Contributor" shall mean Licensor and any Legal Entity on behalf of
-      whom a Contribution has been received by the Licensor and included
-      within the Work.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
    2. Grant of Copyright License. Subject to the terms and conditions of
       this License, each Contributor hereby grants to You a perpetual,
@@ -74,21 +78,22 @@
       use, offer to sell, sell, import, and otherwise transfer the Work,
       where such license applies only to those patent claims licensable
       by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by the combination of their Contribution(s)
+      Contribution(s) alone or by combination of their Contribution(s)
       with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a cross-claim
-      or counterclaim in a lawsuit) alleging that the Work or any Contribution
-      embodied within the Work constitutes direct or contributory patent
-      infringement, then any patent licenses granted to You under this License
-      for that Work shall terminate as of the date such litigation is filed.
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
    4. Redistribution. You may reproduce and distribute copies of the
       Work or Derivative Works thereof in any medium, with or without
       modifications, and in Source or Object form, provided that You
       meet the following conditions:
 
-      (a) You must give any other recipients of the Work or Derivative
-          Works a copy of this License; and
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
       (b) You must cause any modified files to carry prominent notices
           stating that You changed the files; and
@@ -100,25 +105,28 @@
           the Derivative Works; and
 
       (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, You must include a readable copy of the
-          attribution notices contained within such NOTICE file, in
-          at least one of the following places: within a NOTICE text
-          file distributed as part of the Derivative Works; within
-          the Source form or documentation, if provided along with the
-          Derivative Works; or, within a display generated by the
-          Derivative Works, if and wherever such third-party notices
-          normally appear. The contents of the NOTICE file are for
-          informational purposes only and do not modify the License.
-          You may add Your own attribution notices within Derivative
-          Works that You distribute, alongside or in addition to the
-          NOTICE text from the Work, provided that such additional
-          attribution notices cannot be construed as modifying the License.
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-      You may add Your own license statement for Your modifications and
-      may provide additional grant of rights to use, reproduce, modify,
-      prepare Derivative Works of, convert to other formats, and distribute
-      the contributions, provided such additional grant of rights does not
-      conflict with the terms and conditions of this License.
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
    5. Submission of Contributions. Unless You explicitly state otherwise,
       any Contribution intentionally submitted for inclusion in the Work
@@ -140,7 +148,7 @@
       implied, including, without limitation, any warranties or conditions
       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
       PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or reproducing the Work and assume any
+      appropriateness of using or redistributing the Work and assume any
       risks associated with Your exercise of permissions under this License.
 
    8. Limitation of Liability. In no event and under no legal theory,
@@ -148,25 +156,36 @@
       unless required by applicable law (such as deliberate and grossly
       negligent acts) or agreed to in writing, shall any Contributor be
       liable to You for damages, including any direct, indirect, special,
-      incidental, or exemplary damages of any character arising as a
+      incidental, or consequential damages of any character arising as a
       result of this License or out of the use or inability to use the
       Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or all other
-      commercial damages or losses), even if such Contributor has been
-      advised of the possibility of such damages.
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
    9. Accepting Warranty or Additional Liability. While redistributing
       the Work or Derivative Works thereof, You may choose to offer,
       and charge a fee for, acceptance of support, warranty, indemnity,
       or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may offer such
-      obligations only on Your own behalf and on Your sole responsibility,
-      not on behalf of any other Contributor, and only if You agree to
-      indemnify, defend, and hold each Contributor harmless for any
-      liability incurred by, or claims asserted against, such Contributor
-      by reason of your accepting any such warranty or additional liability.
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
    Copyright 2026 Node9 AI
 

--- a/src/__tests__/shield-block-downgrade-realgate.spec.ts
+++ b/src/__tests__/shield-block-downgrade-realgate.spec.ts
@@ -30,6 +30,11 @@ const H = vi.hoisted(() => ({
   initSaaS: vi.fn(),
   evaluatePolicy: vi.fn(),
   registerDaemonEntry: vi.fn(),
+  // Round-3 F1e: the cloud poller is controllable so a row can prove whether
+  // the cloud was ENROLLED as a racer, not merely whether it won. The default
+  // (set in beforeEach) is the original never-resolves promise, so rows A-F
+  // keep their meaning: the timeout racer decides.
+  pollSaaS: vi.fn(),
 }));
 
 vi.mock('../policy', () => ({
@@ -99,8 +104,9 @@ vi.mock('../audit', () => ({
 
 vi.mock('../auth/cloud', () => ({
   initNode9SaaS: (...a: unknown[]) => H.initSaaS(...a),
-  // Never resolves — the cloud poller must not win; the timeout racer decides.
-  pollNode9SaaS: () => new Promise(() => {}),
+  // Delegated so a row can control it. Default (beforeEach) never resolves —
+  // the cloud poller must not win; the timeout racer decides.
+  pollNode9SaaS: (...a: unknown[]) => H.pollSaaS(...a),
   resolveNode9SaaS: vi.fn(),
 }));
 
@@ -156,6 +162,9 @@ describe('real-gate: downgraded ruleName-less hard block (round-2 F1/F3)', () =>
     H.initSaaS.mockResolvedValue({ pending: true, requestId: 'req-1' });
     H.evaluatePolicy.mockResolvedValue(RULENAME_LESS_BLOCK);
     H.registerDaemonEntry.mockResolvedValue({ id: 'entry-1', allowCount: 1 });
+    // Preserves the original module-mock behaviour for every row that does not
+    // override it: the poll never settles, so it can never win the race.
+    H.pollSaaS.mockImplementation(() => new Promise(() => {}));
   });
 
   afterEach(() => {
@@ -252,5 +261,54 @@ describe('real-gate: downgraded ruleName-less hard block (round-2 F1/F3)', () =>
     // answering, the timeout racer denies.
     expect(H.registerDaemonEntry).toHaveBeenCalled();
     expect(res.approved).toBe(false);
+  });
+
+  // ── Round-3 F1e: the cloud as a RACER ────────────────────────────────────
+  // The sixth non-human channel. Rows B/D/E/F closed persistent, trust,
+  // shadowMode and the inline prompt; the immediate-allow guard closed the
+  // !pending branch. The pending branch stayed open: `cloudRequestId` was set
+  // unconditionally, which enrolled the cloud poller in the race.
+  //
+  // Measured on the founder's machine 2026-08-31 — 143 real deny→allow pairs,
+  // e.g. `cat ~/.ssh/id_rsa` recorded as smart-rule-block-override (deny) and
+  // then, 8.7s later, allow with a cloudRequestId and nobody having clicked.
+  it('G: interactive downgrade + cloud PENDING — the cloud must not race a hard block', async () => {
+    process.env.DISPLAY = ':0'; // human reachable → mayDowngrade
+    H.cloudEnabled.mockReturnValue(true);
+    H.initSaaS.mockResolvedValue({ pending: true, requestId: 'req-1' });
+    // The measured BE shape: the pending entry resolves to "no org rule
+    // matched" with no human click. Resolving immediately here means the cloud
+    // WINS the race if it is enrolled at all — which is exactly the bug.
+    H.pollSaaS.mockResolvedValue({ approved: true });
+
+    const res = await authorizeHeadless('Bash', { command: 'echo hello' });
+
+    // Enrolment, not just outcome: the poller must never be reached.
+    expect(H.pollSaaS).not.toHaveBeenCalled();
+    expect(res.checkedBy).not.toBe('cloud');
+    // Nobody answers the popup, so the timeout racer denies. Fails closed.
+    expect(res.approved).toBe(false);
+  });
+
+  it('H: cloud PENDING with NO local match — the cloud still races (normal path intact)', async () => {
+    process.env.DISPLAY = ':0';
+    H.cloudEnabled.mockReturnValue(true);
+    // A plain review: no ruleName, tier != 7, decision != 'block' — so
+    // hardBlockDowngraded stays false and localSmartRuleMatched is never set.
+    // This is the case the cloud SHOULD decide; the fix must not touch it.
+    H.evaluatePolicy.mockResolvedValue({
+      decision: 'review',
+      tier: 1,
+      blockedByLabel: 'Ordinary review',
+      reason: 'ordinary review verdict',
+    });
+    H.initSaaS.mockResolvedValue({ pending: true, requestId: 'req-2' });
+    H.pollSaaS.mockResolvedValue({ approved: true });
+
+    const res = await authorizeHeadless('Bash', { command: 'echo hello' });
+
+    expect(H.pollSaaS).toHaveBeenCalled();
+    expect(res.approved).toBe(true);
+    expect(res.checkedBy).toBe('cloud');
   });
 });

--- a/src/__tests__/unkeyed-parity-golden.spec.ts
+++ b/src/__tests__/unkeyed-parity-golden.spec.ts
@@ -207,7 +207,7 @@ describe('U0 — unkeyed golden: the local stack resolves EXACTLY as today', () 
 // rules-cache PRESENT and no credentials, so a `keyed = cache file exists`
 // mutant flips them to cloud-replace behavior and they fail.
 // ───────────────────────────────────────────────────────────────────────────
-describe('§U — unkeyed byte-parity rows (U1-U15)', () => {
+describe('§U — unkeyed byte-parity rows (U1-U17)', () => {
   let home: string;
   let proj: string;
   const savedEnv: Record<string, string | undefined> = {};
@@ -421,5 +421,20 @@ describe('§U — unkeyed byte-parity rows (U1-U15)', () => {
     expect(c.settings.enableHookLogDebug).toBe(false);
     expect(c.settings.shipper.intervalSeconds).toBe(99);
     expect(c.settings.mcpReconcileIntervalMinutes).toBe(30);
+  });
+
+  it('U16: hook-debug logging is OFF when the config does not mention it', () => {
+    // The DEBUG facility must not be on by default: when on, every tool call
+    // appends to ~/.node9/hook-debug.log, which has no production reader and
+    // no size ceiling. Absent key ⇒ off.
+    writeGlobal({ settings: { mode: 'standard' } });
+    expect(cfg().settings.enableHookLogDebug).toBe(false);
+  });
+
+  it('U17: an explicit enableHookLogDebug:true is still honored', () => {
+    // Flipping the DEFAULT must not take the knob away from someone who asked
+    // for it on purpose — that would be a second bug wearing the first's coat.
+    writeGlobal({ settings: { mode: 'standard', enableHookLogDebug: true } });
+    expect(cfg().settings.enableHookLogDebug).toBe(true);
   });
 });

--- a/src/auth/orchestrator.ts
+++ b/src/auth/orchestrator.ts
@@ -1198,6 +1198,29 @@ async function _authorizeHeadlessCore(
     // {approved:true} without this flag, {pending:true} with it.
     !!taintWarning ||
     undefined;
+  // Round-3 F1e: a DOWNGRADED HARD BLOCK must not be resolvable by the cloud
+  // racer. This is the sixth non-human channel — rows B/D/E/F of
+  // shield-block-downgrade-realgate.spec.ts closed persistent, trust,
+  // shadowMode and the inline prompt, and the immediate-allow guard below
+  // closed the !pending branch. The pending branch stayed open: the poller was
+  // enrolled unconditionally, and the SaaS resolved it with nobody clicking.
+  // Measured 2026-08-31: 143 real deny→allow pairs on the founder's machine.
+  //
+  // Deliberately keyed on `hardBlockDowngraded` and NOT on `forceReview`.
+  // They are boolean-equivalent for the block case but mean opposite things:
+  // forceReview asks the SaaS to create a genuine PENDING entry so a HUMAN
+  // must click, which is a legitimate cloud channel for an admin-chosen review
+  // (app-permission, taint). Gating on it removed that human path and broke
+  // two app-permission rows. Only node9's own floor — a block softened solely
+  // because a human happened to be reachable — is off-limits to the cloud, per
+  // the `mayDowngrade` comment above: "Cloud is deliberately NOT a 'human'
+  // here — it can auto-resolve. Fails closed."
+  //
+  // Gates the VOTE only. `cloudRequestId` is still assigned, because two other
+  // consumers need it: resolveNode9SaaS (so Mission Control does not sit on
+  // PENDING forever) and the audit row's BE linkage (so the shipper enriches
+  // the existing row instead of inserting a duplicate).
+  const cloudMayVote = !hardBlockDowngraded;
   if (cloudEnforced) {
     try {
       const initResult = await initNode9SaaS(
@@ -1245,12 +1268,14 @@ async function _authorizeHeadlessCore(
         // immediate-allow for an exfiltration review either — same reasoning as
         // appPermReview above, and it also covers a stale/older BE that ignores
         // the forceReview flag we now send.
-        if (
-          !localSmartRuleMatched &&
-          !options?.localSmartRuleMatched &&
-          !appPermReview &&
-          !taintWarning
-        ) {
+        // `!forceReview` is exactly the four-term condition this guard used to
+        // restate inline (localSmartRuleMatched / options.localSmartRuleMatched
+        // / appPermReview / taintWarning) — forceReview is built from the same
+        // four a few lines above, so deriving it here removes the duplicate
+        // without changing behaviour. NOT `cloudMayVote`: that one is narrower
+        // (downgraded hard blocks only) and using it here would let a cloud
+        // immediate-allow through for app-permission and taint reviews.
+        if (!forceReview) {
           return {
             approved: !!initResult.approved,
             reason:
@@ -1369,7 +1394,7 @@ async function _authorizeHeadlessCore(
   // Cloud is a valid racer even for local smart rule matches — with forceReview,
   // the SaaS always creates a PENDING entry requiring a real human click in
   // Mission Control, so an approval there is a genuine human decision.
-  if (cloudEnforced && cloudRequestId) {
+  if (cloudEnforced && cloudRequestId && cloudMayVote) {
     racePromises.push(
       (async () => {
         try {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -210,7 +210,14 @@ export const DEFAULT_CONFIG: Config = {
   settings: {
     mode: 'standard',
     autoStartDaemon: true,
-    enableHookLogDebug: true,
+    // Off by default: this is a DEBUG facility, not part of the product's job.
+    // When on, every tool call appends a row to ~/.node9/hook-debug.log, which
+    // has no production reader and no size ceiling. Turn it on deliberately
+    // (this setting, or NODE9_DEBUG=1) while investigating something.
+    // Error breadcrumbs written from catch blocks are NOT gated by this and
+    // keep working when it is off — see CLAUDE.md "Always write to
+    // hook-debug.log in catch blocks that guard audit trail".
+    enableHookLogDebug: false,
     approvalTimeoutMs: 120_000, // 120-second auto-deny timeout
     flightRecorder: true,
     auditHashArgs: true,


### PR DESCRIPTION
Ships three commits from `dev`.

**`chore: restore canonical Apache 2.0 license text`**

The `LICENSE` file was a paraphrase of Apache 2.0 rather than the license text.
Substantive terms differed throughout: the "Contribution" definition had lost its
subject clause, "Contributor" excluded individuals, the section 8 liability
disclaimer dropped consequential damages, and the section 4(d) NOTICE exclusion
was removed. Introduced in `bac1a39` (2026-03-15) when the project moved from MIT
to Apache 2.0; the text was written out instead of copied from the source.

Consequences this fixes:
- GitHub could not classify the file and reported `NOASSERTION`, which enterprise
  license scanners treat as an unknown license and often gate on.
- `package.json` and the README badge declared `Apache-2.0` while the file said
  something else.
- Every published npm tarball carries the paraphrased text.

Replaced with the canonical text from `apache.org/licenses/LICENSE-2.0.txt`, with
the copyright placeholder filled in. That line is the only difference from upstream.

**`fix(auth): the cloud may not race a downgraded hard block`**
**`fix(config): hook-debug logging is off by default`**

Pre-existing on `dev`, unchanged by this PR.

Full suite green locally: 249 files, 4250 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
