### PR TITLE
fix(egress): allow node9's own hosts by default

### DIFF
--- a/packages/policy-engine/src/egress/evaluate.spec.ts
+++ b/packages/policy-engine/src/egress/evaluate.spec.ts
@@ -99,3 +99,27 @@ describe('evaluateEgress', () => {
     expect(v?.verdict).toBe('block');
   });
 });
+
+describe("node9's own hosts", () => {
+  // Turning egress on used to ask the user to approve node9's own API. The
+  // control plane is on the curated default list now, and a user deny entry
+  // still beats it, so the default is not a back door nobody can close.
+  it('is allowed by default with an empty user allowlist', () => {
+    for (const host of ['api.node9.ai', 'app.node9.ai', 'dev-api.node9.ai', 'node9.ai']) {
+      expect(evaluateEgress([dest(host)], policy({ mode: 'block' }))).toBeNull();
+    }
+  });
+
+  it('is still blocked when the user denies it explicitly', () => {
+    const v = evaluateEgress([dest('api.node9.ai')], policy({ deny: ['*.node9.ai'] }));
+    expect(v?.verdict).toBe('block');
+    expect(v?.reason).toContain('deny list');
+  });
+
+  it('does not widen to look-alike domains', () => {
+    // A suffix match would let evil-node9.ai or node9.ai.evil.com through.
+    for (const host of ['evil-node9.ai', 'node9.ai.evil.com', 'notnode9.ai']) {
+      expect(evaluateEgress([dest(host)], policy({ mode: 'block' }))?.verdict).toBe('block');
+    }
+  });
+});

--- a/packages/policy-engine/src/egress/index.ts
+++ b/packages/policy-engine/src/egress/index.ts
@@ -32,6 +32,10 @@ export interface EgressVerdict {
 // egress on doesn't bury the user in prompts for routine traffic. "*.x" matches
 // the apex (x) and any subdomain (see hostMatches). User `allow` adds to this.
 export const DEFAULT_EGRESS_ALLOWLIST: readonly string[] = [
+  // node9's own control plane (api, app, dev-api, staging and the apex).
+  // Without it, turning egress on asks the user to approve node9 itself.
+  // A user `deny` entry still wins over this list, see evaluateEgress.
+  '*.node9.ai',
   '*.github.com',
   '*.githubusercontent.com',
   '*.npmjs.org',


### PR DESCRIPTION
Turning egress on with an empty user allowlist asked the user to approve node9's own API. Measured on a real machine after the workspace enabled egress:

```
curl https://api.node9.ai/v1/ping  ->  REVIEW
```

`*.node9.ai` joins the curated default list (`DEFAULT_EGRESS_ALLOWLIST`). The product talks to five hosts under that apex and the wildcard form covers all of them.

Not a back door: a user `deny` entry is evaluated before the default list and still wins; a test asserts that. A second test asserts the match does not widen to `evil-node9.ai` or `node9.ai.evil.com`. Mutation-checked: removing the entry fails the test.

Cut as its own branch from `main` so it can merge without the README changes parked in #298. Cuts a patch release.