### PR TITLE
fix(ssrf): three addresses that were blocked on every machine by mistake

### DIFF
--- a/packages/policy-engine/src/egress/ssrf.spec.ts
+++ b/packages/policy-engine/src/egress/ssrf.spec.ts
@@ -106,8 +106,10 @@ const B: Array<[string, string, string | null, boolean, string]> = [
   ['B15', '239.255.255.255', 'multicast', false, 'address'],
   ['B16', '240.0.0.1', null, false, 'address'],
   ['B17', 'ff02::1', 'multicast', false, 'address'],
-  ['B18', '0.0.0.0', 'unspecified', false, 'address'],
-  ['B19', '::', 'unspecified', false, 'address'],
+  // Overridable since 2026-09-08: 0.0.0.0 as a destination reaches this host,
+  // so it is governed by the strict tier exactly as 127.0.0.1 is. See F1/F2.
+  ['B18', '0.0.0.0', 'unspecified', true, 'address'],
+  ['B19', '::', 'unspecified', true, 'address'],
   ['B20', '100.63.255.255', null, false, 'address'],
   ['B21', '100.64.0.0', 'cgnat', true, 'address'],
   ['B22', '100.127.255.255', 'cgnat', true, 'address'],
@@ -165,14 +167,18 @@ describe('B. classifySsrf tiers', () => {
   });
 
   it('C-floor2 an OVERRIDABLE tier is exempted, in any spelling', () => {
-    expect(ssrfFloor([{ token: '100.64.0.1', binary: 'curl' }], {})?.tier).toBe('cgnat');
+    // CGNAT only reaches the floor at all once the strict tier is on (F3/F4),
+    // so the exemption is exercised there. What this row pins is the exemption
+    // itself, not which tier happens to be strict-gated.
+    const strict = { ssrfStrict: true };
+    expect(ssrfFloor([{ token: '100.64.0.1', binary: 'curl' }], strict)?.tier).toBe('cgnat');
     expect(
-      ssrfFloor([{ token: '100.64.0.1', binary: 'curl' }], { ssrfAllow: ['100.64.0.1'] })
+      ssrfFloor([{ token: '100.64.0.1', binary: 'curl' }], { ...strict, ssrfAllow: ['100.64.0.1'] })
     ).toBeNull();
     // exemption is by canonical address, so a different spelling of the same
     // address is exempt too.
     expect(
-      ssrfFloor([{ token: '1678033921', binary: 'curl' }], { ssrfAllow: ['100.64.0.1'] })
+      ssrfFloor([{ token: '1678033921', binary: 'curl' }], { ...strict, ssrfAllow: ['100.64.0.1'] })
     ).toBeNull();
   });
 
@@ -181,5 +187,66 @@ describe('B. classifySsrf tiers', () => {
     expect(ssrfFloor(lo, {})).toBeNull();
     expect(ssrfFloor(lo, { ssrfStrict: true })?.tier).toBe('private');
     expect(ssrfFloor(lo, { ssrfStrict: true, ssrfAllow: ['127.0.0.1'] })).toBeNull();
+  });
+});
+
+// ── Live false positives on shipped defaults, measured 2026-09-08 ────────────
+// Found by a false-positive corpus built before any code changed. All three
+// were blocked out of the box, on every machine, with no way to reach the
+// knob from the CLI on a dashboard-governed device.
+describe('F. addresses that must be reachable by default', () => {
+  const floor = (token: string, opts: Parameters<typeof ssrfFloor>[1] = {}) =>
+    ssrfFloor([{ token, binary: 'curl' }], opts);
+
+  it('F1 0.0.0.0 is a way of saying localhost, and localhost is reachable by default', () => {
+    // `curl http://0.0.0.0:3000` connects to 127.0.0.1:3000. Blocking it while
+    // 127.0.0.1 itself is reachable (the strict tier is off by default) was
+    // incoherent, and 0.0.0.0:PORT is how a developer reaches their own dev
+    // server all day.
+    expect(floor('0.0.0.0')).toBeNull();
+    expect(floor('::')).toBeNull();
+  });
+
+  it('F2 but the strict tier still blocks it, since it IS loopback', () => {
+    // The SSRF trick of writing 0.0.0.0 to dodge a 127.0.0.1 filter still has
+    // to fail for anyone who turned the strict tier on.
+    expect(floor('0.0.0.0', { ssrfStrict: true })?.tier).toBe('unspecified');
+    expect(floor('::', { ssrfStrict: true })?.tier).toBe('unspecified');
+  });
+
+  it('F3 a Tailscale peer is reachable by default', () => {
+    // 100.64/10 is where every mesh VPN peer lives. Blocking the whole range
+    // out of the box broke ordinary work for anyone on Tailscale.
+    expect(floor('100.64.0.1')).toBeNull();
+    expect(floor('100.127.255.255')).toBeNull();
+  });
+
+  it('F4 the strict tier still blocks CGNAT', () => {
+    expect(floor('100.64.0.1', { ssrfStrict: true })?.tier).toBe('cgnat');
+  });
+
+  it('F5 the metadata endpoint INSIDE CGNAT stays non-overridable', () => {
+    // Alibaba Cloud serves instance credentials at 100.100.100.200, which the
+    // classifier saw only as CGNAT. Relaxing CGNAT without carving this out
+    // would have opened a live credential endpoint, and it was exemptable
+    // even before that.
+    const m = floor('100.100.100.200');
+    expect(m?.tier).toBe('metadata');
+    expect(floor('100.100.100.200', { ssrfAllow: ['100.100.100.200'] }), 'no allow path').not.toBe(
+      null
+    );
+    expect(floor('100.100.100.200', { ssrfStrict: false })).not.toBeNull();
+  });
+
+  it('F6 the always-on tiers are untouched', () => {
+    for (const t of [
+      '169.254.169.254',
+      '169.254.170.2',
+      '168.63.129.16',
+      '224.0.0.1',
+      'metadata',
+    ]) {
+      expect(floor(t), `${t} must still block`).not.toBeNull();
+    }
   });
 });

--- a/packages/policy-engine/src/egress/ssrf.ts
+++ b/packages/policy-engine/src/egress/ssrf.ts
@@ -181,7 +181,16 @@ const METADATA_ADDRESSES = new Set([
   '169.254.170.2', // AWS ECS task role
   '168.63.129.16', // Azure WireServer
   'fd00:ec2::254', // AWS IMDS over IPv6 (inside fc00::/7, which is NOT a tier)
+  // Alibaba Cloud IMDS. It sits INSIDE 100.64/10, so before this line it was
+  // classified as cgnat and therefore exemptable: one ssrfAllow entry opened a
+  // live credential endpoint. It has to be named here, above the range check,
+  // and it is the reason relaxing cgnat is safe.
+  '100.100.100.200',
 ]);
+
+/** The tiers the `ssrfStrict` knob governs. A tier outside this set blocks on
+ *  every machine and no setting releases it. */
+const STRICT_TIERS = new Set<SsrfTier>(['private', 'unspecified', 'cgnat']);
 
 /** Tier 1, non-overridable: the metadata names node9 cannot resolve to an address. */
 const METADATA_HOSTNAMES = new Set(['metadata.google.internal', 'metadata.goog', 'metadata']);
@@ -218,9 +227,20 @@ export function classifySsrf(host: string): SsrfMatch | null {
 
     const o = v4Octets(ip);
     if (o) {
-      if (o[0] === 0 && o[1] === 0 && o[2] === 0 && o[3] === 0) return hit('unspecified', false);
+      // 0.0.0.0 as a DESTINATION means "this host": curl http://0.0.0.0:3000
+      // reaches 127.0.0.1:3000. It is loopback by another spelling, so it is
+      // gated by the strict tier exactly as loopback is, rather than blocked
+      // on every machine while 127.0.0.1 is allowed. The SSRF trick of writing
+      // it to dodge a 127.0.0.1 filter still fails for anyone with strict on.
+      if (o[0] === 0 && o[1] === 0 && o[2] === 0 && o[3] === 0) return hit('unspecified', true);
       if (o[0] === 169 && o[1] === 254) return hit('link-local', false);
       if (o[0] >= 224 && o[0] <= 239) return hit('multicast', false);
+      // CGNAT is where every mesh-VPN peer lives (Tailscale hands out 100.64/10),
+      // so blocking the range out of the box broke ordinary work for anyone
+      // using one, on every machine, with no reachable knob on a
+      // dashboard-governed device. It is gated by the strict tier now. The
+      // metadata endpoint inside the range is carved out above and stays
+      // non-overridable, which is what makes this safe.
       if (o[0] === 100 && o[1] >= 64 && o[1] <= 127) return hit('cgnat', true);
       // Tier 3: off by default (egress.ssrfStrict), because a developer talks to
       // these constantly. 72 of 308 destinations measured on real history.
@@ -233,7 +253,7 @@ export function classifySsrf(host: string): SsrfMatch | null {
 
     const g = expandIpv6(ip);
     if (!g) return null;
-    if (g.every((x) => x === 0)) return hit('unspecified', false);
+    if (g.every((x) => x === 0)) return hit('unspecified', true); // :: — see the IPv4 note
     if ((g[0] & 0xffc0) === 0xfe80) return hit('link-local', false); // fe80::/10
     if ((g[0] & 0xff00) === 0xff00) return hit('multicast', false); // ff00::/8
     if (g.slice(0, 7).every((x) => x === 0) && g[7] === 1) return hit('private', true); // ::1
@@ -268,7 +288,7 @@ const TIER_REASON: Record<SsrfTier, string> = {
   metadata: 'a cloud instance-metadata endpoint, the classic credential-theft target',
   'link-local': 'a link-local address',
   multicast: 'a multicast address',
-  unspecified: 'the unspecified address',
+  unspecified: 'the unspecified address, which reaches this host',
   cgnat: 'a carrier-grade NAT address',
   private: 'a loopback or private address',
 };
@@ -290,7 +310,10 @@ export function ssrfFloor(
   for (const { token, binary } of tokens) {
     const m = classifySsrf(token);
     if (!m) continue;
-    if (m.tier === 'private' && !opts.ssrfStrict) continue;
+    // Tiers the strict knob governs: reachable by default, blocked when a user
+    // or an org turns the strict tier on. Everything not listed here blocks on
+    // every machine, always.
+    if (STRICT_TIERS.has(m.tier) && !opts.ssrfStrict) continue;
     // An exemption applies to overridable tiers only. Tier 1 has no allow path.
     if (m.overridable && m.normalized && exempt.has(m.normalized)) continue;
     return {

--- a/src/__tests__/ssrf-pins.spec.ts
+++ b/src/__tests__/ssrf-pins.spec.ts
@@ -23,6 +23,8 @@ type Egress = {
   allow?: string[];
   deny?: string[];
   allowPrivate?: boolean;
+  ssrfStrict?: boolean;
+  ssrfAllow?: string[];
 };
 let home: string;
 
@@ -176,8 +178,21 @@ describe('the floor closes every escape route', () => {
     );
   });
 
-  it('B4 0.0.0.0 is blocked (was: allowed, isPrivateHost returns true for it)', () => {
+  it('B4 0.0.0.0 follows loopback: reachable by default, blocked under strict', () => {
+    // Changed 2026-09-08 after a false-positive corpus measured it: as a
+    // DESTINATION 0.0.0.0 reaches this host, so blocking it on every machine
+    // while 127.0.0.1 stayed reachable was incoherent, and `curl
+    // http://0.0.0.0:3000` is how a developer reaches their own dev server.
     home = makeHome({ enabled: true, mode: 'block', allow: [], deny: [], allowPrivate: true });
+    expect(check(home, 'curl http://0.0.0.0/x').decision).not.toBe('deny');
+    home = makeHome({
+      enabled: true,
+      mode: 'block',
+      allow: [],
+      deny: [],
+      allowPrivate: true,
+      ssrfStrict: true,
+    });
     expect(check(home, 'curl http://0.0.0.0/x').decision).toBe('deny');
   });
 
@@ -274,9 +289,19 @@ describe('R2 false positives: an ordinary command must not hit the floor', () =>
   it('but a bare decimal that really denotes a protected address still blocks', () => {
     home = makeHome(undefined);
     expect(check(home, 'curl 2852039166/latest/meta-data/').decision).toBe('deny');
-    // and an explicit scheme keeps the small-integer forms meaningful
-    expect(check(home, 'curl http://0/').decision).toBe('deny');
-    expect(check(home, 'curl http://0.0.0.0/x').decision).toBe('deny');
+    // The small-integer forms still resolve to 0.0.0.0, which is now the
+    // strict tier rather than an always-on one (B4), so what this row pins is
+    // the DECODING, exercised where the floor still acts on it.
+    const strictHome = makeHome({
+      enabled: true,
+      mode: 'block',
+      allow: [],
+      deny: [],
+      allowPrivate: true,
+      ssrfStrict: true,
+    });
+    expect(check(strictHome, 'curl http://0/').decision).toBe('deny');
+    expect(check(strictHome, 'curl http://0.0.0.0/x').decision).toBe('deny');
   });
 });
 


### PR DESCRIPTION
A false-positive corpus, built by a separate agent before any code changed,
measured what the SSRF floor breaks in ordinary work. Three of its results
were live on shipped defaults, on every machine, with no knob reachable from
the CLI on a dashboard-governed device.

| command | before | after |
| --- | --- | --- |
| `curl http://0.0.0.0:3000/health` | BLOCK | allowed (strict tier blocks it) |
| `curl http://100.64.0.1/x` | BLOCK | allowed (strict tier blocks it) |
| `curl http://100.100.100.200/latest/...` | exemptable | non-overridable |

**0.0.0.0 is loopback by another spelling.** As a destination it reaches this
host: `curl http://0.0.0.0:3000` connects to 127.0.0.1:3000, which is how a
developer reaches their own dev server all day. Blocking it everywhere while
127.0.0.1 itself stayed reachable was incoherent. The SSRF trick of writing
0.0.0.0 to dodge a 127.0.0.1 filter still fails once strict is on.

**CGNAT is where every mesh-VPN peer lives.** Tailscale hands out 100.64/10,
so blocking the range out of the box broke ordinary work for anyone using one.

**What makes that safe is the third change.** Alibaba Cloud serves instance
credentials at 100.100.100.200, inside 100.64/10, and the classifier saw it
only as CGNAT: it was exemptable with a single ssrfAllow entry even before
this change, and relaxing the range without carving it out would have opened a
live credential endpoint. It is named among the metadata addresses now, above
the range check, and no setting releases it.

`curl http://239.99/x` is deliberately unchanged. It really denotes
239.0.0.99, and in a shell command that token IS the destination. The
number-that-looks-like-an-address problem is real but belongs to argument
values in non-shell tools, where the existing guard (which lives in
extractShellDestTokens, not in classifySsrf) would not be inherited.

Which tiers the strict knob governs is now one named set rather than a single
tier test, so "is this reachable by default" has one answer in one place.

5 mutants, all killed. Four pins moved with the decision and say why in place.
4850 tests green.

Corpora: `doc/roadmap/active/ssrf-nonshell-fp-corpus.md` and
`ssrf-nonshell-attack-corpus.md` (both untracked, local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)