### PR TITLE
verify: gate must go RED on an injectable workflow (do not merge)

### DIFF
--- a/.github/workflows/zz-verify-injectable.yml
+++ b/.github/workflows/zz-verify-injectable.yml
@@ -1,0 +1,24 @@
+# ⚠️  INTENTIONALLY INSECURE — a fixture that demonstrates what node9 detects.
+#     This is the pull_request_target injection pattern. DO NOT COPY.
+#     It is DISABLED in this repo so it never runs.
+name: vulnerable example (do not copy)
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}   # untrusted head → workspace root
+      - uses: anthropics/claude-code-action@v1
+        with:
+          # ⚠️ removes claude-code-action's default write-access gate → ANY user can trigger it
+          allowed_non_write_users: "*"
+          claude_args: '--allowedTools "Bash"'
+          prompt: 'Review PR ${{ github.event.pull_request.number }}'


### PR DESCRIPTION
Known-true row for the dogfood gate: adds the demo repo's deliberately injectable workflow (pull_request_target + untrusted head + claude-code-action with allowed_non_write_users: * + Bash). Expected: the **scan** check FAILS under fail-on: high. Will be closed unmerged once observed.