### PR TITLE
chore(docs): keep documentation out of the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -27,6 +27,9 @@ CHANGELOG.md
 .nvmrc
 .env*
 
-# docs/ is PUBLISHED on purpose: node9.ai renders these Markdown files from the
-# package, so the documentation has one source and the tests here can check it.
+# Documentation is not shipped in the package. node9.ai fetches docs/ from this
+# repository at build time (a sparse clone of the latest release tag), so the
+# pages have one source and the tests here can check them without the site
+# taking a dependency on the CLI.
 # See doc/roadmap/active/docs-single-source-design.md.
+docs/

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "license": "Apache-2.0",
   "files": [
     "dist",
-    "docs",
     "README.md",
     "LICENSE"
   ],
@@ -77,7 +76,7 @@
     "test": "cross-env NODE9_TESTING=1 vitest --run",
     "test:coverage": "cross-env NODE9_TESTING=1 vitest --run --coverage",
     "test:watch": "cross-env NODE9_TESTING=1 vitest",
-    "preuninstall": "node9 uninstall || echo 'node9 uninstall failed — remove hooks manually from ~/.claude/settings.json'",
+    "preuninstall": "node9 uninstall || echo 'node9 uninstall failed \u2014 remove hooks manually from ~/.claude/settings.json'",
     "prepublishOnly": "npm run validate",
     "test:ui": "vitest --ui",
     "dev:tail": "node -e \"try{const d=JSON.parse(require('fs').readFileSync(require('os').homedir()+'/.node9/daemon.pid','utf8'));const pid=d.pid;if(Number.isInteger(pid)&&pid>0&&pid<4194304)process.kill(pid)}catch(e){if(e.code!=='ESRCH'&&e.code!=='ENOENT')process.stderr.write(e.message+'\\n')}\" && npm run build && node dist/cli.js tail"


### PR DESCRIPTION
Reverses one decision from #313, for a reason found by building the other half.

**What happened:** #313 shipped `docs/` inside the package so the site could read the pages from `node_modules`. Adding `@node9/proxy` as a dev dependency on the site broke every test:

```
Incompatible React versions: "react" and "react-dom" must have the exact same version
```

The package depends on `react` (for the ink terminal UI). It also meant **17 MB pulled to get 88 KB of Markdown**, and the site's React version becoming hostage to the CLI's.

**What replaces it:** the site fetches this repository's `docs/` at build time with a sparse clone of the latest release tag. Measured: **1.9 seconds, 1.1 MB, 17 files**, no dependency, nothing to collide. `git` is present in both the site's build paths (Actions runners, and the Playwright image the Dockerfile builds in).

**Unchanged:** the pages, `docs/README.md`, and `src/__tests__/docs-pages.spec.ts`, which is the point of keeping the docs here. A contributor who changes a command sees the docs test fail in their own PR.

Design (updated): `doc/roadmap/active/docs-single-source-design.md`.