### PR TITLE
Patch: three CodeQL findings from the 2.9.0 merge

### DIFF
--- a/src/__tests__/canary-generate.spec.ts
+++ b/src/__tests__/canary-generate.spec.ts
@@ -3,6 +3,8 @@
 // file proves it for the one that writes to disk. No decoy literal here: the
 // stopword-carrying candidate is built at runtime from parts.
 import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
 import {
   untilBlocked,
   generateAwsProfile,
@@ -53,5 +55,29 @@ describe('generate.ts oracle', () => {
   it('labels and var names never say canary or node9', () => {
     for (const s of [...LABELS, ...STRIPE_VARS, ...DB_VARS])
       expect(s.toLowerCase()).not.toMatch(/canary|node9/);
+  });
+});
+
+// CodeQL js/biased-cryptographic-random, fixed 2026-09-08. A decoy's whole
+// value is being unguessable, so a known modulo bias is not something to leave
+// in the generator, even a small one.
+describe('the decoy alphabet is drawn without modulo bias', () => {
+  it('every character of the alphabet is reachable', () => {
+    // A cheap structural witness: with 256 % len != 0 the OLD code still
+    // reached every character, so this row alone cannot prove the fix. The row
+    // below is the one that can.
+    const seen = new Set<string>();
+    for (let i = 0; i < 60; i++)
+      for (const v of generateAwsProfile().values) for (const c of v.value) seen.add(c);
+    expect(seen.size).toBeGreaterThan(10);
+  });
+
+  it('does not consume raw bytes modulo the alphabet length', () => {
+    // Pin the MECHANISM, because the distribution itself needs a sample far
+    // larger than a unit test to separate a 1.6% skew from noise. randomInt is
+    // rejection-sampled by Node; `% alphabet.length` is not.
+    const src = fs.readFileSync(path.join(__dirname, '../canary/generate.ts'), 'utf8');
+    expect(src).not.toMatch(/bytes\[[^\]]+\]\s*%\s*alphabet\.length/);
+    expect(src).toMatch(/randomInt\(alphabet\.length\)/);
   });
 });

--- a/src/canary/generate.ts
+++ b/src/canary/generate.ts
@@ -5,7 +5,7 @@
 // severity (design 4.3 and H18). The oracle is scanArgs, so "shape passes
 // regex DLP" is asserted on the real bytes, never assumed. No prefix that
 // could complete a credential shape appears contiguously in this source.
-import { randomBytes, randomInt } from 'crypto';
+import { randomInt } from 'crypto';
 import { scanArgs } from '../dlp';
 
 const ALPHA_B32 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
@@ -29,10 +29,13 @@ const DB_USERS = ['app', 'svc', 'reporter'] as const;
 const DB_HOSTS = ['db-internal', 'pg-primary.internal', 'postgres.svc.cluster.local'] as const;
 const DB_NAMES = ['app', 'prod', 'main'] as const;
 
+// randomInt, not `randomBytes[i] % alphabet.length`: modulo over 256 favours
+// the first (256 % len) characters, which biases every decoy this generates.
+// The skew is small, but a decoy's whole value is being unguessable, so it is
+// not a place to leave a known bias (CodeQL js/biased-cryptographic-random).
 const pick = (alphabet: string, n: number): string => {
-  const bytes = randomBytes(n);
   let out = '';
-  for (let i = 0; i < n; i++) out += alphabet[bytes[i] % alphabet.length];
+  for (let i = 0; i < n; i++) out += alphabet[randomInt(alphabet.length)];
   return out;
 };
 const choose = <T>(xs: readonly T[]): T => xs[randomInt(xs.length)];

--- a/src/canary/plant.ts
+++ b/src/canary/plant.ts
@@ -89,9 +89,14 @@ export function plantKind(kind: CanaryKind, home = os.homedir()): PlantResult {
   }
 
   const dir = path.dirname(target);
-  const createdDir = !fs.existsSync(dir);
   const gen = site.generate(); // throws if the engine would not block the shape (H18)
-  if (createdDir) fs.mkdirSync(dir, { recursive: true, mode: site.dirMode });
+  // mkdirSync(recursive) returns the first path it created, or undefined when
+  // the directory was already there. Asking IT is atomic; the old
+  // existsSync-then-create pair could disagree with itself between the two
+  // calls and mis-record whether uninstall should remove the directory
+  // (CodeQL js/file-system-race). The file write below is the guard that
+  // matters and is already exclusive (`wx`).
+  const createdDir = fs.mkdirSync(dir, { recursive: true, mode: site.dirMode }) !== undefined;
   fs.writeFileSync(target, gen.text, { mode: 0o600, flag: 'wx' });
   fs.chmodSync(target, 0o600);
   const fileHash = sha256Hex(gen.text);

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -4364,10 +4364,7 @@ export function registerScanCommand(program: Command): void {
                 chalk.red.bold('🪤  Decoy Tripped') +
                 chalk.dim('  ·  ') +
                 chalk.red(
-                  `${num(n)} decoy credential${n !== 1 ? 's' : ''} left the file node9 plantedit in`.replace(
-                    'planted it in',
-                    'planted it in'
-                  )
+                  `${num(n)} decoy credential${n !== 1 ? 's' : ''} left the file node9 planted it in`
                 )
             );
             const shownCanaries = drillDown


### PR DESCRIPTION
CodeQL analysed main after 2.9.0 and opened five alerts, three in real code.
All three are in the canary work that reached main with that release.

**A user-visible bug.** The scan report printed "left the file node9 plantedit
in". A typo had been patched with `.replace('planted it in', 'planted it in')`,
which replaces a string with itself and did nothing, so the broken sentence
shipped (js/identity-replacement).

**A biased decoy generator.** Characters were drawn as
`randomBytes[i] % alphabet.length`, which favours the first (256 % len)
characters. The skew is small, but a decoy's entire value is being
unguessable, so a known bias does not belong in the generator that produces
them (js/biased-cryptographic-random). randomInt is rejection-sampled.

**A check-then-act on the plant directory.** existsSync decided whether
uninstall may later delete that directory; the two calls can disagree
(js/file-system-race). mkdirSync(recursive) returns the first path it created,
which answers the same question in one operation. The file write was and stays
exclusive, so no security property moved.

The two remaining alerts are in test files, about a temp-dir pattern inside
throwaway homes, not shipped behaviour.

4840 tests. 2 mutants, and the second survived my first run because the
harness had not rebuilt the CLI those rows drive; with the build in the same
command it dies on three rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)