### PR TITLE
ci: Scorecard stage 1+3 — least-privilege tokens, pinned actions, dependabot, CodeQL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# Dependency updates, grouped so they arrive as a few reviewable PRs a week
+# rather than one per package. Security advisories still open their own PR.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /packages/policy-engine
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      actions:
+        patterns: ['*']

--- a/.github/workflows/agent-security.yml
+++ b/.github/workflows/agent-security.yml
@@ -6,10 +6,12 @@ name: node9 agent-security
 on: pull_request
 permissions:
   contents: read
-  pull-requests: write
-  checks: write
 jobs:
   scan:
+    permissions:
+      contents: read
+      pull-requests: write # the sticky PR comment
+      checks: write # the check-run
     runs-on: ubuntu-latest
     steps:
       # Local `uses: ./` needs the repo checked out first so action.yml is found.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+# Least privilege at the workflow level; no job here writes to the repo.
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, dev]
@@ -17,10 +21,10 @@ jobs:
         node: [20, 22]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
           cache: npm
@@ -103,10 +107,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -136,10 +140,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+# CodeQL — static analysis on every change to main and every pull request.
+#
+# Scorecard's SAST check scores 0 unless a SAST tool runs on all commits; this
+# is also the one pipelock runs (security.yaml). Results go to the Security tab
+# (code scanning), which is the right home for *code* findings — unlike the
+# Scorecard grade, which is a practice score and stays out of code scanning.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    - cron: '30 5 * * 1' # Mondays 05:30 UTC, after Scorecard
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write # upload SARIF to code scanning
+      actions: read # required by codeql-action on private repos; harmless here
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@a35ac6e6798d72df5475948b28efb89edc2e19ca # v4.37.9
+        with:
+          languages: javascript-typescript
+          # security-and-quality adds the quality queries on top of the default
+          # security set; the extra findings are mostly maintainability, and they
+          # arrive as alerts. Start with security-extended and widen deliberately.
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@a35ac6e6798d72df5475948b28efb89edc2e19ca # v4.37.9
+        with:
+          category: /language:javascript-typescript

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,22 +5,25 @@ on:
     branches: [main]
 
 permissions:
-  contents: write # create tags + commits
-  issues: write # comment on issues
-  pull-requests: write # comment on PRs
-  id-token: write # npm provenance
+  contents: read
 
 jobs:
   release:
+    # The write set lives on the job that needs it, not on the workflow.
+    permissions:
+    contents: write # create tags + commits
+    issues: write # comment on issues
+    pull-requests: write # comment on PRs
+    id-token: write # npm provenance
     name: Semantic Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0 # full history so semantic-release can walk commits
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
   release:
     # The write set lives on the job that needs it, not on the workflow.
     permissions:
-    contents: write # create tags + commits
-    issues: write # comment on issues
-    pull-requests: write # comment on PRs
-    id-token: write # npm provenance
+      contents: write # create tags + commits
+      issues: write # comment on issues
+      pull-requests: write # comment on PRs
+      id-token: write # npm provenance
     name: Semantic Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -7,16 +7,18 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   sync:
+    permissions:
+    contents: write
     name: Merge main → dev
     runs-on: ubuntu-latest
     # Skip the release bot's own commits to avoid infinite loops
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: dev
           fetch-depth: 0

--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   sync:
     permissions:
-    contents: write
+      contents: write
     name: Merge main → dev
     runs-on: ubuntu-latest
     # Skip the release bot's own commits to avoid infinite loops


### PR DESCRIPTION
Four `ci` commits, no release. Measured baseline (quiet Scorecard run on main, 2026-09-04): **4.4/10**.

- **Token-Permissions 0→10**: read-only at the workflow level everywhere; write scopes moved onto the single job that needs them (release, sync-dev, agent-security). Effective per-job permissions unchanged.
- **Pinned-Dependencies 6→10**: all nine floating `actions/checkout@v4` / `actions/setup-node@v4` pinned by commit SHA (verified against the API). The wrapper's `npm install` stays — node9-wrapper has no lockfile.
- **Dependency-Update-Tool 0→10**: dependabot for npm (root + policy-engine) and github-actions, weekly, grouped.
- **SAST 0→10**: CodeQL (javascript-typescript, security-extended) on main, PRs, and weekly. Pinned v4.37.9.

Expected aggregate after this lands: **~6.7**. Still `publish_results: false`.

⚠️ First run of the corrected `release.yml` / `sync-dev.yml` (job-level permissions). One bad commit (7088a3d, flat indentation) was pushed to dev and rejected by GitHub as an invalid workflow before 2ccb263 fixed it; nothing ran under it.