### PR TITLE
release: rename the Marketplace action, fix an ambient-dependent test

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ What it checks:
     fail-on: high # or 'never' to just comment
 ```
 
-Marketplace: **[node9 Agent Security Check](https://github.com/marketplace/actions/node9-agent-security-check)**
+Marketplace: **[node9 Agent Security](https://github.com/marketplace/actions/node9-agent-security)**
 
 ## Live monitoring
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ What it checks:
 
 ```yaml
 # .github/workflows/agent-security.yml
-- uses: node9-ai/agent-security-action@v1
+- uses: node9-ai/node9-proxy@v2
   with:
     fail-on: high # or 'never' to just comment
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'node9 Agent Security Check'
+name: 'node9 Agent Security'
 description: 'Scan a repo for agent-security risks (injectable CI workflows, unsafe agent configs, MCP) and comment on the PR.'
 author: 'node9'
 branding:

--- a/src/__tests__/hud.spec.ts
+++ b/src/__tests__/hud.spec.ts
@@ -158,14 +158,20 @@ describe('HUD render — offline indicator', () => {
 // ── Environment line (countConfigs + renderEnvironmentLine) ──────────────────
 
 describe('countConfigs', () => {
-  it('returns zeros when cwd has no config files', async () => {
+  it('a cwd with no config files adds nothing over user scope', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'node9-hud-test-'));
     try {
       const { countConfigs } = await import('../cli/hud.js');
+      // countConfigs always counts USER scope (~/.claude) on top of the cwd, and
+      // os.homedir() is not injectable — so absolute zeros are not the contract
+      // and asserting them made this test pass or fail on whether the developer
+      // happens to have ~/.claude/CLAUDE.md. Compare against the no-cwd baseline
+      // instead: an empty project directory must contribute exactly nothing.
+      const baseline = countConfigs(undefined);
       const counts = countConfigs(tmp);
-      // hooksCount may be > 0 from the real user ~/.claude/settings.json
-      expect(counts.claudeMdCount).toBe(0);
-      expect(counts.rulesCount).toBe(0);
+      expect(counts.claudeMdCount).toBe(baseline.claudeMdCount);
+      expect(counts.rulesCount).toBe(baseline.rulesCount);
+      expect(counts.mcpCount).toBe(baseline.mcpCount);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
Three commits since v2.8.0. The `fix(action)` cuts a **patch** (v2.8.1).

**`fix(action)`** — renames the action to **"node9 Agent Security"**. Publishing the
Marketplace listing from this repo returns HTTP 500, reproducibly, before and after
archiving `agent-security-action`. Documented cause: the same `name` was previously
listed from another repo in the org, GitHub keeps a stale record, and the uniqueness
check fails without a usable error ([113415](https://github.com/orgs/community/discussions/113415)).
Renaming is the confirmed workaround ([148885](https://github.com/orgs/community/discussions/148885)).
The Marketplace form reads `action.yml` from the release tag, so this needs a release
to take effect. The README's Marketplace link moves off the now-404 slug in the same commit.

**`test(hud)`** — `countConfigs()` counts user scope (`~/.claude`) on top of the cwd and
`os.homedir()` is not injectable, but the test asserted `claudeMdCount === 0` for an empty
tmp directory. It was green only while the machine had no `~/.claude/CLAUDE.md`; creating
that file turned it red with nothing in the repo changed, and it stays green on CI because
CI has no such file. Now compared against the no-cwd baseline. Sibling tests still cover
the cwd-counting path.

**`docs(readme)`** — the `@v2` snippet from the previous release.

Behaviour is unchanged. `uses: node9-ai/node9-proxy@v2` is unaffected; `v2` moves to v2.8.1
when this releases.