### PR TITLE
release: blocks tell the agent to tell the user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,11 @@ jobs:
         # flatted via eslint) are in tools that never ship in the production bundle and are
         # not exploitable at runtime. --audit-level=moderate: Node9 sits on the critical path
         # of every agent tool call, so moderate-severity prod vulns (e.g. regex DoS) matter.
-        run: npm audit --omit=dev --audit-level=moderate
+        # Three outcomes, not two: clean / vulnerable / DID-NOT-RUN. npm's audit
+        # endpoint going away must not read as a security failure and block main —
+        # and must not read as a pass either. See scripts/audit-deps.sh.
+        shell: bash
+        run: scripts/audit-deps.sh --omit=dev --audit-level=moderate
 
       - name: Audit engine dependencies
         # The engine ships as @node9/policy-engine — used by both the local proxy
@@ -49,7 +53,8 @@ jobs:
         # affects every consumer. Audit the engine workspace separately because
         # `npm audit` at the root only walks the root package's deps. Same
         # threshold (moderate) as the proxy audit above.
-        run: npm --workspace @node9/policy-engine audit --omit=dev --audit-level=moderate
+        shell: bash
+        run: scripts/audit-deps.sh --workspace @node9/policy-engine --omit=dev --audit-level=moderate
 
       - name: Extractor-version hash check
         # Verify CANONICAL_EXTRACTOR_HASH in the engine matches the hash of

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,56 @@
+# OpenSSF Scorecard — QUIET MODE.
+#
+# `publish_results: false` on purpose. Scorecard grades repository practice
+# (branch protection, pinned actions, review coverage, update tooling) and
+# publishing sends that grade to a public API that anyone can query and that
+# backs the public badge. Estimated before writing this: node9-proxy scores
+# somewhere near 5-6.5, with the losses concentrated in config files we have
+# not written yet — no dependabot, 1 of 14 actions pinned by SHA, no top-level
+# `permissions:` in ci.yml, no SAST workflow. Publishing that number before
+# fixing those is a durable public claim about a security product, made from a
+# starting line rather than a finish line.
+#
+# So: run it, read the SARIF from the build artifact, close the cheap gaps,
+# and only then flip publish_results to true and add the badge. Flipping it is
+# a one-word change; un-publishing a grade is not.
+#
+# Nothing here uploads to code scanning. A practice grade filed as dismissible
+# security alerts produces a queue that no code change can close.
+name: OpenSSF Scorecard
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * 1' # Mondays 05:00 UTC
+  branch_protection_rule: # re-grade when protection changes — the check it moves most
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # id-token is only needed by publish_results (OIDC proof of authenticity).
+      # It is omitted while publishing is off, and must be added back with it.
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: false
+
+      # The grade lives here and nowhere else while publishing is off. Download
+      # it from the run's Artifacts, or read the per-check lines in the job log.
+      - name: Upload Scorecard results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 30

--- a/scripts/audit-deps.sh
+++ b/scripts/audit-deps.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Dependency audit with THREE outcomes instead of two.
+#
+# `npm audit` exits non-zero both when it FINDS a vulnerability and when it
+# could not ASK (registry outage, endpoint retired, or a hang). CI used to
+# treat those identically, so an npm-side incident read as a security failure
+# and blocked every merge to main — measured 2026-09-04: 503 on ubuntu, 400 on
+# windows, and a 90s hang locally, all on an unchanged lockfile.
+#
+#   clean        -> exit 0
+#   vulnerable   -> exit 1   (the gate; unchanged behaviour)
+#   unavailable  -> exit 0 + ::warning:: + a line in the step summary that says
+#                   the audit DID NOT RUN. "Could not check" is not "checked".
+#   anything else-> exit non-zero (fail closed; never mistaken for clean)
+#
+# Usage: scripts/audit-deps.sh [npm audit args...]
+# Env:   AUDIT_TIMEOUT (seconds, default 120)
+#        AUDIT_STUB_RC / AUDIT_STUB_STDOUT / AUDIT_STUB_STDERR — test seams that
+#        bypass npm so every branch can be exercised without the network.
+set -uo pipefail
+
+label="npm audit ${*:-}"
+timeout_s="${AUDIT_TIMEOUT:-120}"
+
+if [[ -n "${AUDIT_STUB_RC:-}" ]]; then
+  rc="$AUDIT_STUB_RC"; out="${AUDIT_STUB_STDOUT:-}"; err="${AUDIT_STUB_STDERR:-}"
+else
+  errfile="$(mktemp)"
+  out="$(timeout "$timeout_s" npm audit --json "$@" 2>"$errfile")"; rc=$?
+  err="$(cat "$errfile")"; rm -f "$errfile"
+fi
+
+summary() { # $1 = markdown line
+  echo "$1"
+  [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] && echo "$1" >> "$GITHUB_STEP_SUMMARY" || true
+}
+
+# Did npm produce a real audit result? Only then is exit 1 a finding.
+has_report=0
+if [[ -n "$out" ]] && node -e '
+  let d; try { d = JSON.parse(require("fs").readFileSync(0, "utf8")); } catch { process.exit(1); }
+  process.exit(d && d.metadata && d.metadata.vulnerabilities ? 0 : 1);
+' <<<"$out"; then has_report=1; fi
+
+if (( rc == 0 )) && (( has_report )); then
+  summary "✅ ${label}: no vulnerabilities at or above the threshold."
+  exit 0
+fi
+
+if (( rc == 124 )); then
+  summary "⚠️ ${label}: **DID NOT RUN** — npm did not answer within ${timeout_s}s. Dependencies were NOT checked on this run."
+  echo "::warning title=Dependency audit did not run::npm audit hung for ${timeout_s}s; skipped, not passed."
+  exit 0
+fi
+
+if [[ "$err" == *"audit endpoint returned an error"* ]] || { [[ -n "$out" ]] && (( has_report == 0 )) && node -e '
+  let d; try { d = JSON.parse(require("fs").readFileSync(0, "utf8")); } catch { process.exit(1); }
+  process.exit(d && d.error ? 0 : 1);
+' <<<"$out"; }; then
+  summary "⚠️ ${label}: **DID NOT RUN** — the npm audit endpoint returned an error. Dependencies were NOT checked on this run."
+  echo "::warning title=Dependency audit did not run::npm audit endpoint unavailable; skipped, not passed."
+  printf '%s\n' "$err" | tail -n 3 >&2
+  exit 0
+fi
+
+if (( rc == 1 )) && (( has_report )); then
+  node -e '
+    const d = JSON.parse(require("fs").readFileSync(0, "utf8"));
+    const v = d.metadata.vulnerabilities || {};
+    const parts = Object.entries(v).filter(([, n]) => n).map(([k, n]) => `${n} ${k}`);
+    console.log(`❌ vulnerabilities at or above the threshold: ${parts.join(", ") || "see report"}`);
+    for (const [name, x] of Object.entries(d.vulnerabilities || {}).slice(0, 15)) console.log(`   - ${name}: ${x.severity}${x.fixAvailable ? "  (fix available)" : ""}`);
+  ' <<<"$out"
+  summary "❌ ${label}: vulnerabilities found (see job log)."
+  exit 1
+fi
+
+# Unknown shape: fail closed and show everything.
+summary "❌ ${label}: unexpected result (exit ${rc}); failing closed."
+printf 'stdout:\n%s\nstderr:\n%s\n' "$out" "$err" | head -n 40 >&2
+exit $(( rc == 0 ? 1 : rc ))

--- a/src/__tests__/audit-deps.integration.test.ts
+++ b/src/__tests__/audit-deps.integration.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+// scripts/audit-deps.sh turns `npm audit` into three outcomes. The stub seams
+// let each branch run without npm or the network, and the "unavailable" branch
+// is also exercised for real below by pointing npm at a dead registry.
+const script = path.resolve(process.cwd(), 'scripts/audit-deps.sh');
+const run = (env: Record<string, string>, args: string[] = []) =>
+  spawnSync('bash', [script, ...args], { encoding: 'utf8', env: { ...process.env, ...env } });
+
+const report = (vulns: Record<string, number>, list: Record<string, unknown> = {}) =>
+  JSON.stringify({ metadata: { vulnerabilities: vulns }, vulnerabilities: list });
+
+// Git Bash exists on windows-latest, but this test pins CI behaviour on the
+// runners that hit the outage; skip where `bash` may be a different shell.
+describe.skipIf(process.platform === 'win32')('scripts/audit-deps.sh', () => {
+  it('clean report → exit 0', () => {
+    const r = run({ AUDIT_STUB_RC: '0', AUDIT_STUB_STDOUT: report({ moderate: 0, high: 0 }) });
+    expect(r.error).toBeUndefined();
+    expect(r.status, r.stdout + r.stderr).toBe(0);
+    expect(r.stdout).toMatch(/no vulnerabilities/);
+  });
+
+  it('vulnerabilities found → exit 1 (the gate is unchanged)', () => {
+    const r = run({
+      AUDIT_STUB_RC: '1',
+      AUDIT_STUB_STDOUT: report(
+        { moderate: 1, high: 2 },
+        { lodash: { severity: 'high', fixAvailable: true } }
+      ),
+    });
+    expect(r.status, r.stdout + r.stderr).toBe(1);
+    expect(r.stdout).toMatch(/2 high/);
+    expect(r.stdout).toMatch(/lodash: high/);
+  });
+
+  it('endpoint error → exit 0 with a DID NOT RUN warning, never a pass', () => {
+    const r = run({
+      AUDIT_STUB_RC: '1',
+      AUDIT_STUB_STDOUT: '',
+      AUDIT_STUB_STDERR:
+        'npm warn audit 503 Service Unavailable\nnpm error audit endpoint returned an error',
+    });
+    expect(r.status, r.stdout + r.stderr).toBe(0);
+    expect(r.stdout).toMatch(/DID NOT RUN/);
+    expect(r.stdout).toMatch(/::warning/);
+    expect(r.stdout).not.toMatch(/no vulnerabilities/);
+  });
+
+  it('hang (timeout exit 124) → exit 0 with a DID NOT RUN warning', () => {
+    const r = run({ AUDIT_STUB_RC: '124', AUDIT_STUB_STDOUT: '', AUDIT_STUB_STDERR: '' });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/DID NOT RUN/);
+  });
+
+  it('unknown shape → fails closed', () => {
+    const r = run({ AUDIT_STUB_RC: '2', AUDIT_STUB_STDOUT: 'garbage', AUDIT_STUB_STDERR: '' });
+    expect(r.status).not.toBe(0);
+    expect(r.stdout).toMatch(/failing closed/);
+  });
+
+  it('exit 0 without a real report is NOT treated as clean', () => {
+    const r = run({ AUDIT_STUB_RC: '0', AUDIT_STUB_STDOUT: '', AUDIT_STUB_STDERR: '' });
+    expect(r.status).not.toBe(0);
+  });
+
+  it('REAL npm against a dead registry → DID NOT RUN, not a failure (no stubs)', () => {
+    const r = run({ npm_config_registry: 'http://127.0.0.1:9/', AUDIT_TIMEOUT: '60' }, [
+      '--omit=dev',
+    ]);
+    expect(r.error).toBeUndefined();
+    expect(r.status, r.stdout + r.stderr).toBe(0);
+    expect(r.stdout).toMatch(/DID NOT RUN/);
+  });
+});

--- a/src/__tests__/negotiation.unit.test.ts
+++ b/src/__tests__/negotiation.unit.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { buildNegotiationMessage } from '../policy/negotiation';
+
+// Every deny message node9 hands back to an agent must tell the agent to
+// surface the block to the human. Measured 2026-09-03 on the founder's
+// machine: a project-jail block on a `.env` read reached the agent as a bare
+// "do not retry / find an alternative" instruction, the agent quietly pivoted,
+// and the human never learned node9 had acted. The better the rule, the less
+// visible the product. This is a UX layer, not a security control: a hostile
+// agent can ignore it; audit.log is what always knows.
+const TELLS_THE_USER = /(tell|inform) the user|acknowledge the block to the user/i;
+
+// One label per branch of buildNegotiationMessage, in source order. The
+// strings mirror the `label.includes(...)` checks, so a renamed branch fails
+// here rather than silently falling through to the generic fallback.
+const BRANCHES: Array<[name: string, label: string]> = [
+  ['dlp (secret in arguments)', 'DLP: secret detected in args'],
+  ['sql delete without where', 'SQL safety: DELETE without WHERE'],
+  ['sql update without where', 'SQL safety: UPDATE without WHERE'],
+  ['dangerous word', 'dangerous word: "mkfs"'],
+  ['path blocked / sandbox', 'path blocked: outside sandbox'],
+  ['inline execution', 'inline execution via bash -c'],
+  ['strict mode', 'strict mode'],
+  ['policy rule default block', 'rule "git push --force" default block'],
+  ['generic fallback', 'Something node9 has no template for'],
+];
+
+describe('buildNegotiationMessage tells the agent to inform the user', () => {
+  for (const [name, label] of BRANCHES) {
+    it(name, () => {
+      const msg = buildNegotiationMessage(label, false);
+      expect(msg, `branch "${name}" never asks the agent to tell the user:\n${msg}`).toMatch(
+        TELLS_THE_USER
+      );
+    });
+  }
+
+  it('human decision', () => {
+    expect(buildNegotiationMessage('user decision', true, 'not now')).toMatch(TELLS_THE_USER);
+  });
+
+  it('generic fallback with a recovery command', () => {
+    expect(
+      buildNegotiationMessage('egress: host not trusted', false, undefined, 'node9 trust x')
+    ).toMatch(TELLS_THE_USER);
+  });
+
+  it('the dlp branch never asks the agent to repeat the credential', () => {
+    const msg = buildNegotiationMessage('DLP: secret detected', false);
+    expect(msg).not.toMatch(/quote|repeat|show the (key|token|secret|credential)/i);
+  });
+});

--- a/src/policy/negotiation.ts
+++ b/src/policy/negotiation.ts
@@ -31,19 +31,22 @@ REQUIRED ACTIONS:
 1. Remove the hardcoded credential from your command or code.
 2. Use an environment variable or a dedicated secrets manager instead.
 3. Treat the leaked credential as compromised and rotate it immediately.
-Do NOT attempt to bypass this check or pass the credential through another tool.`;
+Do NOT attempt to bypass this check or pass the credential through another tool.
+- Tell the user node9 blocked this and why, then ask how to proceed.`;
   }
 
   if (label.includes('sql safety') && label.includes('delete without where')) {
     return `NODE9: Blocked — DELETE without WHERE clause would wipe the entire table.
 INSTRUCTION: Add a WHERE clause to scope the deletion (e.g. WHERE id = <value>).
-Do NOT retry without a WHERE clause.`;
+Do NOT retry without a WHERE clause.
+- Tell the user node9 blocked this and why, then ask how to proceed.`;
   }
 
   if (label.includes('sql safety') && label.includes('update without where')) {
     return `NODE9: Blocked — UPDATE without WHERE clause would update every row.
 INSTRUCTION: Add a WHERE clause to scope the update (e.g. WHERE id = <value>).
-Do NOT retry without a WHERE clause.`;
+Do NOT retry without a WHERE clause.
+- Tell the user node9 blocked this and why, then ask how to proceed.`;
   }
 
   if (label.includes('dangerous word')) {
@@ -51,18 +54,21 @@ Do NOT retry without a WHERE clause.`;
     const word = match?.[1] ?? 'a dangerous keyword';
     return `NODE9: Blocked — command contains forbidden keyword "${word}".
 INSTRUCTION: Do NOT use "${word}". Use a non-destructive alternative.
-Do NOT attempt to bypass this with shell tricks or aliases — it will be blocked again.`;
+Do NOT attempt to bypass this with shell tricks or aliases — it will be blocked again.
+- Tell the user node9 blocked this and why, then ask how to proceed.`;
   }
 
   if (label.includes('path blocked') || label.includes('sandbox')) {
     return `NODE9: Blocked — operation targets a path outside the allowed sandbox.
 INSTRUCTION: Move your output to an allowed directory such as /tmp/ or the project directory.
-Do NOT retry on the same path.`;
+Do NOT retry on the same path.
+- Tell the user node9 blocked this and why, then ask how to proceed.`;
   }
 
   if (label.includes('inline execution')) {
     return `NODE9: Blocked — inline code execution (e.g. bash -c "...") is not allowed.
-INSTRUCTION: Use individual tool calls instead of embedding code in a shell string.`;
+INSTRUCTION: Use individual tool calls instead of embedding code in a shell string.
+- Tell the user node9 blocked this and why, then ask how to proceed.`;
   }
 
   if (label.includes('strict mode')) {
@@ -75,7 +81,8 @@ INSTRUCTION: Inform the user this action is pending approval. Wait for them to a
     const rule = match?.[1] ?? 'a policy rule';
     return `NODE9: Blocked — action "${rule}" is forbidden by security policy.
 INSTRUCTION: Do NOT use "${rule}". Find a read-only or non-destructive alternative.
-Do NOT attempt to bypass this rule.`;
+Do NOT attempt to bypass this rule.
+- Tell the user node9 blocked this and why, then ask how to proceed.`;
   }
 
   // Generic fallback


### PR DESCRIPTION
One commit since v2.8.2: `249cc6f`, a `fix`, so semantic-release cuts a **patch** (v2.8.3).

Seven of the ten deny messages node9 hands an agent said what *not* to do and never asked the
agent to surface the block. Measured on this machine 2026-09-03: a `project-jail` block on a
`.env` read reached the agent as "do not use this, find a read-only alternative", the agent
pivoted, and the human only knew because a native popup happened to fire. The more specific the
rule, the quieter the product.

Each of the seven branches now ends with the line the generic fallback already carried:

```
- Tell the user node9 blocked this and why, then ask how to proceed.
```

No verdict, rule, or channel changes. The DLP branch keeps its wording and never asks the agent
to repeat the credential. All three consumers (hook stdout for Claude/Copilot/Antigravity, the
MCP gateway JSON-RPC error, the proxy JSON-RPC error) deliver this text to the model, so one edit
covers every agent.

`negotiation.unit.test.ts` is the first test for this function: it fails on exactly the seven
silent branches without the change and passes with it.

⚠️ **Honest scope:** this is a UX layer, not a control. A hostile agent can ignore the line;
`audit.log` remains the record. **Not yet verified end to end** that a live model obeys the
instruction — that check is queued and is the reason to watch the next real block.