### PR TITLE
feat(ssrf): close the shell-only gap, by a closed list of destinations

### DIFF
--- a/packages/policy-engine/src/egress/destinations.spec.ts
+++ b/packages/policy-engine/src/egress/destinations.spec.ts
@@ -1,0 +1,215 @@
+// The SSRF floor beyond shell commands.
+//
+// Measured gap: `curl http://<metadata>/` blocks, the same address through
+// WebFetch or a browser tool does not, because the floor is called only inside
+// the shell branch. Design and both adversarial corpora:
+//   doc/roadmap/active/ssrf-nonshell-design.md
+//   doc/roadmap/active/ssrf-nonshell-{attack,fp}-corpus.md
+//
+// Two laws this file exists to hold:
+//   1. a value is judged by PARSING it as a URL and taking the host, never by
+//      searching for a substring
+//   2. only a tool on the closed list is judged at all, because there is no
+//      placement that reaches WebFetch without also reaching Grep
+import { describe, it, expect } from 'vitest';
+import { ssrfDestinationFloor } from './destinations';
+
+const META = '169.254.169.254';
+const hit = (tool: string, args: unknown, opts = {}) => ssrfDestinationFloor(tool, args, opts);
+
+describe('A. the closed list', () => {
+  it('A1 WebFetch is judged', () => {
+    expect(hit('WebFetch', { url: `http://${META}/latest/meta-data/` })?.tier).toBe('metadata');
+  });
+
+  it('A2 the browser tools are judged, including a value nested at depth 4', () => {
+    expect(hit('navigate', { url: `http://${META}/` })?.tier).toBe('metadata');
+    expect(hit('preview_start', { url: `http://${META}/` })?.tier).toBe('metadata');
+    expect(
+      hit('browser_batch', {
+        actions: [
+          { input: { url: 'https://ok.example.com' } },
+          { input: { url: `http://${META}/` } },
+        ],
+      })?.tier
+    ).toBe('metadata');
+  });
+
+  it('A3 an MCP server prefix does not hide a listed tool', () => {
+    expect(hit('mcp__Claude_Browser__navigate', { url: `http://${META}/` })?.tier).toBe('metadata');
+  });
+
+  it('A4 a tool NOT on the list is not judged, whatever its arguments say', () => {
+    // The founder call, 2026-09-08: a URL-shaped key on a tool whose network
+    // semantics are undeclared is ignored. There is no placement that sees
+    // WebFetch without also seeing these, so the list is what separates them.
+    for (const tool of [
+      'Grep',
+      'Write',
+      'Read',
+      'Bash',
+      'Agent',
+      'Task',
+      'mcp__unknown__do_thing',
+    ]) {
+      expect(
+        hit(tool, { url: `http://${META}/`, pattern: META, content: `see http://${META}/` }),
+        tool
+      ).toBeNull();
+    }
+  });
+
+  it("A5 an argument that is not on the tool's declared path is not judged", () => {
+    expect(hit('WebFetch', { prompt: `explain http://${META}/latest/meta-data/` })).toBeNull();
+  });
+});
+
+describe('B. a value becomes a host by PARSING, not by searching', () => {
+  it('B1 the row that kills a substring check', () => {
+    // Looks like the metadata address, resolves to example.com. Measured with
+    // the real URL parser before this file was written.
+    expect(hit('WebFetch', { url: `http://${META}%2f@example.com/` })).toBeNull();
+  });
+
+  it('B2 every spelling of the address still lands', () => {
+    for (const u of [
+      `http://${META}/x`,
+      'http://2852039166/x',
+      'http://[::ffff:169.254.169.254]/x',
+      `http://${META.toUpperCase()}./x`,
+      `http://user:pw@${META}/x`,
+    ]) {
+      expect(hit('WebFetch', { url: u })?.tier, u).toBe('metadata');
+    }
+  });
+
+  it('B3 ordinary destinations pass', () => {
+    for (const u of [
+      'https://api.github.com/repos',
+      'https://registry.npmjs.org/x',
+      'http://example.com',
+    ]) {
+      expect(hit('WebFetch', { url: u }), u).toBeNull();
+    }
+  });
+
+  it('B3b a non-http scheme reaching the same address is still a destination', () => {
+    // Found by a surviving mutant: the first version restricted this to
+    // http(s), which was arbitrary rather than safe.
+    expect(hit('WebFetch', { url: `ssh://${META}/x` })?.tier).toBe('metadata');
+    expect(hit('WebFetch', { url: `ftp://${META}/x` })?.tier).toBe('metadata');
+  });
+
+  it('B3c a scheme that carries no host is not a destination', () => {
+    for (const u of [
+      `data:text/html,${META}`,
+      `javascript:fetch('${META}')`,
+      `mailto:a@${META}`,
+      'file:///etc/hosts',
+      // The row a surviving mutant asked for: read the PATH instead of the
+      // host and this blocks, though nothing is being reached.
+      `javascript:${META}`,
+    ]) {
+      expect(hit('WebFetch', { url: u }), u).toBeNull();
+    }
+  });
+
+  it('B4 a value that is not a URL at all is not a destination', () => {
+    // The numeric-collision family: under inet_aton a price or a hash folds to
+    // a protected address. None of these is a URL host, so this path never
+    // meets the problem the shell path has to guard against.
+    for (const v of ['239.99', '0.0', '0', '1678033921', 'not a url', '', 'metadata']) {
+      expect(hit('WebFetch', { url: v }), v).toBeNull();
+    }
+  });
+});
+
+describe('C. the same tiers as the shell path', () => {
+  it('C1 the strict tier is off by default and on when asked', () => {
+    expect(hit('WebFetch', { url: 'http://127.0.0.1:3000/health' })).toBeNull();
+    expect(hit('WebFetch', { url: 'http://0.0.0.0:3000/health' })).toBeNull();
+    expect(
+      hit('WebFetch', { url: 'http://127.0.0.1:3000/health' }, { ssrfStrict: true })?.tier
+    ).toBe('private');
+  });
+
+  it('C2 an exemption applies to an overridable tier only', () => {
+    const strict = { ssrfStrict: true };
+    expect(hit('WebFetch', { url: 'http://100.64.0.1/x' }, strict)?.tier).toBe('cgnat');
+    expect(
+      hit('WebFetch', { url: 'http://100.64.0.1/x' }, { ...strict, ssrfAllow: ['100.64.0.1'] })
+    ).toBeNull();
+    expect(hit('WebFetch', { url: `http://${META}/x` }, { ssrfAllow: [META] })?.tier).toBe(
+      'metadata'
+    );
+  });
+
+  it('C3 the metadata endpoint inside CGNAT is still not exemptable', () => {
+    expect(
+      hit(
+        'WebFetch',
+        { url: 'http://100.100.100.200/latest/meta-data/' },
+        { ssrfAllow: ['100.100.100.200'] }
+      )?.tier
+    ).toBe('metadata');
+  });
+});
+
+describe('D. it can never crash a tool call', () => {
+  it('D1 junk arguments return null rather than throwing', () => {
+    for (const a of [
+      null,
+      undefined,
+      'string',
+      42,
+      [],
+      { url: null },
+      { url: {} },
+      { actions: 'no' },
+      { actions: [null, 1] },
+    ]) {
+      expect(() => hit('WebFetch', a)).not.toThrow();
+      expect(hit('WebFetch', a)).toBeNull();
+    }
+  });
+
+  it('D2 a deeply nested cycle does not hang', () => {
+    const a: Record<string, unknown> = { url: 'https://ok.example.com' };
+    a.self = a;
+    expect(() => hit('WebFetch', a)).not.toThrow();
+  });
+});
+
+// The check has to run BEFORE the ignoredTools fast path. `webfetch`,
+// `get_*`, `read_*` and `list_*` are all on that list, so a placement one
+// block lower is dead code for exactly the tools that carry the gap. That is
+// not hypothetical: the first wiring of this feature sat below it, and
+// WebFetch still reached the metadata endpoint while `navigate` was blocked.
+describe('E. placement', () => {
+  it('E1 an IGNORED tool is still judged', async () => {
+    const { evaluatePolicy } = await import('../policy');
+    const config = {
+      settings: { mode: 'standard' },
+      policy: {
+        ignoredTools: ['webfetch'],
+        dlp: { enabled: false, scanIgnoredTools: false, reviewAction: 'review' },
+        egress: { enabled: false, mode: 'off', allow: [], deny: [], allowPrivate: true },
+        smartRules: [],
+        dangerousWords: [],
+        toolInspection: {},
+        commandChecks: {},
+        jailPaths: [],
+        loopDetection: { enabled: false, threshold: 5, windowSeconds: 120 },
+      },
+    } as unknown as Parameters<typeof evaluatePolicy>[0];
+    const r = await evaluatePolicy(
+      config,
+      'WebFetch',
+      { url: 'http://169.254.169.254/latest/meta-data/' },
+      { agent: 'agent' },
+      {}
+    );
+    expect(r.decision, 'the ignored-tool fast path must not swallow this').toBe('block');
+    expect(r.blockedByLabel).toMatch(/Protected Address/);
+  });
+});

--- a/packages/policy-engine/src/egress/destinations.ts
+++ b/packages/policy-engine/src/egress/destinations.ts
@@ -1,0 +1,134 @@
+// The SSRF floor for tool calls that are not shell commands.
+//
+// Measured 2026-09-08: `curl http://<metadata>/` blocked, the same address
+// through WebFetch or a browser tool did not, because ssrfFloor is called only
+// inside the shell branch of evaluatePolicy. Design and the two adversarial
+// corpora that shaped it: doc/roadmap/active/ssrf-nonshell-design.md.
+//
+// Two decisions are load-bearing here, and both came from measurement rather
+// than from taste:
+//
+// 1. A CLOSED LIST of tool + argument paths, not a scan of arguments. There is
+//    no placement in the orchestrator that reaches WebFetch without also
+//    reaching Grep, Write and an Agent prompt, and a false-positive corpus
+//    returned six families where nothing distinguishes "this argument IS a
+//    destination" from "this argument CONTAINS the text" (free text being the
+//    worst: quoting and instructing are the same bytes). A shape not on this
+//    list is a deliberate false negative. The alternative blocks ordinary work
+//    and then the whole mechanism gets switched off.
+//
+// 2. A value is judged by PARSING it as a URL and taking the host. Never by
+//    searching for a substring. `http://169.254.169.254%2f@example.com/` looks
+//    like the metadata address and really resolves to example.com; a substring
+//    check blocks it wrongly. Parsing also removes the numeric-collision
+//    family for free: under inet_aton the price 239.99 and roughly 6% of
+//    32-bit hashes fold to protected addresses, and none of them is ever a URL
+//    hostname.
+import { classifySsrf, isStrictGatedTier, ssrfReason, type SsrfMatch } from './ssrf';
+
+/**
+ * Tools whose named argument really is a destination the agent is about to
+ * reach. Keyed on the BARE tool name (an `mcp__server__` prefix is stripped
+ * before matching), because the browser tools arrive over MCP.
+ *
+ * Derived from real history, not imagination: walking 240,058 audit entries
+ * produced exactly these argument paths. A tool is here because its network
+ * semantics are declared by its name, not because it happens to carry a key
+ * called `url` (founder call, 2026-09-08: ignore those).
+ *
+ * `[]` in a path means "every element of this array".
+ */
+export const DESTINATION_ARGS: ReadonlyMap<string, readonly string[]> = new Map([
+  ['webfetch', ['url']],
+  ['fetch', ['url', 'uri']],
+  ['navigate', ['url']],
+  ['preview_start', ['url']],
+  ['browser_batch', ['actions[].input.url']],
+]);
+
+/** `mcp__Claude_Browser__navigate` -> `navigate`. */
+function bareToolName(toolName: string): string {
+  const parts = toolName.split('__');
+  return (parts.length >= 3 ? parts.slice(2).join('__') : toolName).toLowerCase();
+}
+
+/** Resolve one path against the argument object, yielding every string it names. */
+function valuesAt(args: unknown, path: string): string[] {
+  let cursors: unknown[] = [args];
+  for (const rawSegment of path.split('.')) {
+    const isArray = rawSegment.endsWith('[]');
+    const key = isArray ? rawSegment.slice(0, -2) : rawSegment;
+    const next: unknown[] = [];
+    for (const cursor of cursors) {
+      if (cursor === null || typeof cursor !== 'object') continue;
+      const child = (cursor as Record<string, unknown>)[key];
+      if (isArray) {
+        if (Array.isArray(child)) next.push(...child);
+      } else if (child !== undefined) {
+        next.push(child);
+      }
+    }
+    cursors = next;
+    if (cursors.length === 0) return [];
+  }
+  return cursors.filter((v): v is string => typeof v === 'string');
+}
+
+/** The host a value denotes, or null when the value is not a URL at all. */
+function hostOf(value: string): string | null {
+  try {
+    // A bare host with no scheme is NOT accepted: on this path the value has
+    // to look like a destination, and "239.99" must stay a price.
+    // Any scheme with a real host counts. Restricting this to http(s) was
+    // arbitrary and merely narrow: ssh:// or ftp:// to a protected address is
+    // the same reach. A scheme that carries no host (data:, javascript:,
+    // mailto:, file:///x) yields an empty hostname and falls out below, so
+    // nothing new is caught by accident.
+    const u = new URL(value);
+    const h = u.hostname;
+    return h.startsWith('[') && h.endsWith(']') ? h.slice(1, -1) : h;
+  } catch {
+    return null;
+  }
+}
+
+export interface DestinationHit extends SsrfMatch {
+  /** The path that carried it, for the message and the audit row. */
+  argPath: string;
+  host: string;
+  reason: string;
+}
+
+/**
+ * Judge a non-shell tool call. Returns the first protected destination, or
+ * null. Never throws: this runs on the hook path, where an exception would
+ * break every tool call on the machine.
+ */
+export function ssrfDestinationFloor(
+  toolName: string,
+  args: unknown,
+  opts: { ssrfStrict?: boolean; ssrfAllow?: readonly string[] } = {}
+): DestinationHit | null {
+  try {
+    const paths = DESTINATION_ARGS.get(bareToolName(toolName));
+    if (!paths) return null;
+    const exempt = new Set((opts.ssrfAllow ?? []).map((a) => classifySsrf(a)?.normalized ?? a));
+    for (const path of paths) {
+      for (const value of valuesAt(args, path)) {
+        const host = hostOf(value);
+        if (!host) continue;
+        const m = classifySsrf(host);
+        if (!m) continue;
+        // The same two questions the shell floor asks, asked of the same
+        // functions rather than re-expressed here. Two spellings of one rule is
+        // how the parts of this feature drifted apart all day.
+        if (isStrictGatedTier(m.tier) && !opts.ssrfStrict) continue;
+        if (m.overridable && m.normalized && exempt.has(m.normalized)) continue;
+        return { ...m, argPath: path, host, reason: ssrfReason(m, host) };
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/policy-engine/src/egress/ssrf.ts
+++ b/packages/policy-engine/src/egress/ssrf.ts
@@ -192,6 +192,23 @@ const METADATA_ADDRESSES = new Set([
  *  every machine and no setting releases it. */
 const STRICT_TIERS = new Set<SsrfTier>(['private', 'unspecified', 'cgnat']);
 
+/** Is this tier reachable by default, waiting on the `ssrfStrict` knob?
+ *  Exported so the non-shell path asks the SAME question rather than
+ *  approximating it with `overridable`, which is a different property. */
+export function isStrictGatedTier(tier: SsrfTier): boolean {
+  return STRICT_TIERS.has(tier);
+}
+
+/** The sentence a user reads when the floor stops them. One builder, so the
+ *  shell path and the non-shell path cannot word the same block differently. */
+export function ssrfReason(m: SsrfMatch, asWritten: string): string {
+  return (
+    `Blocked: ${asWritten} is ${TIER_REASON[m.tier]}` +
+    (m.normalized && m.normalized !== asWritten ? ` (${m.normalized})` : '') +
+    (m.overridable ? '.' : '. This address cannot be allowlisted.')
+  );
+}
+
 /** Tier 1, non-overridable: the metadata names node9 cannot resolve to an address. */
 const METADATA_HOSTNAMES = new Set(['metadata.google.internal', 'metadata.goog', 'metadata']);
 
@@ -313,18 +330,10 @@ export function ssrfFloor(
     // Tiers the strict knob governs: reachable by default, blocked when a user
     // or an org turns the strict tier on. Everything not listed here blocks on
     // every machine, always.
-    if (STRICT_TIERS.has(m.tier) && !opts.ssrfStrict) continue;
+    if (isStrictGatedTier(m.tier) && !opts.ssrfStrict) continue;
     // An exemption applies to overridable tiers only. Tier 1 has no allow path.
     if (m.overridable && m.normalized && exempt.has(m.normalized)) continue;
-    return {
-      ...m,
-      host: token,
-      binary,
-      reason:
-        `Blocked: ${token} is ${TIER_REASON[m.tier]}` +
-        (m.normalized && m.normalized !== token ? ` (${m.normalized})` : '') +
-        (m.overridable ? '.' : '. This address cannot be allowlisted.'),
-    };
+    return { ...m, host: token, binary, reason: ssrfReason(m, token) };
   }
   return null;
 }

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -167,7 +167,15 @@ export type { CanaryValue, CanaryHit, CanaryView } from './dlp/canary';
 
 // SSRF floor: protected addresses, checked before and independently of the
 // egress policy. See doc/roadmap/active/ssrf-floor-design.md.
-export { normalizeIpLiteral, classifySsrf, ssrfFloor, SSRF_MAX_HOST } from './egress/ssrf';
+export {
+  normalizeIpLiteral,
+  classifySsrf,
+  ssrfFloor,
+  isStrictGatedTier,
+  ssrfReason,
+  SSRF_MAX_HOST,
+} from './egress/ssrf';
+export { ssrfDestinationFloor, DESTINATION_ARGS } from './egress/destinations';
 export type { SsrfTier, SsrfMatch, SsrfVerdict, SsrfFloorOptions } from './egress/ssrf';
 export { extractShellDestTokens } from './shell/index';
 export type { ShellDestToken } from './shell/index';

--- a/packages/policy-engine/src/policy/index.ts
+++ b/packages/policy-engine/src/policy/index.ts
@@ -8,6 +8,7 @@
 import type { SmartRule } from '../types';
 import { extractShellDestTokens } from '../shell/index';
 import { ssrfFloor } from '../egress/ssrf';
+import { ssrfDestinationFloor } from '../egress/destinations';
 import { scanArgs } from '../dlp';
 import {
   detectDangerousShellExec,
@@ -335,6 +336,41 @@ export async function evaluatePolicy(
             : 'review',
         blockedByLabel: `DLP: ${dlpMatch.patternName}`,
         reason: `${dlpMatch.patternName} detected in ${dlpMatch.fieldPath}`,
+      };
+    }
+  }
+
+  // ── SSRF floor, non-shell destinations ──────────────────────────────────
+  // A tool that fetches a URL itself reaches a protected address without ever
+  // producing a shell command, so the floor below would never see it. Judged
+  // by a CLOSED LIST of tool + argument paths: there is no seam that reaches
+  // WebFetch without also reaching Grep and an Agent prompt, and a
+  // false-positive corpus found six families where nothing tells a
+  // destination apart from a mention. See egress/destinations.ts.
+  //
+  // Placed BEFORE the ignoredTools fast path, for the same reason the DLP
+  // scanner above is: `webfetch`, `get_*`, `read_*` and `list_*` are all on
+  // that list, so anything after it is dead code for exactly the tools that
+  // carry this gap. Measured: with the check one block lower, WebFetch still
+  // reached the metadata endpoint while `navigate` was blocked.
+  //
+  // Here, in the engine, so `node9 explain`, `simulate` and the posture probes
+  // inherit it and cannot disagree with the gate. The orchestrator calls the
+  // same function on the live hook path, where evaluatePolicy is never reached
+  // for an ignored tool at all.
+  {
+    const dest = ssrfDestinationFloor(toolName, args, {
+      ssrfAllow: config.policy.egress?.ssrfAllow,
+      ssrfStrict: config.policy.egress?.ssrfStrict,
+    });
+    if (dest) {
+      return {
+        decision: 'block',
+        blockedByLabel: '🌐 Node9 Egress (Protected Address)',
+        reason: dest.reason,
+        ruleName: `ssrf:${dest.tier}:${toolName}:${dest.host}`,
+        ruleDescription: dest.reason,
+        tier: 3,
       };
     }
   }

--- a/src/auth/orchestrator.ts
+++ b/src/auth/orchestrator.ts
@@ -5,6 +5,7 @@ import { askNativePopup } from '../ui/native';
 import { computeRiskMetadata, type RiskMetadata } from '../context-sniper';
 import { scanArgs, scanFilePath, detectArgsPii, matchCanaryArgs, type DlpMatch } from '../dlp';
 import { canaryValues, loadCanaries } from '../canary/registry';
+import { ssrfDestinationFloor } from '@node9/policy-engine';
 import { extractShellDestinations, evaluateEgress } from '@node9/policy-engine';
 import { appendHookDebug, appendLocalAudit, appendToLog, HOOK_DEBUG_LOG } from '../audit';
 import { getConfig, getCredentials } from '../config';
@@ -499,6 +500,40 @@ async function _authorizeHeadlessCore(
         // file was read. Witnessed by canary-block-message.spec.ts, which calls
         // the orchestrator directly: this field never reaches the hook stdout.
         ruleDescription: `The fake credential node9 planted in ${rec?.path ?? 'a decoy file'} just left that file. Nothing legitimate reads it.`,
+      };
+    }
+  }
+
+  // ── SSRF FLOOR, NON-SHELL DESTINATIONS ────────────────────────────────────
+  // A tool that fetches a URL itself never produces a shell command, so the
+  // floor inside evaluatePolicy cannot see it — and WebFetch, get_*, read_*
+  // and list_* are on the ignoredTools list, so it never reaches evaluatePolicy
+  // at all. Measured: `curl http://<metadata>/` blocked while the same address
+  // through WebFetch was allowed.
+  //
+  // So this runs here, beside the canary gate and before the ignored-tool fast
+  // path, on the same principle: a protected address in a declared destination
+  // argument has no legitimate path into a tool call. It calls the SAME engine
+  // function evaluatePolicy calls, so the gate and `node9 explain` cannot
+  // disagree. A closed list of tool + argument paths, never a scan: see
+  // egress/destinations.ts for why that is the only safe shape.
+  {
+    const dest = ssrfDestinationFloor(toolName, args, {
+      ssrfAllow: config.policy.egress?.ssrfAllow,
+      ssrfStrict: config.policy.egress?.ssrfStrict,
+    });
+    if (dest && !isObserveMode) {
+      if (!isManual)
+        appendLocalAudit(toolName, args, 'deny', 'ssrf-destination', meta, hashAuditArgs);
+      return {
+        approved: false,
+        checkedBy: 'local-policy',
+        blockedByLabel: '🌐 Node9 Egress (Protected Address)',
+        reason: dest.reason,
+        // AuthResult carries no ruleName; the rule identity the audit row needs
+        // travels in ruleHit, as it does for a smart-rule block.
+        ruleHit: `ssrf:${dest.tier}:${toolName}:${dest.host}`,
+        ruleDescription: dest.reason,
       };
     }
   }


### PR DESCRIPTION
Measured before any code was written: `curl http://<metadata>/` blocked while
the same address through WebFetch or a browser tool was allowed, because
`ssrfFloor` is called only inside the shell branch of `evaluatePolicy`. Claude
Code's own WebFetch walked to the credential endpoint.

**The coverage this adds is real but NARROW, and the wording matters.** It
covers WebFetch and the three browser tools. Walking 241,320 real audit
entries found no URL-carrying tool for the other governed agents, but they had
barely run on that machine (Gemini 20 calls, Copilot 7, Pi 1), so absence of
evidence is what it is. The audit log is the discovery mechanism: when one of
them is used in earnest, its tool appears there and joins the list with
evidence behind it.

Two adversarial corpora, each written by a separate agent before this branch
existed, and both changed the design:

- 90 attack rows found the structural half: `webfetch`, `get_*`, `read_*`,
  `list_*` and `task*` are all on the ignoredTools list, so a check placed
  after the fast path is dead code for exactly the tools that carry the gap.
- 85 false-positive rows found that scanning arguments is not available at
  all. Six families have nothing that separates "this argument IS a
  destination" from "this argument CONTAINS the text", free text worst of all.
  This repository alone carries the metadata address as ordinary text in 14
  source files and 11 documents.

So: a CLOSED LIST of tool plus argument path, never a scan. A shape not on the
list is a deliberate false negative; the alternative blocks ordinary work, and
then the whole mechanism gets switched off. Founder call, same day: a
URL-shaped key on a tool with undeclared network semantics is ignored.

A value is judged by PARSING it as a URL and taking the host, never by
searching. `http://169.254.169.254%2f@example.com/` looks like the metadata
address and resolves to example.com. That also removes the numeric-collision
family for free, since a price or a hash is never a URL hostname.

`isStrictGatedTier` and `ssrfReason` are exported and shared, so the two paths
cannot gate or word the same block differently.

Called from two places on purpose: inside `evaluatePolicy` ABOVE the
ignoredTools fast path, so explain, simulate and the posture probes inherit
it, and again in the orchestrator, where `evaluatePolicy` is never reached for
an ignored tool at all.

Measured at the real gate after the change:

| call | verdict |
| --- | --- |
| `Bash curl <metadata>` | block |
| `WebFetch {url: <metadata>}` | block (was allow) |
| `navigate`, `browser_batch` depth 4 | block |
| `WebFetch` the `%2f@example.com` trap | allow |
| `Grep` for the address, `Write` a doc mentioning it | allow |

19 rows. 8 mutants, 8 killed, and two of them were real defects rather than
coverage gaps: the scheme filter was arbitrarily narrow (`ssh://` to the same
address passed), and the first wiring sat one block BELOW the fast path, where
WebFetch still reached the metadata endpoint while `navigate` was blocked. E1
pins the placement so that cannot come back.

Still not covered, by design and written down rather than half-done: DNS, HTTP
redirects, free text, and MCP tools with undeclared semantics.

After this ships, `node9Firewall/be` needs the engine bumped again or the
dashboard simulator falls behind on exactly this axis.

Design: `doc/roadmap/active/ssrf-nonshell-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)