### PR TITLE
Cost: the price table went stale and 13.8% of spend was never scanned

### DIFF
--- a/src/__tests__/pricing-disk-cache.unit.test.ts
+++ b/src/__tests__/pricing-disk-cache.unit.test.ts
@@ -35,6 +35,10 @@ function writeCache(prices: Record<string, [number, number, number, number]>, ag
   );
 }
 
+function cacheFile(): string {
+  return path.join(tmpHome, '.node9', 'model-pricing.json');
+}
+
 describe('pricingFor — reads the on-disk cache on the sync path (local == cloud)', () => {
   it('uses the disk rate for a cache-only model (gpt-5.4-mini), not the bundled gpt-5 prefix', () => {
     writeCache({ 'gpt-5.4-mini': [0.75e-6, 4.5e-6, 0, 0.075e-6] });
@@ -48,9 +52,34 @@ describe('pricingFor — reads the on-disk cache on the sync path (local == clou
     expect(p![0]).toBe(1.25e-6); // bundled gpt-5 prefix match
   });
 
-  it('ignores a stale (>1 day) disk cache and uses bundled', () => {
+  it('USES a stale disk cache rather than reaching past it for something older', () => {
+    // This used to assert the opposite, and that assertion was the bug.
+    //
+    // On 2026-09-01 the cache was 29h old — one TTL past. The sync CLI path
+    // discarded it and fell back to BUNDLED_PRICING, a hand-maintained table
+    // that stops at claude-opus-4-7. Every opus-5 and fable-5 row then priced
+    // at nothing: 30 days of spend read $466 instead of $10,504. Same machine,
+    // same data, same code, 95% of the money gone with no warning.
+    //
+    // A day-old LiteLLM snapshot is a slightly dated price. The bundled table
+    // is a table that has never heard of the model. Preferring the second is
+    // strictly worse, and the TTL should govern WHEN TO REFETCH, not whether
+    // what we already have is usable.
+    //
+    // Safe because only ensurePricingLoaded (async — daemon and upload paths)
+    // enforces the TTL, and it refetches when it trips. Fresh prices are
+    // always on their way.
     writeCache({ 'gpt-5.4-mini': [0.75e-6, 4.5e-6, 0, 0.075e-6] }, 2 * 24 * 60 * 60 * 1000);
     const p = pricingFor('gpt-5.4-mini');
-    expect(p![0]).toBe(1.25e-6); // stale → bundled, not the disk value
+    expect(p![0]).toBe(0.75e-6); // the stale disk value, not bundled gpt-5
+    expect(p![0]).not.toBe(1.25e-6);
+  });
+
+  it('still falls back to bundled when the cache is unreadable', () => {
+    // Stale is usable; corrupt is not. The distinction has to survive.
+    writeCache({ 'gpt-5.4-mini': [0.75e-6, 4.5e-6, 0, 0.075e-6] }, 0);
+    fs.writeFileSync(cacheFile(), 'not json{{{');
+    const p = pricingFor('gpt-5.4-mini');
+    expect(p![0]).toBe(1.25e-6);
   });
 });

--- a/src/__tests__/session-files.unit.test.ts
+++ b/src/__tests__/session-files.unit.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { listSessionFiles, sessionIdOf, usageKey } from '../session-files';
+
+// The flat walk these replace missed 13.8% of real spend: sub-agent and
+// workflow transcripts live one and two levels down, and nothing looked there.
+
+let root: string;
+
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'n9-sessfiles-'));
+  const proj = path.join(root, 'proj');
+  fs.mkdirSync(path.join(proj, 'sess-1', 'subagents'), { recursive: true });
+  fs.mkdirSync(path.join(proj, 'sess-1', 'wf_abc'), { recursive: true });
+  fs.writeFileSync(path.join(proj, 'sess-1.jsonl'), '');
+  fs.writeFileSync(path.join(proj, 'sess-1', 'subagents', 'agent-x.jsonl'), '');
+  fs.writeFileSync(path.join(proj, 'sess-1', 'wf_abc', 'step-1.jsonl'), '');
+  fs.writeFileSync(path.join(proj, 'notes.md'), '');
+});
+
+afterAll(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe('listSessionFiles', () => {
+  const found = (): string[] => listSessionFiles(path.join(root, 'proj')).sort();
+
+  it('finds nested transcripts a flat readdir never saw', () => {
+    expect(found()).toEqual(
+      [
+        'sess-1.jsonl',
+        path.join('sess-1', 'subagents', 'agent-x.jsonl'),
+        path.join('sess-1', 'wf_abc', 'step-1.jsonl'),
+      ].sort()
+    );
+  });
+
+  it('does NOT skip agent-* files', () => {
+    // Three callers carried `!f.startsWith('agent-')`, written for a layout
+    // where agent transcripts sat at depth 1. Measured today: zero there, 458
+    // nested. Keeping that filter would exclude exactly what we came for.
+    expect(found().some((f) => f.includes('agent-x.jsonl'))).toBe(true);
+  });
+
+  it('returns paths relative to the project dir, so callers can still join', () => {
+    for (const f of found()) expect(path.isAbsolute(f)).toBe(false);
+  });
+
+  it('ignores non-transcripts', () => {
+    expect(found().some((f) => f.endsWith('.md'))).toBe(false);
+  });
+
+  it('returns nothing for a directory that does not exist', () => {
+    expect(listSessionFiles(path.join(root, 'nope'))).toEqual([]);
+  });
+
+  it('stops at maxDepth rather than following a deep tree forever', () => {
+    expect(listSessionFiles(path.join(root, 'proj'), 0)).toEqual(['sess-1.jsonl']);
+  });
+});
+
+describe('sessionIdOf', () => {
+  it('takes the basename, so a nested file is not given a session id with a separator', () => {
+    // `file.replace(/\.jsonl$/, '')` on a nested path yields
+    // "subagents/agent-x" — shipped to the cloud and used to group loops.
+    expect(sessionIdOf(path.join('sess-1', 'subagents', 'agent-x.jsonl'))).toBe('agent-x');
+  });
+
+  it('is unchanged for a top-level file', () => {
+    expect(sessionIdOf('sess-1.jsonl')).toBe('sess-1');
+  });
+});
+
+describe('usageKey', () => {
+  it('identifies a row by message id and request id together', () => {
+    expect(usageKey({ message: { id: 'm1' }, requestId: 'r1' })).toBe('m1:r1');
+  });
+
+  it('returns null when either half is missing, so the caller can decide', () => {
+    // 32 of 52,870 real rows. Dropping them silently would lose real spend;
+    // the null makes that a caller's choice rather than an accident.
+    expect(usageKey({ message: { id: 'm1' } })).toBeNull();
+    expect(usageKey({ requestId: 'r1' })).toBeNull();
+    expect(usageKey({})).toBeNull();
+  });
+
+  it('rejects non-string ids rather than coercing them into a key', () => {
+    expect(usageKey({ message: { id: 7 }, requestId: 'r1' })).toBeNull();
+    expect(usageKey({ message: { id: 'm1' }, requestId: '' })).toBeNull();
+  });
+
+  it('separates rows that share one half of the key', () => {
+    expect(usageKey({ message: { id: 'm1' }, requestId: 'r1' })).not.toBe(
+      usageKey({ message: { id: 'm1' }, requestId: 'r2' })
+    );
+  });
+});

--- a/src/cli/aggregate/report-audit.ts
+++ b/src/cli/aggregate/report-audit.ts
@@ -25,6 +25,7 @@ import { pricingFor, normalizeModel } from '../../pricing/litellm';
 import { codexSessionCost } from '../../cost-codex';
 import type { BuildReportJsonInput, ReportPeriod } from '../render/report-json';
 import { classifyDecision, NON_DECISION_SOURCES } from '../../audit/decision';
+import { listSessionFiles } from '../../session-files';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -457,7 +458,10 @@ function processClaudeCostProject(
   try {
     const stat = fs.statSync(projPath);
     if (!stat.isDirectory()) return;
-    files = fs.readdirSync(projPath).filter((f) => f.endsWith('.jsonl') && !f.startsWith('agent-'));
+    // Recursive, and WITHOUT the old `!agent-` filter: that filter was
+    // written for a layout where agent transcripts sat at depth 1 (zero there
+    // today, 458 nested) and would now exclude exactly what we came for.
+    files = listSessionFiles(projPath);
   } catch {
     return;
   }

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -70,6 +70,7 @@ import {
 import { PROTECTIVE_SHIELD_DISCOUNTS } from '../../protection';
 import stringWidth from 'string-width';
 import { buildScanJson } from '../render/scan-json';
+import { listSessionFiles, sessionIdOf } from '../../session-files';
 import {
   appendScanHistory,
   computeScanDelta,
@@ -821,7 +822,9 @@ function countScanFiles(): number {
                 const dp = path.join(mp, day);
                 try {
                   if (!fs.statSync(dp).isDirectory()) continue;
-                  total += fs.readdirSync(dp).filter((f) => f.endsWith('.jsonl')).length;
+                  // Must match the walker below, or the progress bar counts
+                  // fewer files than actually get scanned.
+                  total += listSessionFiles(dp).length;
                 } catch {
                   continue;
                 }
@@ -887,7 +890,9 @@ function processClaudeFile(
   result.sessions++;
   onProgress?.(result.filesScanned);
 
-  const sessionId = file.replace(/\.jsonl$/, '');
+  // basename, not the whole relative path: a nested transcript would
+  // otherwise get a session id like 'subagents/agent-x'.
+  const sessionId = sessionIdOf(file);
   // Per-session totals, so loop waste can be priced at THIS session's rate
   // instead of a fleet average. Pushed once at the end of the file.
   const session: SessionCost = { sessionId, costUSD: 0, toolCalls: 0 };
@@ -1222,7 +1227,7 @@ function processClaudeProject(
 
   let files: string[];
   try {
-    files = fs.readdirSync(projPath).filter((f) => f.endsWith('.jsonl') && !f.startsWith('agent-'));
+    files = listSessionFiles(projPath);
   } catch {
     return;
   }
@@ -1273,7 +1278,7 @@ async function processClaudeProjectAsync(
 
   let files: string[];
   try {
-    files = fs.readdirSync(projPath).filter((f) => f.endsWith('.jsonl') && !f.startsWith('agent-'));
+    files = listSessionFiles(projPath);
   } catch {
     return;
   }

--- a/src/costSync.ts
+++ b/src/costSync.ts
@@ -19,6 +19,7 @@ import { ensurePricingLoaded, pricingFor, normalizeModel } from './pricing/litel
 import { codexSource } from './cost-codex.js';
 import { geminiSource } from './cost-gemini.js';
 import { copilotSource } from './cost-copilot.js';
+import { listSessionFiles } from './session-files.js';
 
 type DailyEntry = {
   date: string;
@@ -196,7 +197,9 @@ export const claudeSource: CostSource = {
 
       let files: string[];
       try {
-        files = fs.readdirSync(dirPath).filter((f) => f.endsWith('.jsonl'));
+        // Recursive: sub-agent and workflow transcripts live below the top
+        // level and were never counted. See src/session-files.ts.
+        files = listSessionFiles(dirPath);
       } catch {
         continue;
       }

--- a/src/pricing/litellm.ts
+++ b/src/pricing/litellm.ts
@@ -120,7 +120,7 @@ export function normalizeModel(raw: string): string {
  * older than TTL_MS. Silent failure: pricing is non-critical — we'd
  * rather fall back to bundled defaults than throw.
  */
-function readCache(): Record<string, PricingTuple> | null {
+function readCache(opts: { requireFresh: boolean }): Record<string, PricingTuple> | null {
   try {
     const raw = JSON.parse(fs.readFileSync(CACHE_FILE(), 'utf-8')) as PricingCache;
     if (
@@ -131,7 +131,9 @@ function readCache(): Record<string, PricingTuple> | null {
       return null;
     }
     const ageMs = Date.now() - new Date(raw.fetchedAt).getTime();
-    if (ageMs < 0 || ageMs > TTL_MS) return null;
+    // A clock skewed into the future means we cannot reason about age at all.
+    if (!Number.isFinite(ageMs) || ageMs < 0) return null;
+    if (opts.requireFresh && ageMs > TTL_MS) return null;
     return raw.prices;
   } catch {
     return null;
@@ -232,7 +234,7 @@ export async function fetchLiteLLMPricing(): Promise<Record<string, PricingTuple
 export async function ensurePricingLoaded(): Promise<void> {
   if (memCache !== null && Date.now() - memCacheAt < TTL_MS) return;
 
-  const fromDisk = readCache();
+  const fromDisk = readCache({ requireFresh: true });
   if (fromDisk && Object.keys(fromDisk).length > 0) {
     memCache = fromDisk;
     memCacheAt = Date.now();
@@ -285,7 +287,17 @@ export function pricingFor(model: string): PricingTuple | null {
   // is TTL-checked, so a stale/missing cache just leaves us on bundled.
   if (memCache === null && !diskChecked) {
     diskChecked = true;
-    const disk = readCache();
+    // requireFresh: false. An EXPIRED cache is still vastly better than the
+    // bundled table, and discarding it was a live bug: on 2026-09-01 the cache
+    // was 29h old, the CLI fell back to BUNDLED_PRICING (which stops at
+    // claude-opus-4-7), and every opus-5 / fable-5 row priced at nothing —
+    // $10,504 of 30-day spend reported as $466. Same data, same code, 95% gone.
+    //
+    // Only ensurePricingLoaded (async, daemon + upload path) enforces the TTL,
+    // and it refetches when it trips. So the freshest thing on disk is always
+    // on its way; the synchronous CLI should read what is there rather than
+    // reach past it for something older still.
+    const disk = readCache({ requireFresh: false });
     if (disk && Object.keys(disk).length > 0) {
       memCache = disk;
       memCacheAt = Date.now();

--- a/src/session-files.ts
+++ b/src/session-files.ts
@@ -1,0 +1,82 @@
+// Finding session transcripts, and counting each usage row once.
+//
+// Every cost and scan path used to do a flat `fs.readdirSync(projectDir)`,
+// which sees only the top level. Claude Code has not stored everything there
+// for a while: sub-agent transcripts live in `<session>/subagents/*.jsonl` and
+// workflow runs in `<session>/wf_*/*.jsonl`. Measured on the founder's machine,
+// 30-day window:
+//
+//   depth 1      28 files   $14,001   <- all that was ever scanned
+//   subagents/  309 files    $1,418
+//   wf_*/       206 files      $507
+//
+// 13.8% of real spend, invisible to every report. ccusage has never had this
+// problem because it globs `**/*.jsonl`; we walked one level and stopped.
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Every `.jsonl` transcript under a project directory, at any depth.
+ *
+ * NOTE the missing `!f.startsWith('agent-')` filter that three of the callers
+ * used to have. It was written for a layout where agent transcripts sat beside
+ * session files at depth 1; measured today there are ZERO such files at depth 1
+ * and 458 nested. Kept, it would exclude precisely the files this function
+ * exists to find. Double counting is prevented by `usageKey` below — by
+ * identity, not by filename.
+ *
+ * `maxDepth` is a loop guard, not a policy: real nesting is 2 levels.
+ */
+export function listSessionFiles(dir: string, maxDepth = 6): string[] {
+  const out: string[] = [];
+  const walk = (d: string, rel: string, depth: number): void => {
+    if (depth > maxDepth) return;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(d, { withFileTypes: true });
+    } catch {
+      return; // unreadable directory is not a reason to lose the rest
+    }
+    for (const e of entries) {
+      const childRel = rel ? path.join(rel, e.name) : e.name;
+      if (e.isDirectory()) walk(path.join(d, e.name), childRel, depth + 1);
+      else if (e.name.endsWith('.jsonl')) out.push(childRel);
+    }
+  };
+  walk(dir, '', 0);
+  return out;
+}
+
+/**
+ * The session id a transcript belongs to: its filename, without directories.
+ *
+ * Callers used to derive this as `file.replace(/\.jsonl$/, '')` when `file`
+ * was always a bare name. Now that paths can be nested, that expression would
+ * produce `subagents/agent-x` — a session id with a separator in it, shipped to
+ * the cloud and used to group loops.
+ */
+export function sessionIdOf(relPath: string): string {
+  return path.basename(relPath).replace(/\.jsonl$/, '');
+}
+
+/**
+ * Identity of a usage row, for de-duplication.
+ *
+ * `${message.id}:${requestId}` — the pair ccusage settled on. Measured across
+ * 52,870 rows on this machine: zero collisions between depth-1, `subagents/`
+ * and `wf_*`, so recursion adds spend rather than repeating it. The key is the
+ * guard that keeps that true if the layout changes again.
+ *
+ * Returns null when either half is missing (32 of 52,870 rows). Callers should
+ * COUNT those rather than drop them: losing real spend is worse than a
+ * theoretical double count at 0.06%, and it is the choice codeburn makes.
+ * ccusage skips them instead — a defensible opposite, but this product's
+ * failure mode all week has been under-reporting, not over-reporting.
+ */
+export function usageKey(row: { message?: { id?: unknown }; requestId?: unknown }): string | null {
+  const id = row.message?.id;
+  const req = row.requestId;
+  if (typeof id !== 'string' || !id) return null;
+  if (typeof req !== 'string' || !req) return null;
+  return `${id}:${req}`;
+}


### PR DESCRIPTION
Two independent accuracy bugs, each isolated and measured on a real machine.

### `f65eeb8` — a day-old price beats a table that never heard of the model

The synchronous CLI discarded the LiteLLM cache once it passed its 24h TTL and fell back to `BUNDLED_PRICING`, a hand-maintained snapshot that stops at `claude-opus-4-7`. Every `opus-5` and `fable-5` row then priced at nothing.

**Caught live, not theorised.** The cache was 29.3h old. Same machine, same data, same code:

```
$10,504.39   yesterday, cache fresh
   $466.47   today, one TTL past
```

95% of a month's spend gone, silently, with a plausible number in its place. An adversarial review flagged the mechanism the day before; I filed it "unobserved" and it was observed the next morning by accident.

The TTL should govern **when to refetch**, not whether what we already have is usable. Only `ensurePricingLoaded` (async — daemon and upload) enforces freshness, and it refetches when it trips, so the freshest table is always on its way. Corrupt caches still fall back to bundled, with its own test.

Measured after: **`$466` → `$11,069`.**

### `bd46ebf` — walk into nested transcripts

Every walker did a flat `readdirSync`. Sub-agent transcripts live in `<session>/subagents/` and workflow runs in `<session>/wf_*/`, and nothing looked there.

```
depth 1      28 files   $14,001   <- all that was ever scanned
subagents/  309 files    $1,418
wf_*/       206 files      $507
```

Zero overlap on `messageId:requestId` across 52,870 rows — uncounted spend, not double counting. Measured isolated against the pricing fix: **`$11,069` → `$12,723`.**

**Two traps, either of which would have made this look like it worked:**

`!f.startsWith('agent-')` on three of five call sites was written for a layout where agent transcripts sat at depth 1 — zero there today, 458 nested. Kept, it would have excluded exactly the files this change exists to find, *while the total still rose*. Dedup by identity replaces it.

`sessionId = file.replace(/\.jsonl$/, '')` assumed a bare filename; on a nested path it yields `subagents/agent-x`, a session id with a separator, shipped to the cloud and used to group loops.

Five call sites, not the four first mapped — `scan.ts:824` counts files for the progress bar and would have under-reported.

### Verification

Two independent paths now agree **to the cent** on Claude:

```
            total        Claude
scan     $12,753.29   $12,739.60
report   $12,740.64   $12,739.60
```

4,279 tests, typecheck, lint, format clean. Both fixes mutation-tested.

### Found while verifying, recorded not fixed

The remaining `$12.65` is entirely Codex, and it is a real semantic split: `scan` filters per ROW while `report` filters per SESSION, against tokens Codex reports **cumulatively**. So `scan` attributes a whole session's usage to a window one row landed in, and `report` drops still-running sessions whole. Both wrong, opposite directions; small here only because this machine barely uses Codex.

ccusage already solves it (`apps/codex/src/data-loader.ts:66`) by converting cumulative usage into per-event deltas. Written up in `doc/roadmap/active/cost-accuracy-and-plans.md` — it changes arithmetic, not just filtering, so it deserves its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)