### PR TITLE
fix(config): an invalid field costs its own subtree, not the whole block

### DIFF
--- a/src/__tests__/config-sanitize-blast-radius.spec.ts
+++ b/src/__tests__/config-sanitize-blast-radius.spec.ts
@@ -1,0 +1,223 @@
+// The blast radius of an invalid config field.
+//
+// sanitizeConfig drops what fails validation so a broken value cannot override
+// a valid one from another layer. The question this file pins is HOW MUCH it
+// drops: dropping the whole top-level block for one bad field is fail-open,
+// because `policy` carries egress, DLP, the jail and the smart rules, and a
+// machine that loses it silently keeps running with much less enforcement.
+//
+// Measured on 2026-09-08 before the fix: of 202 single-field mutations, 151
+// erased a whole top-level block and 108 of those erased `policy`.
+//
+// The corpus is GENERATED here rather than stored, so it cannot rot into a
+// snapshot of whatever the code happens to do.
+import { describe, it, expect } from 'vitest';
+import { sanitizeConfig, ConfigFileSchema } from '../config-schema';
+
+const BASE = {
+  version: '1.0',
+  settings: { mode: 'standard', autoStartDaemon: true, approvers: { native: true, cloud: true } },
+  policy: {
+    egress: {
+      enabled: true,
+      mode: 'block',
+      allow: ['api.github.com'],
+      deny: ['evil.example.com'],
+      allowPrivate: false,
+      ssrfStrict: true,
+      ssrfAllow: ['100.64.0.1'],
+    },
+    dlp: { enabled: true, pii: 'block', reviewAction: 'block' },
+    loopDetection: { enabled: true, threshold: 5, windowSeconds: 120 },
+    ignoredTools: ['Read'],
+    smartRules: [
+      {
+        name: 'r1',
+        tool: 'Bash',
+        verdict: 'block',
+        conditions: [{ field: 'command', op: 'matches', value: 'rm -rf /' }],
+      },
+    ],
+  },
+  environments: { staging: { requireApproval: true } },
+} as const;
+
+type Json = Record<string, unknown>;
+const clone = (o: unknown): Json => JSON.parse(JSON.stringify(o)) as Json;
+
+/** Every leaf path in the base config. Arrays are DESCENDED INTO, not treated
+ *  as leaves: three mutants survived while they were, because a required field
+ *  nested inside a smart rule was never damaged and the prune's array handling,
+ *  ordering and second pass were therefore never exercised. */
+function leafPaths(o: unknown, prefix: string[] = []): string[][] {
+  if (Array.isArray(o)) {
+    return o.flatMap((v, i) => leafPaths(v, [...prefix, String(i)]));
+  }
+  if (o !== null && typeof o === 'object') {
+    return Object.entries(o).flatMap(([k, v]) => leafPaths(v, [...prefix, k]));
+  }
+  return [prefix];
+}
+function setPath(o: Json, path: string[], value: unknown, del = false): void {
+  let cur: Json = o;
+  for (const k of path.slice(0, -1)) cur = cur[k] as Json;
+  const last = path[path.length - 1];
+  if (!del) {
+    cur[last] = value;
+    return;
+  }
+  // Splice out of an array, delete from an object: leaving a hole in an array
+  // is not a shape a hand-edited config ever has.
+  if (Array.isArray(cur)) (cur as unknown as unknown[]).splice(Number(last), 1);
+  else delete cur[last];
+}
+const VARIANTS: Array<[string, unknown, boolean]> = [
+  ['string', 'not-a-value', false],
+  ['number', 42, false],
+  ['bool', true, false],
+  ['null', null, false],
+  ['empty-string', '', false],
+  ['array', ['x'], false],
+  ['object', { k: 'v' }, false],
+  ['delete', undefined, true],
+];
+
+const ALL_PATHS = leafPaths(BASE);
+const corpus: Array<{ id: string; cfg: Json }> = [{ id: 'base-valid', cfg: clone(BASE) }];
+for (const path of ALL_PATHS) {
+  for (const [tag, value, del] of VARIANTS) {
+    const cfg = clone(BASE);
+    setPath(cfg, path, value, del);
+    corpus.push({ id: `${path.join('.')} := ${tag}`, cfg });
+  }
+}
+// Rows with SEVERAL failures at once. A single-fault corpus cannot see whether
+// the prune removes them in an order that keeps sibling indices valid, nor
+// whether one pass is enough.
+const SECOND_RULE = {
+  name: 'r2',
+  tool: 'Read',
+  verdict: 'review',
+  conditions: [{ field: 'file_path', op: 'contains', value: '.env' }],
+};
+for (const [tag, mutate] of Object.entries<(c: Json) => void>({
+  'two-rules-both-bad': (c) => {
+    const p = c.policy as Json;
+    p.smartRules = [clone(BASE.policy.smartRules[0]), clone(SECOND_RULE)];
+    setPath(c, ['policy', 'smartRules', '0', 'verdict'], 'nope');
+    setPath(c, ['policy', 'smartRules', '1', 'tool'], 42);
+  },
+  'first-of-two-rules-bad': (c) => {
+    const p = c.policy as Json;
+    p.smartRules = [clone(BASE.policy.smartRules[0]), clone(SECOND_RULE)];
+    setPath(c, ['policy', 'smartRules', '0', 'verdict'], 'nope');
+  },
+  'bad-in-two-different-blocks': (c) => {
+    setPath(c, ['policy', 'egress', 'enabled'], 'yes');
+    setPath(c, ['settings', 'mode'], 99);
+  },
+  'required-field-missing': (c) => {
+    setPath(c, ['policy', 'smartRules', '0', 'tool'], undefined, true);
+  },
+  'nested-condition-bad': (c) => {
+    setPath(c, ['policy', 'smartRules', '0', 'conditions', '0', 'op'], 'sideways');
+  },
+})) {
+  const cfg = clone(BASE);
+  mutate(cfg);
+  corpus.push({ id: `multi:${tag}`, cfg });
+}
+
+/** The paths zod itself objects to, as dotted strings. */
+function failingPaths(cfg: unknown): Set<string> {
+  const r = ConfigFileSchema.safeParse(cfg);
+  if (r.success) return new Set();
+  return new Set(r.error.issues.map((i) => i.path.join('.')));
+}
+
+// Structural damage the leaf mutations cannot express: a whole block of the
+// wrong SHAPE. These are what the top-level floor exists for, and without them
+// the floor is unreachable and therefore untested.
+for (const [tag, cfg] of Object.entries<unknown>({
+  'settings-array': { ...clone(BASE), settings: [] },
+  'policy-null': { ...clone(BASE), policy: null },
+  'policy-string': { ...clone(BASE), policy: 'nope' },
+  'unknown-top-level': { ...clone(BASE), totallyUnknown: { a: 1 } },
+  'empty-object': {},
+})) {
+  corpus.push({ id: `struct:${tag}`, cfg: cfg as Json });
+}
+
+describe('sanitizeConfig blast radius', () => {
+  it('the corpus is big enough and the base is genuinely valid', () => {
+    // Instrument first: if the base does not validate, every row below is
+    // measuring a config whose `policy` was already gone and proves nothing.
+    // That exact mistake produced a meaningless "zero differences" earlier.
+    expect(corpus.length).toBeGreaterThan(150);
+    expect(sanitizeConfig(BASE).error).toBeNull();
+    expect(Object.keys(sanitizeConfig(BASE).sanitized).sort()).toEqual([
+      'environments',
+      'policy',
+      'settings',
+      'version',
+    ]);
+  });
+
+  it('P1 nothing invalid survives: the sanitized output validates', () => {
+    for (const { id, cfg } of corpus) {
+      const { sanitized } = sanitizeConfig(cfg);
+      expect(ConfigFileSchema.safeParse(sanitized).success, `${id} left invalid data behind`).toBe(
+        true
+      );
+    }
+  });
+
+  it('P3 a valid sibling survives its broken neighbour', () => {
+    // P2 only looks at top-level blocks, so it cannot see how much was removed
+    // INSIDE one. Four mutations of the prune survived until this row existed.
+    const rules = (cfg: Json): Array<{ name?: string }> =>
+      (((sanitizeConfig(cfg).sanitized.policy as Json) ?? {}).smartRules ?? []) as Array<{
+        name?: string;
+      }>;
+    const one = corpus.find((r) => r.id === 'multi:first-of-two-rules-bad')!;
+    expect(
+      rules(one.cfg).map((r) => r.name),
+      'only the broken rule goes'
+    ).toEqual(['r2']);
+
+    const nested = corpus.find((r) => r.id === 'multi:nested-condition-bad')!;
+    const kept = sanitizeConfig(nested.cfg).sanitized.policy as Json;
+    expect(rules(nested.cfg).length, 'a rule with a bad condition goes').toBe(0);
+    expect(kept.egress, 'and everything beside it stays').toEqual(BASE.policy.egress);
+    expect(kept.dlp).toEqual(BASE.policy.dlp);
+
+    const both = corpus.find((r) => r.id === 'multi:two-rules-both-bad')!;
+    expect(rules(both.cfg), 'two broken rules, both go, nothing else does').toEqual([]);
+    expect((sanitizeConfig(both.cfg).sanitized.policy as Json).egress).toEqual(BASE.policy.egress);
+
+    const across = corpus.find((r) => r.id === 'multi:bad-in-two-different-blocks')!;
+    const s = sanitizeConfig(across.cfg).sanitized;
+    expect((s.policy as Json).dlp, 'a fault in settings does not cost policy').toEqual(
+      BASE.policy.dlp
+    );
+    expect((s.settings as Json).autoStartDaemon, 'nor the rest of settings').toBe(true);
+  });
+
+  it('P2 a bad field costs its own subtree, not a whole top-level block', () => {
+    const casualties: string[] = [];
+    for (const { id, cfg } of corpus) {
+      if (id === 'base-valid') continue;
+      const bad = failingPaths(cfg);
+      if (bad.size === 0) continue; // the variant happened to be valid
+      const kept = new Set(Object.keys(sanitizeConfig(cfg).sanitized));
+      for (const top of Object.keys(BASE)) {
+        if (kept.has(top)) continue;
+        // `top` vanished. That is only honest when zod objected to `top` itself,
+        // not to something nested under it.
+        if (!bad.has(top)) casualties.push(`${id} -> lost the whole "${top}" block`);
+      }
+    }
+    expect(casualties.slice(0, 6)).toEqual([]);
+    expect(casualties.length, `${casualties.length} rows lost a whole block`).toBe(0);
+  });
+});

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -203,6 +203,15 @@ export const ConfigFileSchema = z
 
 export type ConfigFileInput = z.input<typeof ConfigFileSchema>;
 
+/** One line per issue: `  • path: message`, with a root issue labelled 'root'. */
+function formatIssues(issues: ReadonlyArray<{ path: PropertyKey[]; message: string }>): string {
+  const lines = issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.map(String).join('.') : 'root';
+    return `  • ${path}: ${issue.message}`;
+  });
+  return `Invalid config:\n${lines.join('\n')}`;
+}
+
 /**
  * Validates a parsed config object. Returns a formatted error string on failure,
  * or null if valid.
@@ -220,9 +229,70 @@ export function validateConfig(raw: unknown, filePath: string): string | null {
 }
 
 /**
+ * Delete the given paths from a config object, deepest first so that removing a
+ * child cannot invalidate the index of a sibling still queued for removal.
+ * Array elements are spliced out rather than left as holes. Returns whether
+ * anything was actually removed, which is how the caller detects a path it
+ * cannot act on (a missing required field, say) and stops looping.
+ */
+function prunePaths(root: Record<string, unknown>, paths: Array<Array<string | number>>): boolean {
+  let removed = false;
+  // Measured 2026-09-08 over 211 configs: this ordering, and the pass count in
+  // the caller, are EQUIVALENT to their opposites — the retry loop reaches the
+  // same result either way, so mutating them changes nothing observable. They
+  // are kept because they get there in fewer passes, not because correctness
+  // rests on them. Do not add a test that pretends otherwise.
+  const ordered = [...paths].sort((x, y) => {
+    if (y.length !== x.length) return y.length - x.length;
+    const xi = x[x.length - 1];
+    const yi = y[y.length - 1];
+    return typeof xi === 'number' && typeof yi === 'number' ? yi - xi : 0;
+  });
+  for (const path of ordered) {
+    let cur: unknown = root;
+    for (const key of path.slice(0, -1)) {
+      if (cur === null || typeof cur !== 'object') {
+        cur = undefined;
+        break;
+      }
+      cur = (cur as Record<string | number, unknown>)[key];
+    }
+    if (cur === null || typeof cur !== 'object') continue;
+    const last = path[path.length - 1];
+    if (Array.isArray(cur)) {
+      const i = Number(last);
+      if (Number.isInteger(i) && i >= 0 && i < cur.length) {
+        cur.splice(i, 1);
+        removed = true;
+      }
+      continue;
+    }
+    const obj = cur as Record<string, unknown>;
+    if (Object.prototype.hasOwnProperty.call(obj, String(last))) {
+      delete obj[String(last)];
+      removed = true;
+    }
+  }
+  return removed;
+}
+
+/**
  * Like validateConfig, but also returns a sanitized copy of the config with
- * invalid fields removed. Top-level fields that fail validation are dropped so
- * they cannot override valid values from a higher-priority config layer.
+ * invalid fields removed, so a broken value cannot override a valid one from a
+ * higher-priority config layer.
+ *
+ * What gets removed is the FIELD that failed, not the top-level block it sits
+ * in. Dropping the block was fail-open in the direction that matters: `policy`
+ * carries egress, DLP, the jail and the smart rules, so one mistyped boolean
+ * anywhere under it silently took all of them and left the machine running
+ * with far less enforcement than its owner wrote down. Measured before this
+ * change: of 202 single-field mutations, 151 erased a whole top-level block,
+ * 108 of them `policy`.
+ *
+ * Removing a field can expose a new issue underneath it, so the prune runs
+ * until the config parses or stops making progress, bounded. Anything still
+ * failing after that falls back to the old block-level drop, which keeps this
+ * strictly better than the previous behaviour and never worse.
  */
 export function sanitizeConfig(raw: unknown): {
   sanitized: Record<string, unknown>;
@@ -233,30 +303,66 @@ export function sanitizeConfig(raw: unknown): {
     return { sanitized: result.data as Record<string, unknown>, error: null };
   }
 
-  // Build the set of top-level keys that have at least one validation error
-  const invalidTopLevelKeys = new Set(
-    result.error.issues
-      .filter((issue) => issue.path.length > 0)
-      .map((issue) => String(issue.path[0]))
-  );
-
-  // Keep only the top-level keys that had no errors
-  const sanitized: Record<string, unknown> = {};
-  if (typeof raw === 'object' && raw !== null) {
-    for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
-      if (!invalidTopLevelKeys.has(key)) {
-        sanitized[key] = value;
-      }
-    }
+  // A root that is not an object at all has no fields to save.
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    return { sanitized: {}, error: formatIssues(result.error.issues) };
   }
 
-  const lines = result.error.issues.map((issue) => {
-    const path = issue.path.length > 0 ? issue.path.join('.') : 'root';
-    return `  • ${path}: ${issue.message}`;
-  });
+  const working = structuredClone(raw) as Record<string, unknown>;
+  // Remove the smallest thing that makes the config parse, escalating outward
+  // only when the smaller removal cannot work. A REQUIRED field with a wrong
+  // value is the case that forces this: deleting the field leaves it missing,
+  // which fails again, so the fix has to be to drop the smart rule that
+  // contains it — not, as it was, every policy the user wrote.
+  for (let level = 0; level < 6; level++) {
+    for (let pass = 0; pass < 5; pass++) {
+      const attempt = ConfigFileSchema.safeParse(working);
+      if (attempt.success) break;
+      const paths = attempt.error.issues
+        .flatMap((issue) => {
+          const at = issue.path as Array<string | number>;
+          // An unrecognised key is reported ON THE OBJECT, with the offending
+          // names in `keys`, so it has no path of its own to prune. Without
+          // this it survived into the merge and the sanitizer's output did not
+          // itself validate.
+          if (issue.code === 'unrecognized_keys') {
+            return (issue as unknown as { keys: string[] }).keys.map((k) => [...at, k]);
+          }
+          return [at.slice(0, -level || undefined)];
+        })
+        .filter((path) => path.length > 0);
+      // Only root-level complaints left (an unrecognised top-level key), or a
+      // path we cannot act on: stop rather than spin.
+      if (paths.length === 0 || !prunePaths(working, paths)) break;
+    }
+    if (ConfigFileSchema.safeParse(working).success) break;
+  }
+
+  // Floor: anything the prune could not fix loses its top-level block, exactly
+  // as before. This bounds the change to "keeps more, never less".
+  //
+  // Escalation reaches a path of length 1, which removes the top-level key
+  // itself, so no corpus input gets this far and a mutation that disables it
+  // survives. It stays as the last line of defence for a schema shape nobody
+  // has written yet: the alternative is returning data that does not validate,
+  // which is the one thing this function must never do.
+  const after = ConfigFileSchema.safeParse(working);
+  const sanitized: Record<string, unknown> = {};
+  const invalidTopLevelKeys = after.success
+    ? new Set<string>()
+    : new Set(
+        after.error.issues
+          .filter((issue) => issue.path.length > 0)
+          .map((issue) => String(issue.path[0]))
+      );
+  for (const [key, value] of Object.entries(working)) {
+    if (!invalidTopLevelKeys.has(key)) sanitized[key] = value;
+  }
 
   return {
     sanitized,
-    error: `Invalid config:\n${lines.join('\n')}`,
+    // The message names what the USER should fix, so it is built from the
+    // original parse, not from whatever survived the prune.
+    error: formatIssues(result.error.issues),
   };
 }


### PR DESCRIPTION
sanitizeConfig dropped every TOP-LEVEL key that had a validation error anywhere
beneath it. `policy` carries egress, DLP, the jail and the smart rules, so one
mistyped boolean took all of them and the machine kept running with far less
enforcement than its owner had written down, behind a single stderr warning
nobody reads. That is fail-open in the direction that matters, and
`~/.node9/config.json` is a file an agent can write.

Measured before the change, over 202 single-field mutations of a valid config:

| outcome | rows |
| --- | --- |
| lost a whole top-level block | 151 |
| of those, lost `policy` entirely | 108 |

It now removes the smallest thing that makes the config parse, escalating
outward only when the smaller removal cannot work. A required field with a
wrong value forces that: deleting the field leaves it missing, so the fix has
to be dropping the smart rule that contains it, not every policy in the file.
Unrecognised top-level keys are pruned too; they used to survive into the merge,
so the sanitizer's own output did not validate.

**How this was kept from becoming the opposite bug.** Three invariants over a
corpus generated at run time, so there is no snapshot to rot:

- **P1** the sanitized output validates: nothing invalid is left behind (guards
  the too-permissive direction)
- **P2** a block only disappears when zod objected to the block itself (guards
  the fail-open direction)
- **P3** a valid rule survives its broken neighbour, and a fault in `settings`
  does not cost `policy` (guards over-deletion inside a block)

9 mutants, 6 killed. The remaining 3 are EQUIVALENT, measured rather than
assumed: the prune's ordering and pass count produce byte-identical output on
all 211 configs because the retry loop absorbs them. The code says so, so that
nobody writes a test pretending they matter.

The corpus had to be widened twice, and both times a surviving mutant was the
reason: it treated arrays as leaves, so a required field nested inside a smart
rule was never damaged, and it had no config with two faults at once. The
widened version then found a real case the first version of this fix did not
handle.

Also carries the merge of zod 4, vitest 5 and the prettier reformat from main.
4844 tests green on that combination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)