### PR TITLE
Cost: price loop waste from real data, and stop calling it spend

### DIFF
--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -42,6 +42,7 @@ export {
   toolMatchesRule,
   detectInlineExec,
   AST_FS_REGEX_RULES,
+  FS_READ_TOOLS,
   extractShellDestinations,
   parseDestHost,
 } from './shell';

--- a/packages/policy-engine/src/scan/canonical.spec.ts
+++ b/packages/policy-engine/src/scan/canonical.spec.ts
@@ -296,7 +296,9 @@ describe('extractSessionLevelFindings — loop detection', () => {
     expect(out).toHaveLength(1);
     expect(out[0].type).toBe('loop');
     expect(out[0].loopCount).toBeGreaterThanOrEqual(4);
-    expect(out[0].costUsd).toBeGreaterThan(0);
+    // The extractor must not price anything: it sees tool calls, never spend.
+    // A flat constant here looked like a measurement and was read as one.
+    expect(out[0]).not.toHaveProperty('costUsd');
     expect(out[0].commandPreview).toContain('npm test');
   });
 
@@ -406,7 +408,7 @@ describe('dedupeCanonicalFindings', () => {
     expect(merged).toHaveLength(2);
   });
 
-  it('sums costUsd across loop occurrences', () => {
+  it('sums loopCount across loop occurrences', () => {
     const base: CanonicalFinding = {
       type: 'loop',
       ruleName: 'loop',
@@ -422,12 +424,11 @@ describe('dedupeCanonicalFindings', () => {
       firstSeenAt: 'x',
       lastSeenAt: 'x',
       occurrenceCount: 1,
-      costUsd: 0.05,
       loopCount: 5,
     };
     const merged = dedupeCanonicalFindings([base, base]);
-    expect(merged[0].costUsd).toBeCloseTo(0.1);
     expect(merged[0].loopCount).toBe(10);
+    expect(merged[0]).not.toHaveProperty('costUsd');
   });
 });
 

--- a/packages/policy-engine/src/scan/canonical.ts
+++ b/packages/policy-engine/src/scan/canonical.ts
@@ -251,7 +251,7 @@ export const CANONICAL_EXTRACTOR_VERSION = 'canonical-v9';
  * files changed, this hash must change too, and you must consciously
  * decide whether to bump CANONICAL_EXTRACTOR_VERSION."
  */
-export const CANONICAL_EXTRACTOR_HASH = '4ebf40dfe1d7c0a1';
+export const CANONICAL_EXTRACTOR_HASH = '92d7a05d6db84a39';
 
 // Dedupe key length cap — match what scan.ts:502 uses today.
 const DEDUPE_PREVIEW_LEN = 120;

--- a/packages/policy-engine/src/scan/canonical.ts
+++ b/packages/policy-engine/src/scan/canonical.ts
@@ -41,7 +41,6 @@ import { classifyRuleSeverity, type Severity } from '../severity';
 import { DESTRUCTIVE_OP_RE, SENSITIVE_PATH_RE, FILE_TOOLS } from './destructive-regex';
 import { detectPii } from './pii';
 import { evaluateLoopWindow, type ToolCallRecord } from '../loop';
-import { COST_PER_LOOP_ITER_USD } from './index';
 import type { SmartRule } from '../types';
 import type { ScanFinding } from './index';
 
@@ -102,8 +101,10 @@ export interface CanonicalFinding {
 
   /** AST findings: the path that triggered the verdict. */
   subjectPath?: string;
-  /** Loop findings: dollar cost so far. Loop-only today; optional everywhere. */
-  costUsd?: number;
+  // No costUsd here. This extractor sees a session's tool calls and nothing
+  // about spend (SessionExtractContext carries sessionId/project/agent only),
+  // so any price it attached was a flat constant wearing the costume of a
+  // measurement. Callers that DO know the rate attach it themselves.
   /** Loop findings: number of iterations. */
   loopCount?: number;
   loopKind?: 'loop' | 'long-iteration';
@@ -251,7 +252,7 @@ export const CANONICAL_EXTRACTOR_VERSION = 'canonical-v9';
  * files changed, this hash must change too, and you must consciously
  * decide whether to bump CANONICAL_EXTRACTOR_VERSION."
  */
-export const CANONICAL_EXTRACTOR_HASH = '4ebf40dfe1d7c0a1';
+export const CANONICAL_EXTRACTOR_HASH = '6f28baac2e70ebfc';
 
 // Dedupe key length cap — match what scan.ts:502 uses today.
 const DEDUPE_PREVIEW_LEN = 120;
@@ -595,7 +596,6 @@ export function extractSessionLevelFindings(
       loopCount: verdict.count,
       loopKind: 'loop',
       commandPreview: previewArgs(call.args, DEDUPE_PREVIEW_LEN),
-      costUsd: verdict.count * COST_PER_LOOP_ITER_USD,
     });
   }
 
@@ -629,10 +629,6 @@ export function dedupeCanonicalFindings(
     }
     if (f.lastSeenAt && f.lastSeenAt > prev.lastSeenAt) {
       prev.lastSeenAt = f.lastSeenAt;
-    }
-    // Sum cost across loop occurrences; leave undefined otherwise.
-    if (f.costUsd !== undefined) {
-      prev.costUsd = (prev.costUsd ?? 0) + f.costUsd;
     }
     if (f.loopCount !== undefined) {
       prev.loopCount = (prev.loopCount ?? 0) + f.loopCount;

--- a/packages/policy-engine/src/shell/index.ts
+++ b/packages/policy-engine/src/shell/index.ts
@@ -424,7 +424,11 @@ export const detectDangerousEval = detectDangerousShellExec;
 // stdout, and the grep family prints matching lines — which is all an
 // exfiltrator needs. Adding a name here widens EVERY SENSITIVE_PATH_RULES entry
 // (.ssh, .aws, .env, credentials), not just the one being repaired.
-const FS_READ_TOOLS = new Set([
+// Exported so the jail gauntlet can DERIVE its shell cases from this set
+// instead of hand-writing them. Same rule the regex below already follows
+// ("DERIVED from FS_READ_TOOLS, never hand-written beside it") — a name added
+// here must gain coverage for free, or the set and its tests drift apart.
+export const FS_READ_TOOLS = new Set([
   'cat',
   'less',
   'head',

--- a/src/__tests__/__snapshots__/scan-render.snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/scan-render.snapshot.test.ts.snap
@@ -241,7 +241,12 @@ exports[`buildScanJson — envelope snapshot > rich fixture 1`] = `
     ],
     "leaks": [],
     "loops": [],
-    "loopWastedUSD": 0.246
+    "loopWastedUSD": 0.246,
+    "loopWaste": {
+      "usd": 0.246,
+      "pricedIterations": 1,
+      "unpricedIterations": 0
+    }
   },
   "blast": {
     "score": 25,

--- a/src/__tests__/__snapshots__/scan-render.snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/scan-render.snapshot.test.ts.snap
@@ -60,7 +60,7 @@ exports[`N6 — state-aware phrasing (enabledShields injected) > ink scorecard: 
 🛡  node9 dashboard  ·  scanned last 90 days
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Spend & activity ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ╭──────────────────────────────────────────╮ ╭──────────────────────────────────────────╮
-│ COST                                     │ │ ACTIVITY                                 │
+│ COST · API value                         │ │ ACTIVITY                                 │
 │ Total           $14.5K                   │ │ Sessions        39                       │
 │ Wasted on loops ~$0.25                   │ │ Tools           15,000                   │
 │                                          │ │   Shell         7,500                    │
@@ -412,7 +412,7 @@ exports[`renderScanScorecardInk — output snapshots > clean fixture (good score
 🛡  node9 dashboard  ·  scanned last 90 days
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Spend & activity ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ╭──────────────────────────────────────────╮ ╭──────────────────────────────────────────╮
-│ COST                                     │ │ ACTIVITY                                 │
+│ COST · API value                         │ │ ACTIVITY                                 │
 │ Total           $1.50                    │ │ Sessions        5                        │
 │                                          │ │ Tools           200                      │
 │                                          │ │   Shell         80                       │
@@ -431,7 +431,7 @@ exports[`renderScanScorecardInk — output snapshots > panel fixture (critical s
 🛡  node9 dashboard  ·  scanned last 90 days
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Spend & activity ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ╭──────────────────────────────────────────╮ ╭──────────────────────────────────────────╮
-│ COST                                     │ │ ACTIVITY                                 │
+│ COST · API value                         │ │ ACTIVITY                                 │
 │ Total           $14.5K                   │ │ Sessions        39                       │
 │ Wasted on loops ~$0.25                   │ │ Tools           15,000                   │
 │                                          │ │   Shell         7,500                    │

--- a/src/__tests__/__snapshots__/scan-render.snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/scan-render.snapshot.test.ts.snap
@@ -4,7 +4,7 @@ exports[`N6 — state-aware phrasing (enabledShields injected) > chalk panel: an
 "  ╭─ TOP FINDINGS ───────────────────────────────────────────────────────────╮
   │ 🚨 2 credential leaks in tool input  (latest: 2d ago, GitHub Token)      │
   │ 🛑 2 ops node9 would have blocked  (block-read-ssh, block-eval-remote)   │
-  │ 🔁 1 agent loops detected  (Edit dominates, 125 wasted calls · 1% of calls) │
+  │ 🔁 1 agent loops detected  (Edit dominates, 125 repeat calls · 1% of calls) │
   │ 🔭 5 secrets reachable on disk  → project-jail ✓ enabled                 │
   ╰──────────────────────────────────────────────────────────────────────────╯
 
@@ -24,7 +24,7 @@ exports[`N6 — state-aware phrasing (enabledShields injected) > chalk panel: an
   │ 👁️  review-read-credentials  ×3    ✓ shield:project-jail                 │
   ╰──────────────────────────────────────────────────────────────────────────╯
 
-  ╭─ AGENT LOOPS  ·  1 pattern  ·  125 wasted calls (1% of all calls) ───────╮
+  ╭─ AGENT LOOPS  ·  1 pattern  ·  125 repeat calls (1% of all calls) ───────╮
   │ Edit      ×125 repeats    (100%)                                         │
   │                                                                          │
   │ Top stuck patterns:                                                      │
@@ -83,7 +83,7 @@ exports[`N6 — state-aware phrasing (enabledShields injected) > ink scorecard: 
 │ ✗  ~/.npmrc                            npm auth token                                  │
 │ → project-jail shield blocks agent reads of these paths                                │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
-━━━━━━━━━ Medium (37 ops flagged · 1 loop · 125 wasted calls (1% of all calls)) ━━━━━━━━━━
+━━━━━━━━━ Medium (37 ops flagged · 1 loop · 125 repeat calls (1% of all calls)) ━━━━━━━━━━
 ╭──────────────────────────────────────────╮ ╭──────────────────────────────────────────╮
 │ REVIEW QUEUE                             │ │ AGENT LOOPS                              │
 │ review-git-destructive×22   default      │ │ Edit      ×125          100%             │
@@ -302,7 +302,7 @@ $9025.15 AI spend  ·  4 risky operations
 
 🔑  4   credential leak     (GitHub Token ×2, AWS Access Key, JWT)
 🛑  8   would have blocked  (force-push ×5, eval-remote)
-🔁  1   agent loops         (125 wasted calls (1% of all calls)  ·  ~$0.2460)
+🔁  1   agent loops         (125 repeat calls (1% of all calls)  ·  ~$0.2460)
 📂  1   long iterations     (deep work — not waste)
 👁  56  flagged for review  (rm)
 
@@ -337,7 +337,7 @@ exports[`renderNarrativeScorecard — output snapshots > rich fixture (critical 
      • 5 credential files reachable on disk
 
   🟢  MEDIUM     3 findings
-     • 2 agent loops (225 wasted calls, 2% of calls, ~$0.2460 wasted)
+     • 2 agent loops (225 repeat calls, 2% of calls, ~$0.2460 wasted)
      • rm calls
 
 →  npx node9-ai scan       run this on your machine
@@ -358,7 +358,7 @@ exports[`renderPanelScorecard — output snapshots > panel fixture (critical sco
 "  ╭─ TOP FINDINGS ───────────────────────────────────────────────────────────╮
   │ 🚨 2 credential leaks in tool input  (latest: 2d ago, GitHub Token)      │
   │ 🛑 2 ops node9 would have blocked  (block-read-ssh, block-eval-remote)   │
-  │ 🔁 1 agent loops detected  (Edit dominates, 125 wasted calls · 1% of calls) │
+  │ 🔁 1 agent loops detected  (Edit dominates, 125 repeat calls · 1% of calls) │
   │ 🔭 5 secrets reachable on disk  → enable project-jail                    │
   ╰──────────────────────────────────────────────────────────────────────────╯
 
@@ -378,7 +378,7 @@ exports[`renderPanelScorecard — output snapshots > panel fixture (critical sco
   │ 👁️  review-read-credentials  ×3    needs shield:project-jail             │
   ╰──────────────────────────────────────────────────────────────────────────╯
 
-  ╭─ AGENT LOOPS  ·  1 pattern  ·  125 wasted calls (1% of all calls) ───────╮
+  ╭─ AGENT LOOPS  ·  1 pattern  ·  125 repeat calls (1% of all calls) ───────╮
   │ Edit      ×125 repeats    (100%)                                         │
   │                                                                          │
   │ Top stuck patterns:                                                      │
@@ -454,7 +454,7 @@ exports[`renderScanScorecardInk — output snapshots > panel fixture (critical s
 │ ✗  ~/.npmrc                            npm auth token                                  │
 │ → project-jail shield blocks agent reads of these paths                                │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
-━━━━━━━━━ Medium (37 ops flagged · 1 loop · 125 wasted calls (1% of all calls)) ━━━━━━━━━━
+━━━━━━━━━ Medium (37 ops flagged · 1 loop · 125 repeat calls (1% of all calls)) ━━━━━━━━━━
 ╭──────────────────────────────────────────╮ ╭──────────────────────────────────────────╮
 │ REVIEW QUEUE                             │ │ AGENT LOOPS                              │
 │ review-git-destructive×22   default      │ │ Edit      ×125          100%             │

--- a/src/__tests__/dashboard-report-data.unit.test.ts
+++ b/src/__tests__/dashboard-report-data.unit.test.ts
@@ -29,6 +29,7 @@ const emptyScan: ScanResult = {
   firstDate: null,
   lastDate: null,
   sessionsWithEarlySecrets: 0,
+  perSession: [],
 };
 
 vi.mock('../cli/commands/scan', () => ({

--- a/src/__tests__/dashboard-report-derive.unit.test.ts
+++ b/src/__tests__/dashboard-report-derive.unit.test.ts
@@ -26,6 +26,7 @@ function emptyResult(): ScanResult {
     firstDate: null,
     lastDate: null,
     sessionsWithEarlySecrets: 0,
+    perSession: [],
   };
 }
 

--- a/src/__tests__/dashboard-score-banner.unit.test.tsx
+++ b/src/__tests__/dashboard-score-banner.unit.test.tsx
@@ -101,6 +101,7 @@ const READY: ScanCache = {
       firstDate: null,
       lastDate: null,
       sessionsWithEarlySecrets: 0,
+      perSession: [],
     },
     gemini: {
       filesScanned: 0,
@@ -114,6 +115,7 @@ const READY: ScanCache = {
       firstDate: null,
       lastDate: null,
       sessionsWithEarlySecrets: 0,
+      perSession: [],
     },
     codex: {
       filesScanned: 0,
@@ -127,6 +129,7 @@ const READY: ScanCache = {
       firstDate: null,
       lastDate: null,
       sessionsWithEarlySecrets: 0,
+      perSession: [],
     },
   },
 };

--- a/src/__tests__/jail-gauntlet.integration.test.ts
+++ b/src/__tests__/jail-gauntlet.integration.test.ts
@@ -26,6 +26,7 @@
 import { describe, it, expect, beforeAll, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
+import { FS_READ_TOOLS } from '@node9/policy-engine';
 import {
   CLI,
   makeHome,
@@ -181,5 +182,102 @@ describe('jail gauntlet — the credential jail holds at the real gate', () => {
     expect({ gate: gate.verdict, explainSaysAllow }, 'jail add promised reads BLOCK').toMatchObject(
       { gate: expect.not.stringMatching(/^allow$/) }
     );
+  });
+});
+
+/**
+ * The VERB axis (added 2026-08-31).
+ *
+ * Everything above varies WHICH TOOL carries the path — Read, Grep, Glob,
+ * shell. Every shell case is `cat`. That single hard-coded verb is why
+ * `base64 ~/.ssh/id_rsa` shipped undetected: it prints a file exactly like
+ * `cat` does, it simply was never in the suite because nobody thought to add
+ * it. A hand-written case list only ever covers what its author imagined.
+ *
+ * So this block DERIVES its cases from `FS_READ_TOOLS` — the same set the
+ * engine consults at `shell/index.ts:1765`. Add a name to that set and it gains
+ * jail coverage for free; remove one and the deletion shows up in the diff.
+ * Identical rule to the one the regex beside the set already follows:
+ * "DERIVED from FS_READ_TOOLS, never hand-written beside it."
+ */
+describe('jail gauntlet — the verb axis, derived from FS_READ_TOOLS', () => {
+  for (const verb of [...FS_READ_TOOLS].sort()) {
+    it(`shell: \`${verb}\` on a jailed path is blocked`, () => {
+      const { home, jailed } = jailedHome();
+      const r = probe(home, 'Bash', { command: `${verb} ${jailed}/key.txt` });
+      expect(r.verdict, `${verb} reads file contents — the jail must stop it`).toBe('block');
+    });
+  }
+});
+
+/** Build a command that MOVES rather than prints, per verb. */
+function copyCmd(verb: string, src: string): string {
+  if (verb === 'tar') return `tar cf /tmp/n9-gauntlet.tar ${src}`;
+  if (verb === 'ln') return `ln -s ${src} /tmp/n9-gauntlet-link`;
+  return `${verb} ${src} /tmp/n9-gauntlet-copy`;
+}
+const COPY_VERBS = ['cp', 'install', 'ln', 'rsync', 'tar'];
+
+/**
+ * ⭐ The two jails do NOT share a mechanism, and it decides copy coverage.
+ *
+ * Written 2026-08-31 after this suite refuted the assumption behind
+ * `BUGS.md` § A. § A says copy verbs escape the jail. That is true of the
+ * BUILT-IN baseline only — a `jail add` / fleet path covers them fine:
+ *
+ *   user + org jail  →  `pathRules` emits a bash rule matching the PATH
+ *                       anywhere in the command (shields/build.ts:107).
+ *                       Verb-agnostic, so `cp`/`tar`/`rsync` are caught.
+ *   built-in baseline → `analyzeFsOperation`, which resolves the VERB first
+ *                       and only then its target paths. A verb outside
+ *                       `FS_READ_TOOLS` is never reached, so copying escapes.
+ *
+ * Same promise, two implementations, opposite coverage — the four-list problem
+ * in miniature. These blocks pin both halves so the difference can't drift.
+ */
+describe('jail gauntlet — copy verbs ARE covered by a user/org jail', () => {
+  for (const verb of COPY_VERBS) {
+    it(`\`${verb}\` out of a user-jailed dir is blocked`, () => {
+      const { home, jailed } = jailedHome();
+      const r = probe(home, 'Bash', { command: copyCmd(verb, `${jailed}/key.txt`) });
+      expect(r.verdict, `the path rule matches ${verb} regardless of verb`).toBe('block');
+    });
+  }
+});
+
+/**
+ * KNOWN UNCOVERED — the real, narrowed `BUGS.md` § A.
+ *
+ * The baseline paths (`~/.ssh`, `~/.aws`, `.env`) are guarded by the AST tier,
+ * which asks "which command PRINTS a file". `cp`/`tar`/`rsync` don't print,
+ * they move — and once the secret sits at /tmp every rule is gone, because they
+ * all key on the original path.
+ *
+ * ⚠️ These assertions are deliberately INVERTED: they assert the gap still
+ * exists. Until now it lived only in a doc — nothing told a reader it was
+ * there, nothing failed if someone half-fixed it, nothing would catch a later
+ * regression. As a test it is a fact CI reads every run.
+ *
+ * ✅ WHEN YOU FIX ONE this test FAILS. That is success — move the verb up into
+ * the covered block and delete its line here. Never silence it by loosening
+ * the assertion.
+ */
+describe('jail gauntlet — copy verbs escape the BUILT-IN baseline (BUGS.md § A)', () => {
+  for (const verb of COPY_VERBS) {
+    it(`⚠️ \`${verb}\` on ~/.ssh still escapes — read the block comment before fixing`, () => {
+      const { home } = jailedHome();
+      const ssh = path.join(home, '.ssh');
+      fs.mkdirSync(ssh, { recursive: true });
+      const r = probe(home, 'Bash', { command: copyCmd(verb, path.join(ssh, 'id_rsa')) });
+      expect(r.verdict, `${verb} moves the baseline secret out unnoticed`).toBe('allow');
+    });
+  }
+
+  it('CONTROL: a PRINTING verb on the same baseline path IS blocked', () => {
+    const { home } = jailedHome();
+    const ssh = path.join(home, '.ssh');
+    fs.mkdirSync(ssh, { recursive: true });
+    const r = probe(home, 'Bash', { command: `cat ${path.join(ssh, 'id_rsa')}` });
+    expect(r.verdict, 'without this the block above proves nothing').toBe('block');
   });
 });

--- a/src/__tests__/jail-gauntlet.integration.test.ts
+++ b/src/__tests__/jail-gauntlet.integration.test.ts
@@ -26,7 +26,7 @@
 import { describe, it, expect, beforeAll, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
-import { FS_READ_TOOLS } from '@node9/policy-engine';
+import { FS_READ_TOOLS, analyzeFsOperation } from '@node9/policy-engine';
 import {
   CLI,
   makeHome,
@@ -261,23 +261,97 @@ describe('jail gauntlet — copy verbs ARE covered by a user/org jail', () => {
  * ✅ WHEN YOU FIX ONE this test FAILS. That is success — move the verb up into
  * the covered block and delete its line here. Never silence it by loosening
  * the assertion.
+ *
+ * ⚠️ WINDOWS — skipped, because the premise itself is absent there.
+ * `path.join` yields backslashes on win32, and mvdan-sh parses `\` as a POSIX
+ * escape and EATS it, so the literal reaching the matcher has no separators
+ * left at all:
+ *
+ *   POSIX    paths ["/home/x/.ssh/id_rsa"]   6 tokens  → block
+ *   win32    paths ["C:Usersx.sshid_rsa"]    2 tokens  → NULL
+ *
+ * So on Windows the built-in baseline never fires for ANY verb, and both the
+ * "copy escapes" rows and their CONTROL become vacuous — the rows would pass
+ * for the wrong reason and the CONTROL fails outright. That is a real product
+ * gap, not a test bug; it is pinned platform-independently by the engine-level
+ * block below so skipping here hides nothing.
+ *
+ * `pathRules` (user + fleet jail) is unaffected — it is a regex over raw
+ * command text with `[\s/\\]` separators and never meets the parser. The
+ * derived read-verb suite above therefore still runs everywhere.
  */
-describe('jail gauntlet — copy verbs escape the BUILT-IN baseline (BUGS.md § A)', () => {
-  for (const verb of COPY_VERBS) {
-    it(`⚠️ \`${verb}\` on ~/.ssh still escapes — read the block comment before fixing`, () => {
+describe.skipIf(process.platform === 'win32')(
+  'jail gauntlet — copy verbs escape the BUILT-IN baseline (BUGS.md § A)',
+  () => {
+    for (const verb of COPY_VERBS) {
+      it(`⚠️ \`${verb}\` on ~/.ssh still escapes — read the block comment before fixing`, () => {
+        const { home } = jailedHome();
+        const ssh = path.join(home, '.ssh');
+        fs.mkdirSync(ssh, { recursive: true });
+        const r = probe(home, 'Bash', { command: copyCmd(verb, path.join(ssh, 'id_rsa')) });
+        expect(r.verdict, `${verb} moves the baseline secret out unnoticed`).toBe('allow');
+      });
+    }
+
+    it('CONTROL: a PRINTING verb on the same baseline path IS blocked', () => {
       const { home } = jailedHome();
       const ssh = path.join(home, '.ssh');
       fs.mkdirSync(ssh, { recursive: true });
-      const r = probe(home, 'Bash', { command: copyCmd(verb, path.join(ssh, 'id_rsa')) });
-      expect(r.verdict, `${verb} moves the baseline secret out unnoticed`).toBe('allow');
+      const r = probe(home, 'Bash', { command: `cat ${path.join(ssh, 'id_rsa')}` });
+      expect(r.verdict, 'without this the block above proves nothing').toBe('block');
+    });
+  }
+);
+
+/**
+ * ⚠️ KNOWN UNCOVERED — the AST tier is blind to Windows backslash paths.
+ *
+ * Pure-function assertions, so they run on EVERY platform: the gap stays
+ * visible on Linux CI instead of only surfacing when a Windows runner happens
+ * to execute the integration block above.
+ *
+ * `mvdan-sh` treats `\` as a POSIX escape and removes it, so a real Windows
+ * path arrives at the matcher with no separators. Consequence on a real
+ * Windows box: the built-in jail (`~/.ssh`, `~/.aws`, `.env`) never fires —
+ * not merely for copy verbs, for everything.
+ *
+ * ⛔ Bigger and NOT yet measured: the destructive AST rules (rm / mkfs / dd)
+ * very likely go blind the same way, since this is a parse-level loss rather
+ * than a matcher-level one.
+ *
+ * ⭐ These use `it.fails`, NOT an assertion that the gap exists. The difference
+ * matters. Asserting the broken value (`toBeNull()`) would write the bug into
+ * the suite as if it were the spec: a reader sees the wrong expectation, and
+ * whoever fixes the parser gets a red test whose easiest "fix" is to edit the
+ * assertion — silently re-hiding the gap. With `it.fails` the body states the
+ * DESIRED behaviour and only the marker says "known broken", so a fix makes
+ * vitest raise `Expect test to fail`, which cannot be satisfied by weakening
+ * an assertion — only by deleting the marker. Verified, not assumed.
+ */
+describe('AST tier — Windows path blindness (known gap)', () => {
+  const WIN_CASES: Array<[string, string]> = [
+    ['~/.ssh', 'cat C:\\Users\\x\\.ssh\\id_rsa'],
+    ['~/.aws', 'cat C:\\Users\\x\\.aws\\credentials'],
+    ['.env', 'cat C:\\proj\\.env'],
+    [
+      'quoted — quotes do not help, POSIX escapes apply inside them too',
+      'cat "C:\\Users\\x\\.ssh\\id_rsa"',
+    ],
+  ];
+  for (const [label, cmd] of WIN_CASES) {
+    // Body = what SHOULD happen. Marker = it does not yet. Delete the marker
+    // when the parse is fixed; never touch the expectation.
+    it.fails(`a Windows backslash path should be detected: ${label}`, () => {
+      expect(analyzeFsOperation(cmd)?.verdict).toBe('block');
     });
   }
 
-  it('CONTROL: a PRINTING verb on the same baseline path IS blocked', () => {
-    const { home } = jailedHome();
-    const ssh = path.join(home, '.ssh');
-    fs.mkdirSync(ssh, { recursive: true });
-    const r = probe(home, 'Bash', { command: `cat ${path.join(ssh, 'id_rsa')}` });
-    expect(r.verdict, 'without this the block above proves nothing').toBe('block');
+  it('CONTROL: the same Windows path with FORWARD slashes IS detected', () => {
+    const r = analyzeFsOperation('cat C:/Users/x/.ssh/id_rsa');
+    expect(r?.verdict, 'proves the matcher is fine — only the separator breaks it').toBe('block');
+  });
+
+  it('CONTROL: the POSIX equivalent IS detected', () => {
+    expect(analyzeFsOperation('cat /home/x/.ssh/id_rsa')?.verdict).toBe('block');
   });
 });

--- a/src/__tests__/loop-waste.unit.test.ts
+++ b/src/__tests__/loop-waste.unit.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { computeLoopWaste, MAX_PLAUSIBLE_RATE_USD } from '../scan-summary';
+import type { LoopRef } from '../scan-summary';
+import type { SessionCost } from '../cli/commands/scan';
+
+// Cases written against an adversarial matrix produced BEFORE this code
+// existed, not against the implementation. The recurring failure in this
+// codebase is a check that reports health it cannot actually observe, so most
+// of what follows attacks the reassuring answer rather than the wrong one.
+
+const loop = (over: Partial<LoopRef> = {}): LoopRef => ({
+  toolName: 'Edit',
+  commandPreview: '/tmp/x.ts',
+  count: 10,
+  timestamp: '2026-08-31T00:00:00Z',
+  project: 'p',
+  sessionId: 's1',
+  agent: 'claude',
+  kind: 'loop',
+  ...over,
+});
+
+const session = (over: Partial<SessionCost> = {}): SessionCost => ({
+  sessionId: 's1',
+  costUSD: 100,
+  toolCalls: 100,
+  ...over,
+});
+
+describe('computeLoopWaste', () => {
+  it('prices iterations beyond the threshold at the session rate', () => {
+    // count 10, threshold 3 -> 7 wasted, at $1.00/call
+    const r = computeLoopWaste([loop({ count: 10 })], [session()]);
+    expect(r.usd).toBeCloseTo(7);
+    expect(r.pricedIterations).toBe(7);
+    expect(r.unpricedIterations).toBe(0);
+  });
+
+  it('ignores sustained work on one target', () => {
+    const r = computeLoopWaste([loop({ kind: 'long-iteration', count: 500 })], [session()]);
+    expect(r).toEqual({ usd: 0, pricedIterations: 0, unpricedIterations: 0 });
+  });
+
+  it('charges nothing for a loop at exactly the detection threshold', () => {
+    // count 3 is the smallest detectable loop and the modal finding in real
+    // data; those are Edits to distinct files, i.e. ordinary development.
+    const r = computeLoopWaste([loop({ count: 3 })], [session()]);
+    expect(r.usd).toBe(0);
+  });
+
+  // ── the reassuring-zero hunt ───────────────────────────────────────────
+  it('does not price a zero-cost session as free waste', () => {
+    // Antigravity and Copilot transcripts carry no token data, so cost is a
+    // structural 0 next to thousands of real calls. 0/5000 is FINITE, so an
+    // isFinite guard passes it through and 40 real iterations render $0.00.
+    const r = computeLoopWaste([loop({ count: 43 })], [session({ costUSD: 0, toolCalls: 5000 })]);
+    expect(r.usd).toBe(0);
+    expect(r.pricedIterations).toBe(0);
+    expect(r.unpricedIterations).toBe(40);
+  });
+
+  it('does not divide by a zero call count', () => {
+    const r = computeLoopWaste([loop({ count: 13 })], [session({ toolCalls: 0 })]);
+    expect(r.unpricedIterations).toBe(10);
+    expect(Number.isFinite(r.usd)).toBe(true);
+  });
+
+  it('leaves a loop whose session is absent unpriced, not free', () => {
+    const r = computeLoopWaste([loop({ sessionId: 'ghost', count: 13 })], [session()]);
+    expect(r.usd).toBe(0);
+    expect(r.unpricedIterations).toBe(10);
+  });
+
+  it('rejects an implausible rate instead of reporting a fortune', () => {
+    // One session whose calls went uncounted: $13,700 for a single call.
+    const r = computeLoopWaste([loop({ count: 43 })], [session({ costUSD: 13700, toolCalls: 1 })]);
+    expect(r.usd).toBe(0);
+    expect(r.unpricedIterations).toBe(40);
+    expect(MAX_PLAUSIBLE_RATE_USD).toBeLessThan(13700);
+  });
+
+  it('rejects a negative cost rather than crediting waste back', () => {
+    const r = computeLoopWaste([loop({ count: 13 })], [session({ costUSD: -50 })]);
+    expect(r.usd).toBe(0);
+    expect(r.unpricedIterations).toBe(10);
+  });
+
+  // ── the 250x error a single blended basis produces ─────────────────────
+  it('prices each session at its own rate, never at a blend', () => {
+    const loops = [
+      loop({ sessionId: 'pricey', count: 13 }), // 10 wasted @ $1.00
+      loop({ sessionId: 'cheap', count: 1003 }), // 1000 wasted @ $0.001
+    ];
+    const sessions = [
+      session({ sessionId: 'pricey', costUSD: 100, toolCalls: 100 }),
+      session({ sessionId: 'cheap', costUSD: 10, toolCalls: 10000 }),
+    ];
+    const r = computeLoopWaste(loops, sessions);
+    expect(r.usd).toBeCloseTo(10 + 1);
+    // A blended basis is (110 / 10100) = $0.0109 over 1010 iterations = $11.00
+    // by coincidence here, so assert the per-session split explicitly instead
+    // of trusting the total alone.
+    expect(r.pricedIterations).toBe(1010);
+  });
+
+  it('is additive and order-independent', () => {
+    const a = loop({ sessionId: 's1', count: 8 });
+    const b = loop({ sessionId: 's2', count: 6 });
+    const ss = [session({ sessionId: 's1' }), session({ sessionId: 's2', costUSD: 50 })];
+    const both = computeLoopWaste([a, b], ss);
+    const reversed = computeLoopWaste([b, a], ss);
+    const split = computeLoopWaste([a], ss).usd + computeLoopWaste([b], ss).usd;
+    expect(both.usd).toBeCloseTo(reversed.usd);
+    expect(both.usd).toBeCloseTo(split);
+  });
+
+  it('returns clean zeros for no loops at all', () => {
+    expect(computeLoopWaste([], [session()])).toEqual({
+      usd: 0,
+      pricedIterations: 0,
+      unpricedIterations: 0,
+    });
+  });
+
+  it('never reports dollars without iterations behind them', () => {
+    // An impossible pair — money with nothing priced — is exactly how a
+    // fabricated figure would look. Generated inputs, so no single fixture
+    // can hide it.
+    for (const count of [0, 1, 3, 4, 12, 500]) {
+      for (const cost of [0, 1, 100, -5]) {
+        for (const calls of [0, 1, 100]) {
+          const r = computeLoopWaste(
+            [loop({ count })],
+            [session({ costUSD: cost, toolCalls: calls })]
+          );
+          if (r.usd > 0) expect(r.pricedIterations).toBeGreaterThan(0);
+          if (r.pricedIterations === 0) expect(r.usd).toBe(0);
+          expect(r.usd).toBeGreaterThanOrEqual(0);
+          expect(Number.isFinite(r.usd)).toBe(true);
+        }
+      }
+    }
+  });
+
+  it('treats a missing kind as a real loop, not as excluded', () => {
+    // kind is optional for legacy data. Dropping those to $0 would be the
+    // reassuring direction; counting them keeps the number honest.
+    const legacy = { ...loop({ count: 13 }) } as LoopRef;
+    delete (legacy as { kind?: unknown }).kind;
+    expect(computeLoopWaste([legacy], [session()]).pricedIterations).toBe(10);
+  });
+});

--- a/src/__tests__/scan-json.unit.test.ts
+++ b/src/__tests__/scan-json.unit.test.ts
@@ -48,6 +48,7 @@ function emptySummary(overrides: Partial<ScanSummary> = {}): ScanSummary {
     leaks: [],
     loops: [],
     loopWastedUSD: 0,
+    loopWaste: { usd: 0, pricedIterations: 0, unpricedIterations: 0 },
     ...overrides,
   };
 }
@@ -140,6 +141,7 @@ describe('buildScanJson', () => {
     const summary = emptySummary({
       byVerdict: { blocked: 1, supervised: 2, leaks: 3, loops: 4 },
       loopWastedUSD: 0.5,
+      loopWaste: { usd: 0.5, pricedIterations: 1, unpricedIterations: 0 },
     });
     const out = buildScanJson({
       scan: emptyScan(),

--- a/src/__tests__/scan-json.unit.test.ts
+++ b/src/__tests__/scan-json.unit.test.ts
@@ -27,6 +27,7 @@ function emptyScan(overrides: Partial<ScanResult> = {}): ScanResult {
     firstDate: null,
     lastDate: null,
     sessionsWithEarlySecrets: 0,
+    perSession: [],
     ...overrides,
   };
 }

--- a/src/__tests__/scan-render.snapshot.test.ts
+++ b/src/__tests__/scan-render.snapshot.test.ts
@@ -89,6 +89,7 @@ function emptySummary(overrides: Partial<ScanSummary> = {}): ScanSummary {
     leaks: [],
     loops: [],
     loopWastedUSD: 0,
+    loopWaste: { usd: 0, pricedIterations: 0, unpricedIterations: 0 },
     ...overrides,
   };
 }
@@ -298,6 +299,7 @@ function richFixture(): CompactInput {
       },
     ],
     loopWastedUSD: 0.246,
+    loopWaste: { usd: 0.246, pricedIterations: 1, unpricedIterations: 0 },
   });
 
   return {
@@ -489,6 +491,7 @@ function panelFixture(): CompactInput {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     leaks: scan.dlpFindings as any,
     loopWastedUSD: 0.25,
+    loopWaste: { usd: 0.25, pricedIterations: 1, unpricedIterations: 0 },
   });
 
   return {

--- a/src/__tests__/scan-render.snapshot.test.ts
+++ b/src/__tests__/scan-render.snapshot.test.ts
@@ -68,6 +68,7 @@ function emptyScan(overrides: Partial<ScanResult> = {}): ScanResult {
     firstDate: null,
     lastDate: null,
     sessionsWithEarlySecrets: 0,
+    perSession: [],
     ...overrides,
   };
 }

--- a/src/__tests__/scan-summary.unit.test.ts
+++ b/src/__tests__/scan-summary.unit.test.ts
@@ -305,9 +305,35 @@ describe('buildScanSummary', () => {
         },
       ],
     });
+    scan.perSession = [{ sessionId: 's', costUSD: 200, toolCalls: 100 }];
     const s = buildScanSummary([claudeAgent(scan)]);
-    // Total wasted = 9 iters × $0.006 = $0.054
-    expect(s.loopWastedUSD).toBeCloseTo(9 * 0.006);
+    // 9 wasted iterations, priced at that session's own rate ($2.00/call).
+    // The flat $0.006 this replaced would have called the same work $0.054.
+    expect(s.loopWaste.pricedIterations).toBe(9);
+    expect(s.loopWastedUSD).toBeCloseTo(9 * 2);
+  });
+
+  it('reports waste it cannot price as unpriced, never as free', () => {
+    const scan = emptyScan({
+      loopFindings: [
+        {
+          toolName: 'edit',
+          commandPreview: 'edit /a',
+          count: 10,
+          timestamp: '',
+          project: '~/p',
+          sessionId: 's',
+          agent: 'claude',
+        },
+      ],
+    });
+    // No perSession row: Antigravity and Copilot transcripts carry no token
+    // data, so this is the real shape for those agents — and $0.00 next to 7
+    // wasted iterations reads as "nothing happened".
+    const s = buildScanSummary([claudeAgent(scan)]);
+    expect(s.loopWastedUSD).toBe(0);
+    expect(s.loopWaste.pricedIterations).toBe(0);
+    expect(s.loopWaste.unpricedIterations).toBe(7);
   });
 
   it('sorts sections: most blocked first, then by total findings', () => {
@@ -458,10 +484,13 @@ describe('loopWastedUSD excludes long-iteration findings', () => {
         },
       ],
     });
+    scan.perSession = [{ sessionId: 'sess1', costUSD: 100, toolCalls: 100 }];
     const s = buildScanSummary([claudeAgent(scan)]);
-    // Only 7 wasted iters (10 loop - 3 threshold), at $0.006/iter = $0.042.
-    // The 97 long-iteration iters above threshold contribute ZERO.
-    expect(s.loopWastedUSD).toBeCloseTo(7 * 0.006, 4);
+    // Only 7 wasted iters (10 loop - 3 threshold) at $1.00/call. The 97
+    // long-iteration iterations above threshold contribute ZERO: that is
+    // sustained work on one target, not a stuck loop.
+    expect(s.loopWaste.pricedIterations).toBe(7);
+    expect(s.loopWastedUSD).toBeCloseTo(7, 4);
   });
 
   it('treats missing kind as a real loop (backwards compat)', () => {
@@ -480,8 +509,10 @@ describe('loopWastedUSD excludes long-iteration findings', () => {
         },
       ],
     });
+    scan.perSession = [{ sessionId: 'sess1', costUSD: 100, toolCalls: 100 }];
     const s = buildScanSummary([claudeAgent(scan)]);
-    expect(s.loopWastedUSD).toBeCloseTo(7 * 0.006, 4);
+    expect(s.loopWaste.pricedIterations).toBe(7);
+    expect(s.loopWastedUSD).toBeCloseTo(7, 4);
   });
 });
 

--- a/src/__tests__/scan-summary.unit.test.ts
+++ b/src/__tests__/scan-summary.unit.test.ts
@@ -103,6 +103,7 @@ function emptyScan(overrides: Partial<ScanResult> = {}): ScanResult {
     firstDate: null,
     lastDate: null,
     sessionsWithEarlySecrets: 0,
+    perSession: [],
     ...overrides,
   };
 }

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -170,6 +170,29 @@ export interface ScanResult {
   firstDate: string | null;
   lastDate: string | null;
   sessionsWithEarlySecrets: number;
+  /**
+   * Cost and tool-call volume per session, so a loop can be priced by the
+   * session it actually ran in.
+   *
+   * The aggregates above cannot do this. Measured on the founder's history,
+   * the per-call rate swings 11x across sessions ($0.11 to $1.21) because the
+   * model differs (opus-4-8 / opus-5 / fable-5) and context grows through a
+   * session. Any single average erases exactly the variation that matters:
+   * 99.2% of his spend sits in the 19 sessions that looped.
+   *
+   * Claude only for now. Antigravity and Copilot transcripts carry no token
+   * data at all (totalCostUSD is a structural 0), so a rate for them would be
+   * unknown, not cheap — and callers must render that difference.
+   */
+  perSession: SessionCost[];
+}
+
+/** Per-session totals. `toolCalls` counts tool_use blocks, matching the
+ *  denominator scan-upload-history.ts uses when it builds SessionToolCall. */
+export interface SessionCost {
+  sessionId: string;
+  costUSD: number;
+  toolCalls: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -865,6 +888,9 @@ function processClaudeFile(
   onProgress?.(result.filesScanned);
 
   const sessionId = file.replace(/\.jsonl$/, '');
+  // Per-session totals, so loop waste can be priced at THIS session's rate
+  // instead of a fleet average. Pushed once at the end of the file.
+  const session: SessionCost = { sessionId, costUSD: 0, toolCalls: 0 };
 
   let raw: string;
   try {
@@ -992,11 +1018,13 @@ function processClaudeFile(
     if (usage && model) {
       const p = claudeModelPrice(model);
       if (p) {
-        result.totalCostUSD +=
+        const rowCost =
           (usage.input_tokens ?? 0) * p.i +
           (usage.output_tokens ?? 0) * p.o +
           (usage.cache_creation_input_tokens ?? 0) * p.cw +
           (usage.cache_read_input_tokens ?? 0) * p.cr;
+        result.totalCostUSD += rowCost;
+        session.costUSD += rowCost;
       }
     }
 
@@ -1007,6 +1035,7 @@ function processClaudeFile(
     for (const block of content) {
       if (block.type !== 'tool_use') continue;
       result.totalToolCalls++;
+      session.toolCalls++;
 
       const toolName = block.name ?? '';
       const toolNameLower = toolName.toLowerCase();
@@ -1158,6 +1187,11 @@ function processClaudeFile(
   if (firstDlpTs !== null && (firstEditTs === null || firstDlpTs < firstEditTs)) {
     result.sessionsWithEarlySecrets++;
   }
+
+  // Record the session even at zero cost: an empty record says "we looked and
+  // this session priced at nothing", which a consumer must be able to tell
+  // apart from "we have no record of this session at all".
+  result.perSession.push(session);
 }
 
 /**
@@ -1279,6 +1313,7 @@ function emptyClaudeScan(): ScanResult {
     firstDate: null,
     lastDate: null,
     sessionsWithEarlySecrets: 0,
+    perSession: [],
   };
 }
 
@@ -1383,6 +1418,7 @@ export function scanGeminiHistory(
     firstDate: null,
     lastDate: null,
     sessionsWithEarlySecrets: 0,
+    perSession: [],
   };
   const dedup = emptyScanDedup();
 
@@ -1709,6 +1745,7 @@ export function scanAntigravityHistory(
     firstDate: null,
     lastDate: null,
     sessionsWithEarlySecrets: 0,
+    perSession: [],
   };
   const dedup = emptyScanDedup();
 
@@ -1973,6 +2010,7 @@ export function scanCopilotHistory(
     firstDate: null,
     lastDate: null,
     sessionsWithEarlySecrets: 0,
+    perSession: [],
   };
   const dedup = emptyScanDedup();
 
@@ -2198,6 +2236,7 @@ export function scanCodexHistory(
     firstDate: null,
     lastDate: null,
     sessionsWithEarlySecrets: 0,
+    perSession: [],
   };
   const dedup = emptyScanDedup();
 
@@ -2521,6 +2560,7 @@ function mergeScans(a: ScanResult, b: ScanResult): ScanResult {
     firstDate: dates.length ? dates.sort()[0] : null,
     lastDate: lastDates.length ? lastDates.sort().at(-1)! : null,
     sessionsWithEarlySecrets: a.sessionsWithEarlySecrets + b.sessionsWithEarlySecrets,
+    perSession: [...a.perSession, ...b.perSession],
   };
 }
 

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -386,7 +386,7 @@ export interface StuckTool {
   toolName: string;
   /** Wasted calls = sum of (count - 1) across all loop findings for this tool. */
   waste: number;
-  /** Share of total wasted calls across all tools, rounded to nearest %. */
+  /** Share of total repeat calls across all tools, rounded to nearest %. */
   pct: number;
 }
 
@@ -2713,7 +2713,7 @@ export function renderCompactScorecard(input: CompactInput): void {
     const wasteParts: string[] = [];
     // "% of all calls", never bare "% wasted": the percentage is a share of
     // tool CALLS, and unlabeled it reads as a share of the cost beside it.
-    if (wastedCalls > 0) wasteParts.push(`${wastedCalls} wasted calls (${wastePct}% of all calls)`);
+    if (wastedCalls > 0) wasteParts.push(`${wastedCalls} repeat calls (${wastePct}% of all calls)`);
     if (summary.loopWastedUSD > 0) wasteParts.push('~' + fmtCost(summary.loopWastedUSD));
     const wasteSummary = wasteParts.length ? `(${wasteParts.join('  ·  ')})` : '';
     console.log(
@@ -2843,7 +2843,7 @@ export function renderNarrativeScorecard(input: CompactInput): void {
     const { wastePct, wastedCalls } = computeLoopWaste(scan.loopFindings, scan.totalToolCalls);
     const cost = summary.loopWastedUSD > 0 ? `, ~${fmtCost(summary.loopWastedUSD)} wasted` : '';
     medium.push({
-      label: `${scan.loopFindings.length} agent loops (${wastedCalls} wasted calls, ${wastePct}% of calls${cost})`,
+      label: `${scan.loopFindings.length} agent loops (${wastedCalls} repeat calls, ${wastePct}% of calls${cost})`,
       count: scan.loopFindings.length,
     });
   }
@@ -3051,7 +3051,7 @@ export function renderPanelScorecard(input: CompactInput, now: Date = new Date()
     }
     const top = [...byTool.entries()].sort((a, b) => b[1] - a[1])[0];
     const wasteSuffix =
-      wastedCalls > 0 ? `, ${wastedCalls} wasted calls · ${wastePct}% of calls` : '';
+      wastedCalls > 0 ? `, ${wastedCalls} repeat calls · ${wastePct}% of calls` : '';
     const detail = top ? `(${top[0]} dominates${wasteSuffix})` : '';
     topLines.push(
       mkLine(
@@ -3207,7 +3207,7 @@ export function renderPanelScorecard(input: CompactInput, now: Date = new Date()
     }
 
     const wasteSuffix =
-      wastedCalls > 0 ? `  ·  ${wastedCalls} wasted calls (${wastePct}% of all calls)` : '';
+      wastedCalls > 0 ? `  ·  ${wastedCalls} repeat calls (${wastePct}% of all calls)` : '';
     const title = `AGENT LOOPS  ·  ${scan.loopFindings.length} pattern${scan.loopFindings.length !== 1 ? 's' : ''}${wasteSuffix}`;
     for (const ln of boxPanel(title, loopLines)) console.log('  ' + ln);
     // Earlier the "N repeated calls (~N × cost-per-iteration)" line
@@ -4021,7 +4021,7 @@ export function registerScanCommand(program: Command): void {
             }
 
             // ── Most stuck tools (top 3 by wasted-call share) ──────────────
-            // Aggregate wasted calls (count - 1 per finding) by toolName, so
+            // Aggregate repeat calls (count - 1 per finding) by toolName, so
             // a heavy user can see at a glance which tool is burning their
             // tokens. Hidden when total waste is trivial (<5) to avoid noise.
             const stuckTools = computeStuckTools(scan.loopFindings);

--- a/src/cli/render/ink/StaticScorecard.tsx
+++ b/src/cli/render/ink/StaticScorecard.tsx
@@ -147,11 +147,13 @@ export function StaticScorecard({ input, rangeLabel, now }: Props): React.ReactE
         const parts: string[] = [];
         if (reviewCount > 0) parts.push(`${reviewCount} op${reviewCount !== 1 ? 's' : ''} flagged`);
         if (loopCount > 0)
-          // loops = repeated PATTERNS; wasted calls = repeats inside them. The
+          // loops = repeated PATTERNS; repeat calls = the repeats inside them,
+          // NOT a waste claim: this list is unfiltered, so sustained work on one
+          // file (kind: long-iteration) is counted here too. The
           // % is a share of ALL TOOL CALLS — never render it as a cost share.
           parts.push(
             `${loopCount} loop${loopCount !== 1 ? 's' : ''}${
-              wastedCalls > 0 ? ` · ${wastedCalls} wasted calls (${wastePct}% of all calls)` : ''
+              wastedCalls > 0 ? ` · ${wastedCalls} repeat calls (${wastePct}% of all calls)` : ''
             }`
           );
         return (

--- a/src/cli/render/ink/panels/CostPanel.tsx
+++ b/src/cli/render/ink/panels/CostPanel.tsx
@@ -29,7 +29,13 @@ export function CostPanel({ summary, width }: Props): React.ReactElement {
   const total = summary.stats.totalCostUSD;
   return (
     <Box borderStyle="round" borderColor="gray" paddingX={1} flexDirection="column" width={width}>
-      <Text bold>COST</Text>
+      {/* "API value", not "spend": this is tokens x list price. A user on a
+          flat monthly plan pays their plan, not this — and today the product
+          has no concept of a plan at all, so an unqualified "Total" asserts
+          something false for every subscriber. The number is right; the word
+          was wrong. It is also the better story once labelled: this much
+          value consumed, against whatever the plan actually costs. */}
+      <Text bold>COST · API value</Text>
 
       <Box>
         <Box width={LABEL_W}>

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -944,6 +944,7 @@ export function startDaemon(): void {
           firstDate: null,
           lastDate: null,
           sessionsWithEarlySecrets: 0,
+          perSession: [],
         };
         let claude: ScanResult = EMPTY_SCAN;
         let gemini: ScanResult = EMPTY_SCAN;

--- a/src/scan-summary.ts
+++ b/src/scan-summary.ts
@@ -15,7 +15,7 @@
 //
 // This module is PURE: no fs, no network. Any I/O (scanning JSONL) lives
 // in cli/commands/scan.ts; this module only consumes ScanResult instances.
-import type { ScanResult } from './cli/commands/scan';
+import type { ScanResult, SessionCost } from './cli/commands/scan';
 import { SHIELDS } from './shields';
 
 // ---------------------------------------------------------------------------
@@ -108,6 +108,9 @@ export interface ScanSummary {
   leaks: LeakRef[];
   loops: LoopRef[];
   loopWastedUSD: number;
+  /** Coverage behind loopWastedUSD — see LoopWaste. Absent dollars are not
+   *  zero dollars, and a renderer needs to be able to say so. */
+  loopWaste: LoopWaste;
 }
 
 export interface AgentSummary {
@@ -176,12 +179,84 @@ export interface LoopRef {
 // compute the same loop-waste figure without copying values across packages.
 // ---------------------------------------------------------------------------
 
-export { LOOP_THRESHOLD_FOR_WASTE, COST_PER_LOOP_ITER_USD } from '@node9/policy-engine';
-import { LOOP_THRESHOLD_FOR_WASTE, COST_PER_LOOP_ITER_USD } from '@node9/policy-engine';
+// COST_PER_LOOP_ITER_USD is deliberately NOT imported or re-exported here any
+// more. Loop dollars come from computeLoopWaste and the session that produced
+// them; a reachable constant is how six competing loop-waste formulas grew in
+// the first place — whoever needed a price multiplied by the nearest one.
+export { LOOP_THRESHOLD_FOR_WASTE } from '@node9/policy-engine';
+import { LOOP_THRESHOLD_FOR_WASTE } from '@node9/policy-engine';
 
 // ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
+
+/**
+ * Highest believable price for one tool call, in USD.
+ *
+ * Real rates measured across live sessions span $0.11 to $1.21. A basis above
+ * this ceiling means the denominator is wrong (a session whose tool calls were
+ * not counted), not that a call truly cost that much — and 40 iterations times
+ * a bad basis renders a six-figure "finding". Reject instead: unknown is
+ * recoverable, a fabricated headline number is not.
+ */
+export const MAX_PLAUSIBLE_RATE_USD = 50;
+
+export interface LoopWaste {
+  /** Dollars for the iterations we could price. Never includes a guess. */
+  usd: number;
+  /** Iterations priced from their own session's real cost. */
+  pricedIterations: number;
+  /**
+   * Iterations we could not price. NOT zero dollars — the session carried no
+   * usable cost (Antigravity and Copilot transcripts have no token data at
+   * all). Renderers must show `usd` as a floor when this is > 0.
+   */
+  unpricedIterations: number;
+}
+
+/**
+ * Price loop waste at the rate of the session each loop actually ran in.
+ *
+ * Per session, never blended. With a single average over a mixed set the
+ * arithmetic is not merely imprecise, it inverts: 10 iterations at $1.015 plus
+ * 10,000 at $0.001 is $20.15, while the same iterations against a blended
+ * $0.504 basis reads $5,049.
+ *
+ * Exported for its unit test — this is the one place a count becomes money.
+ */
+export function computeLoopWaste(
+  loops: ReadonlyArray<LoopRef>,
+  perSession: ReadonlyArray<SessionCost>
+): LoopWaste {
+  const rate = new Map<string, number>();
+  for (const s of perSession) {
+    // Every rejection below must land on "unknown", never on 0. A zero basis
+    // is a finite number, so it survives an isFinite guard and then prices
+    // real waste at $0.00 — which reads as "nothing to see here".
+    if (!(s.toolCalls > 0) || !(s.costUSD > 0)) continue;
+    const r = s.costUSD / s.toolCalls;
+    if (!Number.isFinite(r) || r <= 0 || r > MAX_PLAUSIBLE_RATE_USD) continue;
+    rate.set(s.sessionId, r);
+  }
+
+  let usd = 0;
+  let pricedIterations = 0;
+  let unpricedIterations = 0;
+  for (const l of loops) {
+    // Long iterations are sustained work on one target, not a stuck loop.
+    if (l.kind === 'long-iteration') continue;
+    const wasted = Math.max(0, l.count - LOOP_THRESHOLD_FOR_WASTE);
+    if (!Number.isFinite(wasted) || wasted === 0) continue;
+    const r = rate.get(l.sessionId);
+    if (r === undefined) {
+      unpricedIterations += wasted;
+      continue;
+    }
+    usd += wasted * r;
+    pricedIterations += wasted;
+  }
+  return { usd, pricedIterations, unpricedIterations };
+}
 
 export function buildScanSummary(agents: AgentScanInput[]): ScanSummary {
   // Aggregate stats across all agents
@@ -255,12 +330,15 @@ export function buildScanSummary(agents: AgentScanInput[]): ScanSummary {
   // Build sections — group findings by (sourceType, shieldName)
   const sections = buildSections(allFindings);
 
-  // Loop savings estimate — only true loops count toward waste, not long
-  // iterations (sustained deep work on one target across the session).
-  const wastedIters = allLoops
-    .filter((l) => l.kind !== 'long-iteration')
-    .reduce((sum, l) => sum + Math.max(0, l.count - LOOP_THRESHOLD_FOR_WASTE), 0);
-  const loopWastedUSD = wastedIters * COST_PER_LOOP_ITER_USD;
+  // Loop waste, priced per session. The flat COST_PER_LOOP_ITER_USD it
+  // replaced assumed ~2K Sonnet tokens for every iteration; against measured
+  // rates that is 100x to 200x low, and it reported $0.24 where the same
+  // iterations priced at their own sessions come to roughly $35.
+  const loopWaste = computeLoopWaste(
+    allLoops,
+    agents.flatMap((a) => a.scan.perSession)
+  );
+  const loopWastedUSD = loopWaste.usd;
 
   return {
     stats,
@@ -270,6 +348,7 @@ export function buildScanSummary(agents: AgentScanInput[]): ScanSummary {
     leaks: allLeaks,
     loops: allLoops,
     loopWastedUSD,
+    loopWaste,
   };
 }
 

--- a/src/tui/dashboard/views/report/panels/Cost.tsx
+++ b/src/tui/dashboard/views/report/panels/Cost.tsx
@@ -59,7 +59,8 @@ export function Cost({ audit }: { audit: AggregateResult | null }): React.ReactE
       flexGrow={1}
       flexBasis={0}
     >
-      <Text bold>COST</Text>
+      {/* See CostPanel: tokens x list price, not what the user is billed. */}
+      <Text bold>COST · API value</Text>
       {audit === null ? (
         <Text dimColor>loading…</Text>
       ) : (


### PR DESCRIPTION
Five commits. Every number below was measured on a real machine, not estimated.

### The number was wrong two ways at once

The scorecard printed `1212 wasted calls` beside `~$0.24`. Both were wrong, in opposite directions.

**`1212` counted the user's own work.** 167 of his 230 loop findings are `kind: 'long-iteration'` — sustained work on one file — and the renderer passes the unfiltered list. Even among true loops it overclaims: 44 of 63 sit at `count: 3`, and those are Edits to *distinct* files. Three edits to `auth.service.ts` is how people write code.

**`$0.24` was a flat constant.** `COST_PER_LOOP_ITER_USD` assumes ~2K Sonnet tokens per iteration. Measured against the sessions those loops actually ran in, the same 40 iterations come to **`$34.96`** — 100x to 200x higher.

### Priced per session, never blended

Real rates span **11x** between sessions (`$0.1076` to `$1.2103`) because the model differs (opus-4-8 / opus-5 / fable-5) and context grows through a session. 99.2% of spend sits in the 19 sessions that looped; one 3,525-call session accounts for 40% of the waste.

A single average does not blur that, it inverts it: 10 iterations at `$1.015` plus 10,000 at `$0.001` is `$20.15`, but against a blended `$0.504` basis it reads `$5,049`.

Every rejected basis lands on **unpriced, never zero**. `0 cost / 5000 calls` is finite, so an `isFinite` guard passes it through and prices real waste at `$0.00` — and that is the permanent shape for Antigravity and Copilot, whose transcripts carry no token data at all.

### `fix(cost):` and it is not spend

The COST panel said `Total $13.7K`. The founder pays **`$100/month`**. Tokens, prices and arithmetic are all correct; the word was wrong, and wrong for probably most users, because there is no concept of a plan anywhere in the codebase.

`COST · API value` on both panels. It stops asserting something false, and it is the better story: this much value consumed against whatever the plan costs.

### `refactor(engine):` the extractor stops pricing what it cannot see

`CanonicalFinding.costUsd` was `count × constant`. `SessionExtractContext` holds no spend data of any kind, so that field was a constant wearing the costume of a measurement. Nothing consumed it. Measured on the pipeline that actually ships — 60 sessions, 12,668 tool calls — 14 findings before, 14 after, one key gone.

### Verification

**Cross-checked against an independent path.** A harness built on `costSync` (node9's own LiteLLM-backed module), counting `tool_use` blocks the way `scan-upload-history` does, arrives at **`$34.96`** — the same figure to the cent, from code sharing nothing with this.

4264 tests, typecheck, lint, format clean. 13 unit cases from an adversarial matrix written before the code existed, including a generated-input invariant that dollars never appear without priced iterations behind them. Mutants killed on every commit.

### Merge note

The extractor hash conflicted — `#277` and this branch both touched `canonical.ts`. Resolved by recomputing from the merged content rather than picking a side, since either stale hash would have failed its own CI check.

### Known, out of scope

`tui/dashboard/views/report/index.tsx:329` still uses `count × constant` with no threshold — it prices the first, legitimate call as waste, and shows `$8.70` where the truth is `$34.96`. It has no access to `perSession`.

13.8% of spend is still never scanned: the walkers are flat `readdirSync` and miss `subagents/` and `wf_*`. Measured `$1,925` over 30 days, zero overlap across 52,870 rows. Mapped in `doc/roadmap/active/cost-accuracy-and-plans.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)